### PR TITLE
Add build metadata and cache headers configuration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1868,7 +1868,11 @@ export default function App() {
       {/* Footer */}
       <footer className="border-t border-slate-200 dark:border-slate-700 py-4 mt-8">
         <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
-          <p className="text-center text-xs text-slate-400">JSW One Pipes & Tubes — Inventory Management System v1.0</p>
+          <p className="text-center text-xs text-slate-400">
+            JSW One Pipes & Tubes — Inventory Management System v1.0
+            {' · '}Build <span className="font-mono">{__BUILD_SHA__}</span>
+            {' · '}{__BUILD_TIME__}
+          </p>
         </div>
       </footer>
     </div>

--- a/vercel.json
+++ b/vercel.json
@@ -9,5 +9,25 @@
   },
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
   ]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const buildSha = (process.env.VERCEL_GIT_COMMIT_SHA || 'dev').slice(0, 7)
+const buildTime = new Date().toISOString()
+
 export default defineConfig({
   plugins: [react()],
-  server: { port: 3000, open: true }
+  server: { port: 3000, open: true },
+  define: {
+    __BUILD_SHA__: JSON.stringify(buildSha),
+    __BUILD_TIME__: JSON.stringify(buildTime),
+  },
 })


### PR DESCRIPTION
## Summary
This PR adds build metadata tracking and implements cache control headers for the application. Build information (commit SHA and timestamp) is now injected at build time and displayed in the footer, while cache headers are configured to prevent caching of HTML and enable long-term caching for assets.

## Key Changes
- **Cache Headers Configuration**: Added HTTP cache control headers in `vercel.json` to:
  - Prevent caching of root path and `index.html` (no-cache, no-store, must-revalidate)
  - Enable aggressive caching for assets in `/assets/` directory (1-year max-age with immutable flag)

- **Build Metadata Injection**: Modified `vite.config.js` to:
  - Capture the Vercel Git commit SHA (or 'dev' for local builds) and truncate to 7 characters
  - Capture the current build timestamp in ISO format
  - Inject these values as global constants (`__BUILD_SHA__` and `__BUILD_TIME__`)

- **Footer Enhancement**: Updated `App.jsx` footer to display:
  - Build commit SHA in monospace font
  - Build timestamp
  - Provides visibility into which version is deployed

## Implementation Details
- Build metadata is captured at build time using environment variables and injected via Vite's `define` configuration
- Cache headers follow best practices: HTML files are never cached to ensure users get latest version, while hashed assets can be cached indefinitely
- Footer display is non-intrusive and uses semantic separators for readability

https://claude.ai/code/session_01JP5EUQE18e8vaZVUTcvpKf