### PR TITLE
Add purchase orders table with RLS policies

### DIFF
--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -147,6 +147,14 @@ alter table dispatches enable row level security;
 alter table skus enable row level security;
 alter table purchase_orders enable row level security;
 
+drop policy if exists "Allow all access" on coils;
+drop policy if exists "Allow all access" on baby_coils;
+drop policy if exists "Allow all access" on tubes;
+drop policy if exists "Allow all access" on bundles;
+drop policy if exists "Allow all access" on dispatches;
+drop policy if exists "Allow all access" on skus;
+drop policy if exists "Allow all access" on purchase_orders;
+
 create policy "Allow all access" on coils for all using (true) with check (true);
 create policy "Allow all access" on baby_coils for all using (true) with check (true);
 create policy "Allow all access" on tubes for all using (true) with check (true);

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -91,6 +91,22 @@ create table if not exists dispatches (
   created_at timestamptz default now()
 );
 
+-- PO Master (Purchase Orders)
+create table if not exists purchase_orders (
+  id uuid primary key default gen_random_uuid(),
+  purchase_order_date date,
+  purchase_order_number text,
+  vendor_name text,
+  item_name text,
+  quantity_ordered numeric,
+  updated_qty numeric,
+  item_price numeric,
+  updated_price numeric,
+  po_end_date date,
+  deleted boolean default false,
+  created_at timestamptz default now()
+);
+
 -- SKU Master
 create table if not exists skus (
   id text primary key,
@@ -129,6 +145,7 @@ alter table tubes enable row level security;
 alter table bundles enable row level security;
 alter table dispatches enable row level security;
 alter table skus enable row level security;
+alter table purchase_orders enable row level security;
 
 create policy "Allow all access" on coils for all using (true) with check (true);
 create policy "Allow all access" on baby_coils for all using (true) with check (true);
@@ -136,6 +153,7 @@ create policy "Allow all access" on tubes for all using (true) with check (true)
 create policy "Allow all access" on bundles for all using (true) with check (true);
 create policy "Allow all access" on dispatches for all using (true) with check (true);
 create policy "Allow all access" on skus for all using (true) with check (true);
+create policy "Allow all access" on purchase_orders for all using (true) with check (true);
 
 -- ═══════════════════════════════════════════════════════════════
 -- SEED DATA — 8 Default SKUs


### PR DESCRIPTION
## Summary
This PR adds support for purchase order management by introducing a new `purchase_orders` table to the database schema and configuring row-level security (RLS) policies for it.

## Key Changes
- **New Table**: Created `purchase_orders` table with fields for tracking purchase order details including:
  - Purchase order metadata (date, number, vendor name)
  - Item information (name, quantity, pricing)
  - PO end date and soft delete flag
  - Automatic timestamp tracking
  
- **RLS Configuration**: 
  - Enabled row-level security on the `purchase_orders` table
  - Refactored existing RLS policies by dropping and recreating all "Allow all access" policies to ensure consistency
  - Applied permissive "Allow all access" policy to the new table

## Implementation Details
The `purchase_orders` table includes both original and updated quantity/price fields (`quantity_ordered`/`updated_qty` and `item_price`/`updated_price`) to support audit trails and change tracking. The table uses a soft delete pattern with a `deleted` boolean flag rather than hard deletion.

https://claude.ai/code/session_0145Jd7YmPq2f3Pf733FQCRc