### PR TITLE
Fix silent Supabase sync failures on Excel upload and form saves

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1823,6 +1823,21 @@ function POMaster({ purchaseOrders, setPurchaseOrders }) {
   const fileRef = useRef(null)
   const f = (k, v) => setForm(p => ({ ...p, [k]: v }))
 
+  // Surface Supabase sync failures so the user knows saves didn't persist.
+  useEffect(() => {
+    const handler = (e) => {
+      const d = e.detail || {}
+      if (d.tableName !== 'purchase_orders') return
+      const parts = [d.message, d.details, d.hint].filter(Boolean).join(' — ')
+      setUploadMsg({
+        kind: 'err',
+        text: `Database rejected ${d.op} on ${d.rowCount} row(s): ${parts}. Rows were NOT saved and will disappear on refresh.`,
+      })
+    }
+    window.addEventListener('jsw:syncError', handler)
+    return () => window.removeEventListener('jsw:syncError', handler)
+  }, [])
+
   const save = () => {
     const record = { ...form, id: editId || uid(), deleted: false }
     setPurchaseOrders(prev =>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1823,21 +1823,6 @@ function POMaster({ purchaseOrders, setPurchaseOrders }) {
   const fileRef = useRef(null)
   const f = (k, v) => setForm(p => ({ ...p, [k]: v }))
 
-  // Surface Supabase sync failures so the user knows saves didn't persist.
-  useEffect(() => {
-    const handler = (e) => {
-      const d = e.detail || {}
-      if (d.tableName !== 'purchase_orders') return
-      const parts = [d.message, d.details, d.hint].filter(Boolean).join(' — ')
-      setUploadMsg({
-        kind: 'err',
-        text: `Database rejected ${d.op} on ${d.rowCount} row(s): ${parts}. Rows were NOT saved and will disappear on refresh.`,
-      })
-    }
-    window.addEventListener('jsw:syncError', handler)
-    return () => window.removeEventListener('jsw:syncError', handler)
-  }, [])
-
   const save = () => {
     const record = { ...form, id: editId || uid(), deleted: false }
     setPurchaseOrders(prev =>
@@ -1984,6 +1969,43 @@ const TABS = [
   { key: 'poMaster', label: 'PO Master' },
 ]
 
+const TABLE_LABELS = {
+  coils: 'Coil Inward',
+  baby_coils: 'Baby Coils',
+  tubes: 'Tubes',
+  bundles: 'Bundles',
+  dispatches: 'Dispatches',
+  skus: 'SKU Master',
+  purchase_orders: 'PO Master',
+}
+
+function SyncErrorBanner() {
+  const [err, setErr] = useState(null)
+  useEffect(() => {
+    const handler = (e) => setErr(e.detail || null)
+    window.addEventListener('jsw:syncError', handler)
+    return () => window.removeEventListener('jsw:syncError', handler)
+  }, [])
+  if (!err) return null
+  const tbl = TABLE_LABELS[err.tableName] || err.tableName
+  const parts = [err.message, err.details, err.hint].filter(Boolean).join(' — ')
+  return (
+    <div className="bg-red-50 dark:bg-red-950 border-b border-red-200 dark:border-red-900 text-red-800 dark:text-red-200 text-sm">
+      <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-start gap-3">
+        <span className="font-semibold whitespace-nowrap">Sync failed ({tbl}):</span>
+        <span className="flex-1 break-words">
+          {err.op} rejected for {err.rowCount} row{err.rowCount === 1 ? '' : 's'}. {parts}. These changes will NOT persist on refresh.
+        </span>
+        <button
+          onClick={() => setErr(null)}
+          className="text-red-700 dark:text-red-300 hover:underline shrink-0"
+          title="Dismiss"
+        >Dismiss</button>
+      </div>
+    </div>
+  )
+}
+
 export default function App() {
   const [dark, setDark] = useState(() => LS.get('jsw:dark') ?? false)
   const [tab, setTab] = useState('dashboard')
@@ -2064,6 +2086,8 @@ export default function App() {
           </div>
         </div>
       </header>
+
+      <SyncErrorBanner />
 
       {/* Tab Navigation */}
       <nav className="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 overflow-x-auto">

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -90,6 +90,25 @@ export function useSupabaseStore(localStorageKey, fallback) {
 }
 
 // ═══════════════════════════════════════════════════════════════
+// SYNC ERROR BROADCAST — UI components can listen for failures
+// ═══════════════════════════════════════════════════════════════
+function emitSyncError(tableName, op, error, rows) {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent('jsw:syncError', {
+    detail: {
+      tableName,
+      op,
+      message: error?.message || String(error),
+      details: error?.details || '',
+      hint: error?.hint || '',
+      code: error?.code || '',
+      sampleRow: Array.isArray(rows) ? rows[0] : rows,
+      rowCount: Array.isArray(rows) ? rows.length : 0,
+    },
+  }))
+}
+
+// ═══════════════════════════════════════════════════════════════
 // SYNC LOGIC — diffs local state against Supabase
 // ═══════════════════════════════════════════════════════════════
 async function syncToSupabase(tableName, prev, next, prevIdsRef) {
@@ -110,13 +129,19 @@ async function syncToSupabase(tableName, prev, next, prevIdsRef) {
   if (toUpsert.length > 0) {
     const snakeRows = toUpsert.map(toSnake)
     const { error } = await supabase.from(tableName).upsert(snakeRows, { onConflict: 'id', ignoreDuplicates: false })
-    if (error) console.error(`[db] Upsert error on ${tableName}:`, error.message)
+    if (error) {
+      console.error(`[db] Upsert error on ${tableName}:`, error.message, { sampleRow: snakeRows[0] })
+      emitSyncError(tableName, 'upsert', error, snakeRows)
+    }
   }
 
   // Hard-delete removed items
   if (toDelete.length > 0) {
     const { error } = await supabase.from(tableName).delete().in('id', toDelete)
-    if (error) console.error(`[db] Delete error on ${tableName}:`, error.message)
+    if (error) {
+      console.error(`[db] Delete error on ${tableName}:`, error.message)
+      emitSyncError(tableName, 'delete', error, toDelete)
+    }
   }
 
   // Update tracked IDs


### PR DESCRIPTION
## Problem

PO Master Excel upload and manual form saves (coils, etc.) appeared to succeed in the UI but the rows vanished after refresh. Three related bugs in the Supabase sync path:

1. **Date format swap** — `toISODate` assumed DD/MM/YYYY, so an Excel cell formatted as MM/DD/YYYY (e.g. `04/28/2026`) became `2026-28-04`, which Postgres rejects: `date/time field value out of range`.
2. **Empty strings on nullable numeric/date columns** — Every form in the app initializes numeric fields as `''`. `toSnake` forwarded those straight to Postgres, which rejects `""` on `numeric`/`date` with a 400. This affected every table (coils, baby_coils, tubes, bundles, dispatches, skus, purchase_orders), not just POs.
3. **IST off-by-one** — xlsx 0.18.x produces local-time `Date` objects; `getUTCDate()` on those shifted the day back by 5.5h in IST so `2026-04-22` persisted as `2026-04-21`.

On top of that, sync errors were logged only to the browser console — the UI reported success, so failures were invisible.

## Changes

### `src/App.jsx`
- `toISODate` auto-detects MM/DD/YYYY vs DD/MM/YYYY (based on whether the first or second segment is `> 12`), falls back to DD/MM/YYYY for ambiguous cases, accepts `YYYY/M/D` and single-digit ISO variants, and uses local getters on `Date` objects to avoid timezone drift.
- PO Excel upload uses `sheet_to_json({ raw: true })` so date cells arrive as real `Date` objects.
- New `SyncErrorBanner` mounted in the app shell listens for `jsw:syncError` events and shows the table, operation, row count, and full Postgres `message` / `details` / `hint`. Now every tab surfaces sync failures, not just PO Master.

### `src/lib/db.js`
- `toSnake` converts `''` to `null` before upsert (safe across every synced table — all affected columns are nullable).
- Upsert and delete failures dispatch a `jsw:syncError` `CustomEvent` with diagnostic payload (message, details, hint, code, sample row, row count).

## Test plan
- [ ] Upload a Zoho Books PO Excel export with dates in both `MM/DD/YYYY` and `DD/MM/YYYY` formats — all rows persist after refresh.
- [ ] Save a coil with some numeric fields blank — row persists after refresh (empty fields arrive as `null` in Postgres).
- [ ] Simulate a Supabase failure (e.g. disconnect network) and confirm the red banner appears with the Postgres error.
- [ ] Sanity-check the other stages (slit, tube, bundle, dispatch, SKU) — form saves still round-trip cleanly.

## Not in scope (flagged for follow-up)
- `SEED_VERSION` effect in `App.jsx:2001-2012` can wipe remote data when localStorage is cleared (calls `setCoils([])` which `syncToSupabase` interprets as "delete all").
- Missing `VITE_SUPABASE_*` env vars fail silently with empty fallbacks.
- `hr_coil_id` uniqueness is only checked in-memory, so concurrent tabs can hit the UNIQUE constraint.

https://claude.ai/code/session_015nhmVq4HycqbfYNfnDgSUx