### PR TITLE
Remove seed data builders and auto-seeding logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,15 +29,6 @@ const CARD_COLORS = {
 }
 
 // ═══════════════════════════════════════════════════════════════
-// SEED DATA BUILDERS
-// ═══════════════════════════════════════════════════════════════
-function buildSeedCoils() { return [] }
-function buildSeedBabyCoils() { return [] }
-function buildSeedTubes() { return [] }
-function buildSeedBundles() { return [] }
-function buildSeedDispatches() { return [] }
-
-// ═══════════════════════════════════════════════════════════════
 // UTILITY FUNCTIONS
 // ═══════════════════════════════════════════════════════════════
 const today = () => new Date().toISOString().split('T')[0]
@@ -1995,20 +1986,6 @@ export default function App() {
   const [purchaseOrders, setPurchaseOrders, poLoading] = useSupabaseStore('jsw:purchaseOrders', [])
 
   const loading = coilsLoading || babyCoilsLoading || tubesLoading || bundlesLoading || dispatchesLoading || skusLoading || poLoading
-
-  // Auto-seed: push seed data to Supabase when seed version changes
-  const SEED_VERSION = 5
-  useEffect(() => {
-    if (!loading && LS.get('jsw:seedVersion') !== SEED_VERSION) {
-      setCoils(buildSeedCoils())
-      setBabyCoils(buildSeedBabyCoils())
-      setTubes(buildSeedTubes())
-      setBundles(buildSeedBundles())
-      setDispatches(buildSeedDispatches())
-      setSkus(DEFAULT_SKUS)
-      LS.set('jsw:seedVersion', SEED_VERSION)
-    }
-  }, [loading]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Dark mode
   useEffect(() => {


### PR DESCRIPTION
## Summary
Removed the seed data builder functions and the auto-seeding mechanism that was responsible for populating the database with initial data when the seed version changed.

## Key Changes
- Deleted `buildSeedCoils()`, `buildSeedBabyCoils()`, `buildSeedTubes()`, `buildSeedBundles()`, and `buildSeedDispatches()` functions that were returning empty arrays
- Removed the `useEffect` hook that automatically seeded data to Supabase based on `SEED_VERSION` comparison with localStorage
- Removed the `SEED_VERSION` constant (was set to 5)
- Removed the seed data initialization calls for coils, baby coils, tubes, bundles, dispatches, and SKUs

## Notes
This appears to be cleanup of development/testing code that is no longer needed. The seed data builders were not performing any actual data generation (all returned empty arrays), and the auto-seeding mechanism has been replaced or is no longer required for the application's data initialization flow.

https://claude.ai/code/session_015sH9J7Z3YgvNpNand4w7qR