### PR TITLE
Add ±10mm tolerance to Stage 3 slit-too-narrow check

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -561,6 +561,11 @@ function SlitToTube({ babyCoils, tubes, setTubes, skus, coils }) {
     return 2 * (Number(sku.height || 0) + Number(sku.breadth || 0))
   }, [sku])
 
+  // A slit may run up to ±10 mm off the theoretical strip width (corner allowance / spring-back).
+  // Minimum acceptable slit width = stripWidth − tolerance.
+  const SLIT_TOLERANCE_MM = 10
+  const minSlitWidth = stripWidth > 0 ? stripWidth - SLIT_TOLERANCE_MM : 0
+
   // Total batch weight = pieces × weightPerTube, converted kg → T
   const theoreticalWeight = sku?.weightPerTube && form.numberOfPieces
     ? (Number(form.numberOfPieces) * Number(sku.weightPerTube)) / 1000
@@ -570,7 +575,7 @@ function SlitToTube({ babyCoils, tubes, setTubes, skus, coils }) {
   const maxByWeight = baby?.weight && sku?.weightPerTube
     ? Math.floor((Number(baby.weight) * 1000) / Number(sku.weightPerTube))
     : null
-  const slitTooNarrow = stripWidth > 0 && baby && stripWidth > Number(baby.width || 0)
+  const slitTooNarrow = stripWidth > 0 && baby && Number(baby.width || 0) < minSlitWidth
   const piecesOverMax = maxByWeight != null && Number(form.numberOfPieces || 0) > maxByWeight
 
   const motherCoil = useMemo(() => baby ? coils.find(c => c.hrCoilId === baby.hrCoilId) : null, [baby, coils])
@@ -641,7 +646,7 @@ function SlitToTube({ babyCoils, tubes, setTubes, skus, coils }) {
               helper={
                 sku && baby
                   ? slitTooNarrow
-                    ? `⚠ Slit width ${Number(baby.width).toFixed(1)} mm is too narrow for this SKU (needs ≥ ${stripWidth.toFixed(1)} mm)`
+                    ? `⚠ Slit width ${Number(baby.width).toFixed(1)} mm is too narrow for this SKU (needs ≥ ${minSlitWidth.toFixed(1)} mm — ${stripWidth.toFixed(1)} mm strip, ±${SLIT_TOLERANCE_MM} mm tolerance)`
                     : maxByWeight != null
                       ? piecesOverMax
                         ? `⚠ Over the weight-based cap — max possible from this slit: ${maxByWeight} tubes`


### PR DESCRIPTION
## Problem

In **Stage 3 (Slit to Tube)**, selecting an SKU could surface a *"too narrow"* error that blocked Save — e.g. a 97 mm baby coil rejected for a 25×25 SHS SKU.

The validation required the slit width to be **≥** the theoretical strip width:
- SHS/RHS: `2 × (H + B)` → 25×25 needs 100 mm
- CHS: `π × OD`

97 mm < 100 mm, so it was hard-blocked. But real tube forming allows a margin for corner radius and spring-back, so an exact-perimeter minimum is unrealistically strict.

## Change

Introduce a **±10 mm tolerance**. A slit is now flagged "too narrow" only when it falls **more than 10 mm below** the strip width.

```js
const SLIT_TOLERANCE_MM = 10
const minSlitWidth = stripWidth > 0 ? stripWidth - SLIT_TOLERANCE_MM : 0
const slitTooNarrow = stripWidth > 0 && baby && Number(baby.width || 0) < minSlitWidth
```

The warning message now shows the tolerance-adjusted minimum:
> ⚠ Slit width 97.0 mm is too narrow for this SKU (needs ≥ 90.0 mm — 100.0 mm strip, ±10 mm tolerance)

## Effect

| SKU | Strip width | Old minimum | New minimum |
|-----|-------------|-------------|-------------|
| 25×25 SHS | 100 mm | 100 mm (97 mm blocked) | 90 mm (97 mm passes ✓) |

Only the narrow side is tolerated; wider slits were never restricted.

## Verification

- `npm run build` passes clean (pre-existing chunk-size warnings unrelated).
- Logic change is self-contained to `src/App.jsx` Stage 3.

## Notes

- "±10 mm" was read as a 10 mm tolerance on the **narrow** side (the side the error is about). If a hard reject for slits >10 mm **over** strip width is also wanted, that can be added.

https://claude.ai/code/session_018deETMEjQSRScUAEAJ9CX1

---
_Generated by [Claude Code](https://claude.ai/code/session_018deETMEjQSRScUAEAJ9CX1)_