### PR TITLE
Fix baby coil letter reuse by including soft-deleted siblings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -324,11 +324,15 @@ function CoilToSlit({ coils, babyCoils, setBabyCoils }) {
 
   const parentCoil = useMemo(() => coils.find(c => !c.deleted && c.hrCoilId === form.hrCoilId), [coils, form.hrCoilId])
   const siblingsOfParent = useMemo(() => babyCoils.filter(b => !b.deleted && b.hrCoilId === form.hrCoilId && b.id !== editId), [babyCoils, form.hrCoilId, editId])
-  const nextLetter = useMemo(() => genBabyLetter(siblingsOfParent.length + (editId ? 0 : 0)), [siblingsOfParent, editId])
+  // Include deleted siblings in count so letters are never reused — reusing a letter would collide with the
+  // soft-deleted DB row that still holds the unique baby_coil_id value.
+  const allSiblingsOfParent = useMemo(() => babyCoils.filter(b => b.hrCoilId === form.hrCoilId && b.id !== editId), [babyCoils, form.hrCoilId, editId])
+  const nextLetter = useMemo(() => genBabyLetter(allSiblingsOfParent.length), [allSiblingsOfParent])
 
   const babyCoilEntry = editId ? form.babyCoilEntry : nextLetter
   const babyCoilId = form.hrCoilId ? `${form.hrCoilId}-${babyCoilEntry}` : ''
-  const isDupe = babyCoils.some(b => !b.deleted && b.babyCoilId === babyCoilId && b.id !== editId)
+  // Check all records (including soft-deleted) to prevent reuse of baby_coil_id still present in DB
+  const isDupe = babyCoils.some(b => b.babyCoilId === babyCoilId && b.id !== editId)
 
   // Width cap: slit widths must fit within (mother width − 5 mm); hard cap is mother width itself.
   // Target  → sum ≤ mother − 5  (green)


### PR DESCRIPTION
## Summary
Fixed a bug in the Coil to Slit stage where baby coil letters could be reused after deletion, causing collisions with soft-deleted database records that still hold the unique `baby_coil_id` value.

## Key Changes
- **Include deleted siblings in letter assignment**: Modified `allSiblingsOfParent` to include soft-deleted records when calculating the next available letter, ensuring letters are never reused
- **Simplified letter calculation**: Removed unnecessary ternary logic (`editId ? 0 : 0`) from `nextLetter` computation
- **Updated duplicate check**: Modified `isDupe` validation to check all records (including soft-deleted) to prevent reuse of `baby_coil_id` values still present in the database
- **Added clarifying comments**: Documented why soft-deleted records must be included in both the sibling count and duplicate detection

## Implementation Details
The fix addresses the soft-delete pattern used throughout the application. When a baby coil is deleted, its record remains in the database with `deleted: true`, and its `baby_coil_id` (e.g., "HR001-A") is still unique. By including deleted siblings in the count and duplicate check, we ensure:
1. Letters are assigned sequentially without gaps or reuse
2. No collision with existing (even if soft-deleted) `baby_coil_id` values in the database
3. Data integrity is maintained across the pipeline

https://claude.ai/code/session_01HswyYfdtyK2QbS2tQc8mFH