### PR TITLE
fix: hard-delete coils to prevent hr_coil_id unique constraint violat…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -213,7 +213,7 @@ function CoilInward({ coils, setCoils, babyCoils, dispatches }) {
   const f = (k, v) => setForm(p => ({ ...p, [k]: v }))
 
   const nextNo = useMemo(() => {
-    const nums = coils.filter(c => !c.deleted).map(c => c.hrCoilNo)
+    const nums = coils.map(c => c.hrCoilNo)
     return nums.length ? Math.max(...nums) + 1 : 1
   }, [coils])
 
@@ -222,7 +222,7 @@ function CoilInward({ coils, setCoils, babyCoils, dispatches }) {
     return form.dateOfInward && n ? genHRCoilId(form.dateOfInward, n) : ''
   }, [form.dateOfInward, form.hrCoilNo, nextNo, editId])
 
-  const isDupe = useMemo(() => coils.some(c => !c.deleted && c.hrCoilId === hrCoilId && c.id !== editId), [coils, hrCoilId, editId])
+  const isDupe = useMemo(() => coils.some(c => c.hrCoilId === hrCoilId && c.id !== editId), [coils, hrCoilId, editId])
 
   const save = () => {
     const no = form.hrCoilNo || nextNo
@@ -240,7 +240,7 @@ function CoilInward({ coils, setCoils, babyCoils, dispatches }) {
   }
 
   const softDelete = (row) => {
-    if (confirm('Delete this coil record?')) setCoils(prev => prev.map(c => c.id === row.id ? { ...c, deleted: true } : c))
+    if (confirm('Delete this coil record?')) setCoils(prev => prev.filter(c => c.id !== row.id))
   }
 
   // Cross-stage calculations

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -25,7 +25,7 @@ function toCamel(obj) {
 
 // Tables that use hard-delete (no soft-delete). On load, any lingering rows with
 // deleted=true are purged from Supabase — cleans up legacy soft-deleted data.
-const HARD_DELETE_TABLES = new Set(['baby_coils'])
+const HARD_DELETE_TABLES = new Set(['baby_coils', 'coils'])
 
 // ═══════════════════════════════════════════════════════════════
 // TABLE NAME MAPPING — localStorage key → Supabase table name


### PR DESCRIPTION
…ions

Same issue as baby_coils — soft-deleted coil records kept their hr_coil_id locked in Supabase, blocking re-entry of the same coil number. Switches coils to hard-delete, adds coils to HARD_DELETE_TABLES so legacy soft-deleted rows are purged from Supabase on load, and cleans up derived isDupe/nextNo guards that are no longer needed.

https://claude.ai/code/session_01HswyYfdtyK2QbS2tQc8mFH