### PR TITLE
Coil Tracker: Excel-style summary with pinned subtotals and date period filter

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -30,8 +30,8 @@ Invoice Reconciliation CSV export on the Dispatch tab.
 
 ## Phase 2: Coil Tracker Excel-Style Summary
 
-**Status:** Executed (2026-06-10) — manual browser checks pending, see
-phases/02-coil-tracker-summary/02-01-SUMMARY.md
+**Status:** Complete (executed 2026-06-10, UAT passed 6/6 — see
+phases/02-coil-tracker-summary/02-UAT.md)
 **Plans:** 1 plan — 02-PLAN.md (plan committed 2026-06-10)
 
 **Goal:** Rebuild the Coil Tracker inventory summary as an Excel-style coil

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -30,7 +30,8 @@ Invoice Reconciliation CSV export on the Dispatch tab.
 
 ## Phase 2: Coil Tracker Excel-Style Summary
 
-**Status:** Planned
+**Status:** Executed (2026-06-10) — manual browser checks pending, see
+phases/02-coil-tracker-summary/02-01-SUMMARY.md
 **Plans:** 1 plan — 02-PLAN.md (plan committed 2026-06-10)
 
 **Goal:** Rebuild the Coil Tracker inventory summary as an Excel-style coil

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -31,6 +31,7 @@ Invoice Reconciliation CSV export on the Dispatch tab.
 ## Phase 2: Coil Tracker Excel-Style Summary
 
 **Status:** Planned
+**Plans:** 1 plan — 02-PLAN.md (plan committed 2026-06-10)
 
 **Goal:** Rebuild the Coil Tracker inventory summary as an Excel-style coil
 summary report: 14 fixed columns tracing each mother coil from inward through

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -6,7 +6,7 @@
 
 ## Phase 1: Slit-to-Tube Capacity Fix & Invoice Cost Reconciliation
 
-**Status:** Planned
+**Status:** Complete (executed 2026-06-03 — see phases/01-slit-tube-recon/01-01-SUMMARY.md)
 **Goal:** Fix Stage 3 tube-capacity accounting so already-produced tubes reduce a
 baby coil's remaining capacity, reorder the Slit-to-Tube form to pick the coil
 first and filter SKUs by the coil's thickness (±5%), and add a per-SKU/per-date
@@ -27,3 +27,35 @@ Invoice Reconciliation CSV export on the Dispatch tab.
 - Selecting a baby coil filters the SKU dropdown to thickness-compatible SKUs.
 - The Dispatch tab exports a CSV with one row per (dispatch date × invoice × SKU)
   and the 9 specified columns, costs computed per the locked cost model.
+
+## Phase 2: Coil Tracker Excel-Style Summary
+
+**Status:** Planned
+
+**Goal:** Rebuild the Coil Tracker inventory summary as an Excel-style coil
+summary report: 14 fixed columns tracing each mother coil from inward through
+slitting, conversion, tube production, and dispatch to tube inventory; compact
+Excel-density rows; a subtotals row pinned at the top; and a date-based time
+period (From/To) filter.
+
+**Requirements:**
+- R4 — Summary table with exactly these 14 columns per mother coil: Coil ID,
+  Grade, Coil Wt (T), # Baby Coils, Baby Coil Wt (T), # Converted,
+  Converted Wt (T), # Tubes, Tubes Wt (T), # Dispatched, Dispatched Wt (T),
+  Balance to Roll (T), Tube Inventory (T), Tube Inventory (#). Derived columns:
+  Balance to Roll = Coil Wt − Baby Coil Wt; Tube Inventory (T) = Tubes Wt −
+  Dispatched Wt; Tube Inventory (#) = # Tubes − # Dispatched.
+- R5 — Date-based time period filter (From/To) on the summary.
+- R6 — Subtotals row pinned at the top of the table (above all coil rows),
+  summing every numeric column.
+- R7 — Excel-standard presentation: compact row height/density, gridlines,
+  right-aligned numerics, weights to 2 decimals, counts with thousands
+  separators, zero/empty cells rendered as "-".
+
+**Success criteria:**
+- The Coil Tracker shows one row per mother coil with all 14 columns and values
+  that reconcile (sample-verified formulas above).
+- Changing the From/To dates narrows the rows and the subtotals recompute.
+- The subtotal row stays at the top in all states (filtered, sorted, scrolled).
+- Rows render at Excel-like density and the table matches the formatting rules
+  in R7.

--- a/.planning/phases/02-coil-tracker-summary/02-01-SUMMARY.md
+++ b/.planning/phases/02-coil-tracker-summary/02-01-SUMMARY.md
@@ -1,0 +1,74 @@
+# Phase 2 — Execution Summary
+
+**Executed:** 2026-06-10
+**Plan:** 02-PLAN.md (plan check: PASSED, 12 dimensions)
+**Result:** ✓ Complete — R4–R7 implemented, build passes, all automated acceptance criteria green.
+**Files modified:** `src/App.jsx` only (single-file pattern preserved; no data-model/Supabase changes)
+
+## What was built
+
+### R4 — 14-column Excel-style coil summary
+- `inventorySummary` memo rewritten: maps over `filteredCoils`, computes per coil
+  `coilWt`, `babyCount`, `babyWt`, `convertedCount`/`convertedWt` (baby coils with
+  ≥1 tube record), `tubePcs`, `tubesWt`, `dispatchedPcs`/`dispatchedWt` (via
+  `bundleEntries.traceBabyCoilId`), and deriveds `balanceToRoll = coilWt − babyWt`,
+  `tubeInvWt = tubesWt − dispatchedWt`, `tubeInvPcs = tubePcs − dispatchedPcs`
+  (negatives never clamped). Deps `[filteredCoils, ab, at, ad]`.
+- Module consts `SUMMARY_HEADERS` (14 locked labels) + `SUMMARY_COLS` (12 numeric
+  columns with wt/count formatting), `SUMMARY_TD`/`SUBTOTAL_TD` cell classes.
+- Dead code removed: `summaryColumns`, `unbundledPcs`, CoilTracker's
+  `undispatchedBundles`/`yieldPct`/`bundledPcs` aggregation. `YieldBadge`
+  component retained (shared UI). Journey/weightFlowData memos byte-identical.
+
+### R5 — Date period filter
+- `dateFrom`/`dateTo` state + `filteredCoils` memo: inclusive lexicographic ISO
+  compare on `coil.dateOfInward` (CoilToSlit precedent), open-ended bounds,
+  rows sorted by `dateOfInward` then `hrCoilId`. From/To `<input type="date">`
+  pair in the Section `actions` slot.
+- Downstream quantities stay lifetime totals (locked decision — rows reconcile).
+
+### R6 — Subtotals pinned at top
+- `subtotals` memo (single reduce over `inventorySummary`): 12 numeric sums +
+  `coilCount`. Rendered as the FIRST tbody row, `Total (N)` label, cells
+  `sticky top-8 z-10` with opaque `bg-slate-100 dark:bg-slate-800`, bold,
+  `border-b-2` — pins just below the `h-8` sticky header. No onClick.
+
+### R7 — Excel-standard presentation
+- Scrollport wrapper `overflow-auto max-h-96`; table `text-xs border-separate
+  border-spacing-0`; every th/td `px-2 py-1` with `border-b border-r` gridlines;
+  header `sticky top-0 z-20` opaque `bg-slate-50 dark:bg-slate-700`; numerics
+  right-aligned `tabular-nums`; weights 2-dp via local `fmt2`, counts via
+  `fmtCount` ('en-US' grouping → `1,011`); rounded-zero/blank renders `-`
+  (round-before-zero-test kills float dust and `-0`, keeps `-17.89`);
+  empty state `colSpan={14}`; dark-mode variants on every new element.
+- Row click preserved: `setSelectedCoilId(row.hrCoilId)` + indigo highlight;
+  Coil Journey section unchanged.
+
+## Verification run
+- `node node_modules/vite/bin/vite.js build` → ✓ built (only the pre-existing
+  chunk-size warning).
+- Sample-value reconciliation through the implemented formatters:
+  `fmt2(20.63−20.51)` → `0.12`; `fmt2(0−17.89)` → `-17.89`;
+  `fmtCount(1011−864)` → `147`; `fmt2(0)`/`fmtCount(0)`/`fmt2(-0)`/`fmt2(1e-15)`
+  → `-`; `fmt2(-17.894)` → `-17.89`; `fmtCount(1011)` → `1,011`.
+- Dead-code sweep: `unbundledPcs` 0 file-wide; `undispatchedBundles` only in
+  Dispatch (:1036/:1048/:1052); `yieldPct` only in CoilInward (:256-257).
+- `git status --porcelain`: `src/App.jsx` is the only modified source file.
+
+## Manual browser checks (required — CSS assumptions A1/A2)
+
+Run `npm run dev` (needs `.env.local` Supabase vars) and verify on the Coil
+Tracker tab, in BOTH light and dark mode:
+
+- [ ] (a) Scroll the summary table body — the header row AND the `Total (N)`
+  subtotal row stay pinned at the top; cell gridlines persist while scrolling.
+- [ ] (b) No data-row content bleeds through behind the sticky header/subtotal
+  cells (backgrounds are opaque).
+- [ ] (c) Set From/To dates — rows narrow by coil inward date and `Total (N)`
+  recomputes; clear both — all coils return.
+- [ ] (d) Click a coil row — indigo highlight + Coil Journey opens below; the
+  subtotal row is not clickable.
+- [ ] (e) Pick one coil and reconcile its 14 cells against manual sums of its
+  Stage 2 (baby coils), Stage 3 (tubes), and Stage 5 (dispatch) records.
+- [ ] (f) Accepted quirk: if the date filter hides a selected coil's row, its
+  Journey stays open (journey reads unfiltered coils).

--- a/.planning/phases/02-coil-tracker-summary/02-CONTEXT.md
+++ b/.planning/phases/02-coil-tracker-summary/02-CONTEXT.md
@@ -1,0 +1,146 @@
+# Phase 2: Coil Tracker Excel-Style Summary - Context
+
+**Gathered:** 2026-06-10
+**Status:** Ready for planning
+**Source:** PRD Express Path (user-provided column spec + 54-row sample dataset)
+
+<domain>
+## Phase Boundary
+
+Rebuild the Coil Tracker's "Inventory Summary — All Coils" section in
+`src/App.jsx` as an Excel-style coil summary report. One row per mother coil,
+14 fixed columns, a subtotals row pinned at the top, a From/To date period
+filter, and Excel-standard row density/formatting.
+
+In scope: the summary table inside the `CoilTracker` component only.
+Out of scope: the Coil Journey detail section (keep as-is), other tabs, data
+model changes, Supabase schema changes, decomposing App.jsx.
+</domain>
+
+<decisions>
+## Implementation Decisions (LOCKED)
+
+### R4 — Columns (exact order) and formulas
+
+The user supplied a 54-row sample export; every derived-column formula below
+was verified against that sample.
+
+| # | Column | Source / Formula |
+|---|--------|------------------|
+| 1 | Coil ID | `coil.hrCoilId` |
+| 2 | Grade | `coil.coilGrade` |
+| 3 | Coil Wt (T) | `coil.actualWeight` |
+| 4 | # Baby Coils | count of non-deleted baby coils with `hrCoilId === coil.hrCoilId` |
+| 5 | Baby Coil Wt (T) | Σ `baby.weight` over those baby coils |
+| 6 | # Converted | count of those baby coils having ≥1 non-deleted tube record |
+| 7 | Converted Wt (T) | Σ `baby.weight` over the converted baby coils |
+| 8 | # Tubes | Σ `tube.numberOfPieces` over tube records of this coil's babies |
+| 9 | Tubes Wt (T) | Σ `tube.theoreticalWeight` over the same tube records |
+| 10 | # Dispatched | Σ `bundleEntry.pieces` over dispatch `bundleEntries` with `traceBabyCoilId` among this coil's babies |
+| 11 | Dispatched Wt (T) | Σ `bundleEntry.weight` over the same entries (existing CoilTracker logic) |
+| 12 | Balance to Roll (T) | `Coil Wt − Baby Coil Wt` (sample: 20.63 − 20.51 = 0.12; unslit coil shows its full weight) |
+| 13 | Tube Inventory (T) | `Tubes Wt − Dispatched Wt` (sample: blank Tubes Wt ⇒ 0 − 17.89 = −17.89) |
+| 14 | Tube Inventory (#) | `# Tubes − # Dispatched` (sample: 1,011 − 864 = 147) |
+
+- Negative derived values are legitimate and shown with a minus sign — do not
+  clamp to 0.
+- Soft-deleted records (`deleted: true`) excluded everywhere, matching the
+  existing `active()` filter in `CoilTracker`.
+
+### R5 — Date-based time period filter
+- From/To `date` inputs above the table.
+- Filter selects **mother coils by `dateOfInward`** within the inclusive range.
+- Either bound may be empty (open-ended); both empty = all coils (default).
+- Downstream quantities for an included coil are lifetime totals — they are
+  NOT clipped to the period. The period selects which coils appear.
+
+### R6 — Subtotals pinned at the top
+- A single totals row rendered ABOVE all data rows (first row of the body, or
+  a second sticky header row), labelled `Total` (with coil count).
+- Sums columns 3–14 across the currently filtered rows; recomputes when the
+  date filter changes.
+- Stays at the top when the table scrolls (sticky alongside the header).
+
+### R7 — Excel-standard presentation
+- Compact row density: small font (text-xs), tight cell padding (~`px-2 py-1`),
+  Excel-like row height (~22–24px) — NOT the existing roomy `px-4 py-3`
+  DataTable cells.
+- Visible gridlines on all cells (border on every td/th), light header fill.
+- Numeric columns right-aligned; Coil ID / Grade left-aligned.
+- Weights: **2 decimal places** (sample shows 20.63 / −0.08 — note this
+  intentionally differs from the 3-dp `fmtT` used elsewhere).
+- Counts: integer with thousands separators (`1,011`).
+- Zero or empty values render as `-` (per sample), in both data and subtotal
+  rows.
+- Sticky header row; horizontal scroll allowed for narrow viewports.
+- Dark mode variants consistent with the rest of the app.
+
+### Placement & behavior
+- **Replace** the existing "Inventory Summary — All Coils" `DataTable` section
+  inside `CoilTracker` with this new table (custom `<table>` markup — the
+  shared `DataTable` cannot render a pinned subtotal row or Excel density).
+- Keep the existing row-click → coil journey behavior: clicking a coil row
+  still sets `selectedCoilId` and shows the Journey section below, with the
+  selected row highlighted.
+- The Coil Journey detail section is unchanged.
+
+### Claude's Discretion
+- Exact Tailwind classes for Excel styling, sticky implementation details.
+- Whether to keep/add column sorting and a search box on the new table (nice
+  to have, not required).
+- Default row order (coil ID or inward date ascending is fine).
+- Small formatter helpers (e.g., `fmt2`, `fmtCount`) — local to the component
+  or hoisted next to `fmtT`.
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Source of truth
+- `src/App.jsx` — single-file application. Key regions:
+  - `CoilTracker` component (~lines 1527–1760): `inventorySummary` useMemo,
+    `summaryColumns`, the Section being replaced, `selectedCoilId` wiring.
+  - Formatters `fmtT` / `fmtPct` (~lines 36–37); Dashboard `fmt2` precedent
+    (~line 1299).
+  - Record shapes: coil `emptyForm` (~line 209, `dateOfInward`,
+    `coilGrade`, `actualWeight`), baby coil (~line 316), tube (~line 557),
+    dispatch (~line 1026, `bundleEntries[]` with `traceBabyCoilId`, `pieces`,
+    `weight`).
+- `CLAUDE.md` — single-file pattern, soft-delete, color conventions, dark mode.
+
+### Data-flow facts
+- Trace chain: `coil.hrCoilId → baby.hrCoilId` / `baby.babyCoilId →
+  tube.babyCoilId` and `→ dispatch.bundleEntries[].traceBabyCoilId`.
+- ⚠ Known limitation (from Phase 1): a dispatch `bundleEntry` traces only the
+  bundle's first-row baby coil, so dispatched pieces/weight attribute to that
+  trace coil. Accept as-is; do not redesign tracing in this phase.
+- Date fields: coils `dateOfInward`, baby coils & tubes `dateOfConversion`,
+  dispatches `dateOfDispatch` (only `dateOfInward` is used for the R5 filter).
+</canonical_refs>
+
+<specifics>
+## Specific Ideas
+- The user's sample renders blank/zero as `-` and counts like `1,011` —
+  mirror that exactly.
+- Subtotal row look: bold, slightly shaded background, double/heavier border
+  below it (classic Excel totals-at-top).
+- Reuse the existing `active()` soft-delete filter and the dispatched-weight
+  aggregation already in `inventorySummary` as the starting point — extend it
+  with the new columns rather than rebuilding from scratch.
+</specifics>
+
+<deferred>
+## Deferred Ideas
+- CSV/XLSX export of this summary (user asked for on-screen format only).
+- Period-clipping downstream quantities (e.g., "tubes produced during the
+  period") — would need per-stage date filtering and a different reconciliation
+  model.
+- Grade-wise grouping/sub-subtotals.
+</deferred>
+
+---
+
+*Phase: 02-coil-tracker-summary*
+*Context gathered: 2026-06-10 via PRD Express Path*

--- a/.planning/phases/02-coil-tracker-summary/02-PLAN.md
+++ b/.planning/phases/02-coil-tracker-summary/02-PLAN.md
@@ -1,0 +1,209 @@
+---
+phase: 02-coil-tracker-summary
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified: [src/App.jsx]
+autonomous: true
+requirements: [R4, R5, R6, R7]
+
+must_haves:
+  truths:
+    - "The Coil Tracker summary shows one row per non-deleted mother coil with exactly 14 columns in the locked order: Coil ID, Grade, Coil Wt (T), # Baby Coils, Baby Coil Wt (T), # Converted, Converted Wt (T), # Tubes, Tubes Wt (T), # Dispatched, Dispatched Wt (T), Balance to Roll (T), Tube Inventory (T), Tube Inventory (#)."
+    - "Derived columns reconcile: Balance to Roll = Coil Wt − Baby Coil Wt; Tube Inventory (T) = Tubes Wt − Dispatched Wt; Tube Inventory (#) = # Tubes − # Dispatched; negatives render with a minus sign (e.g. -17.89), never clamped to 0."
+    - "Setting From/To dates filters mother coils by dateOfInward (inclusive; either bound may be empty) and the subtotal row recomputes over the filtered set."
+    - "A single subtotal row labelled 'Total (N)' renders ABOVE all data rows and stays pinned together with the header while the table body scrolls."
+    - "Cells render at Excel density (text-xs, px-2 py-1) with gridlines on every cell, right-aligned numerics, 2-dp weights, thousands-separated counts ('1,011'), and '-' for rounded-zero/blank — in both light and dark mode."
+    - "Clicking a coil row still sets selectedCoilId, highlights the row (indigo), and opens the unchanged Coil Journey section below."
+  artifacts:
+    - path: "src/App.jsx"
+      provides: "Excel-style 14-column coil summary inside CoilTracker: filteredCoils + extended inventorySummary + subtotals memos, fmt2/fmtCount formatters, From/To date inputs, custom sticky table replacing the DataTable"
+      contains: "Balance to Roll"
+  key_links:
+    - from: "dateFrom/dateTo state"
+      to: "inventorySummary"
+      via: "filteredCoils useMemo gates the coils mapped by inventorySummary"
+      pattern: "filteredCoils"
+    - from: "subtotal <tr> (first tbody row)"
+      to: "subtotals useMemo"
+      via: "cells render subtotals.* through fmt2/fmtCount"
+      pattern: "subtotals\\."
+    - from: "data row onClick"
+      to: "selectedCoilId / Coil Journey"
+      via: "setSelectedCoilId(row.hrCoilId) on the new <tr>"
+      pattern: "setSelectedCoilId\\(row\\.hrCoilId\\)"
+    - from: "summary <table>"
+      to: "persistent gridlines under sticky cells"
+      via: "border-separate border-spacing-0 on table + border-b/border-r on every th/td"
+      pattern: "border-separate"
+---
+
+<objective>
+Replace the "Inventory Summary — All Coils" DataTable inside the `CoilTracker` component of `src/App.jsx` with a custom Excel-style coil summary report:
+- R4: 14 locked columns per mother coil tracing inward → slit → converted → tubes → dispatched → tube inventory, with sample-verified formulas.
+- R5: From/To date filter on coil `dateOfInward` (inclusive, open-ended bounds; downstream quantities stay lifetime totals).
+- R6: A subtotal row pinned at the TOP (above all data rows), sticky alongside the header, summing columns 3–14 over the filtered rows.
+- R7: Excel-standard presentation — text-xs density, ~px-2 py-1 cells, gridlines on every cell, right-aligned numerics, 2-dp weights, thousands-separated counts, '-' for zero/blank, dark-mode variants.
+
+Purpose: the current summary (10 generic columns, roomy DataTable) cannot express the reconciliation view the user works from in Excel; the shared DataTable cannot render a pinned subtotal row or Excel density.
+Output: Modified `src/App.jsx` only (single-file pattern preserved; Coil Journey section untouched; no data-model or Supabase changes).
+</objective>
+
+<execution_context>
+All edits in ONE file (`src/App.jsx`), ONE component (`CoilTracker`, :1532-1832). Execute tasks in order (Task 1 → Task 2 → Task 3) to avoid edit conflicts. Do NOT split the file. `CoilTracker` already receives all five datasets as props (`:2193`) — no prop threading needed. After Task 1, the old DataTable transiently renders blank cells for dropped keys (`unbundledPcs`, `undispatchedBundles`, `yieldPct`); this is expected and resolved by Task 2 in the same plan — the build still passes (no type checking in Vite/JSX).
+</execution_context>
+
+<context>
+@.planning/phases/02-coil-tracker-summary/02-CONTEXT.md
+@.planning/phases/02-coil-tracker-summary/02-RESEARCH.md
+@CLAUDE.md
+
+<interfaces>
+<!-- Key shapes the executor needs (verified against src/App.jsx this session). Use directly — no exploration needed. -->
+
+CoilTracker({ coils, babyCoils, tubes, bundles, dispatches }) — src/App.jsx:1532
+- `active(arr)` soft-delete filter :1534; `ac, ab, at, abn, ad` :1535 (recomputed each render — existing memos already depend on them; mirror that pattern).
+- `inventorySummary` useMemo :1538-1566 — already computes per coil: `babies` (`ab.filter(b => b.hrCoilId === c.hrCoilId)`), `babyIds`, `coilTubes` (`at.filter(t => babyIds.includes(t.babyCoilId))`), `totalTubePcs` (Σ `numberOfPieces`), `slitWt` (Σ `b.weight`), `dispatchedWt` (`ad.flatMap(d => d.bundleEntries || []).filter(be => babyIds.includes(be.traceBabyCoilId)).reduce(... be.weight)`), plus dropped fields `bundledPcs/unbundledPcs/undispatchedBundles/yieldPct` (consumed ONLY by `summaryColumns` :1637-1648, which this plan deletes).
+- Journey memo :1570-1622 uses `abn` and unfiltered `ac` — leave :1535 and the journey untouched.
+- Section being replaced :1654-1664: `<Section title="Inventory Summary — All Coils">` wrapping `<div className="overflow-x-auto"><DataTable columns={summaryColumns} data={inventorySummary} onRowClick={(row) => setSelectedCoilId(row.hrCoilId)} highlightRow={(row) => row.hrCoilId === selectedCoilId} /></div>`.
+
+Record fields (all may be strings or '' — wrap every operand in `Number(x || 0)`):
+- coil :209: `dateOfInward` (ISO yyyy-mm-dd), `hrCoilId`, `coilGrade`, `actualWeight`.
+- babyCoil :367-373: `babyCoilId`, `hrCoilId`, `weight`.
+- tube :602-609: `babyCoilId`, `numberOfPieces`, `theoreticalWeight` (tonnes).
+- dispatch bundleEntry :1057-1063: `{ pieces, weight, traceBabyCoilId, ... }` under `dispatch.bundleEntries`.
+
+Patterns to mirror:
+- Date filter (CoilToSlit :448-455): `if (customFrom && b.dateOfConversion < customFrom) return false; if (customTo && b.dateOfConversion > customTo) return false` — lexicographic ISO compare, inclusive, empty = open-ended.
+- Date input UI (CoilToSlit :539-543): `<input type="date" ... className="px-2 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100" />` pair separated by `<span className="text-sm text-slate-500">to</span>`, placed in the `Section` `actions` prop (`Section = ({ title, children, actions })` :128).
+- Table header cell classes (BundleFormation :926-935): `bg-slate-50 dark:bg-slate-700` row, th `text-xs font-medium text-slate-500 dark:text-slate-300 uppercase tracking-wider whitespace-nowrap`.
+- Totals-row styling (BundleFormation :999-1004): `bg-slate-100/70 dark:bg-slate-800/50 border-b-2 border-slate-300 dark:border-slate-600` + `font-semibold` — use OPAQUE bg (drop the /70 and /50) because the subtotal row is sticky.
+- Row highlight (DataTable :182): `bg-indigo-50 dark:bg-indigo-900/20`; hover `hover:bg-slate-50 dark:hover:bg-slate-700/50`; empty state row (DataTable :177-179): single td with colSpan, `px-4 py-8 text-center text-slate-400`.
+- Formatter precedents NOT to reuse: `fmtT` :36 (3 dp, '—' blank) and SKUMaster's local `fmt2` :1299 ('' blank, '0.00' zero) — both violate R7.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1 (R4 + R5 logic): fmt2/fmtCount formatters, dateFrom/dateTo state, filteredCoils memo, extended inventorySummary, subtotals memo</name>
+  <read_first>
+    src/App.jsx:1532-1670 (CoilTracker: active/ac-ad, inventorySummary, journey deps, summaryColumns, Section being replaced).
+    src/App.jsx:448-455 and :320-322 (CoilToSlit date-filter logic + state precedent).
+    src/App.jsx:34-37 (today/uid/fmtT/fmtPct — note fmtT is 3-dp and NOT used for new columns).
+    02-CONTEXT.md §R4/§R5 (locked formulas) and 02-RESEARCH.md §Current State, §Date Filter Precedent, §Formatting.
+  </read_first>
+  <action>
+    All edits inside the `CoilTracker` function in src/App.jsx:
+    1. Add two local formatter consts (plain functions, not hooks) near the top of the component, named exactly `fmt2` and `fmtCount`. Keep them LOCAL to CoilTracker (do not hoist — a module-level `fmt2` would shadow-confuse with SKUMaster's different local `fmt2` at :1299). `fmt2(v)`: compute `const r = Math.round(Number(v || 0) * 100) / 100` then return `r ? r.toFixed(2) : '-'` — rounding BEFORE the zero test kills float dust (1e-15) and `-0` (falsy) while preserving real negatives like -17.89. `fmtCount(v)`: compute `const n = Math.round(Number(v || 0))` then return `n ? n.toLocaleString('en-US') : '-'` — explicit 'en-US' produces the sample's `1,011` grouping (not en-IN lakh grouping).
+    2. Add state next to `selectedCoilId` (:1533): `dateFrom` and `dateTo`, both `useState('')`.
+    3. Add a `filteredCoils` useMemo over `[ac, dateFrom, dateTo]`: filter `ac` keeping coils where NOT (`dateFrom && c.dateOfInward < dateFrom`) and NOT (`dateTo && c.dateOfInward > dateTo`) — lexicographic ISO compare per the :452-453 precedent (inclusive bounds, empty string = open-ended, both empty = all coils). Then sort the filtered array ascending by `dateOfInward` with `hrCoilId` localeCompare tiebreak (deterministic default order — documented discretion per 02-CONTEXT.md).
+    4. Rewrite the `inventorySummary` useMemo (:1538-1566) to map over `filteredCoils` (not `ac`) and return per coil EXACTLY these raw-number fields (formatting happens at render in Task 2): `hrCoilId` = `c.hrCoilId`; `grade` = `c.coilGrade`; `coilWt` = `Number(c.actualWeight || 0)`; keep `babies`/`babyIds`/`coilTubes` derivations as today; `babyCount` = `babies.length`; `babyWt` = Σ `Number(b.weight || 0)` over `babies`; NEW `convertedBabies` = `babies.filter(b => coilTubes.some(t => t.babyCoilId === b.babyCoilId))`, with `convertedCount` = its length and `convertedWt` = Σ `Number(b.weight || 0)` over it; `tubePcs` = Σ `Number(t.numberOfPieces || 0)` over `coilTubes`; NEW `tubesWt` = Σ `Number(t.theoreticalWeight || 0)` over `coilTubes`; keep the existing dispatch-entry derivation (`ad.flatMap(d => d.bundleEntries || []).filter(be => babyIds.includes(be.traceBabyCoilId))`) and from it compute NEW `dispatchedPcs` = Σ `Number(be.pieces || 0)` and existing `dispatchedWt` = Σ `Number(be.weight || 0)`; derived `balanceToRoll` = `coilWt - babyWt`, `tubeInvWt` = `tubesWt - dispatchedWt`, `tubeInvPcs` = `tubePcs - dispatchedPcs`. DROP from this memo: `coilBundles`, `bundledPcs`, `unbundledPcs`, `undispatchedBundles` (the local const), `yieldPct`, `thickness`, `width` (only the soon-deleted `summaryColumns` consumed them). New dependency array: `[filteredCoils, ab, at, ad]` (`abn` is no longer read here; the journey memo still uses `abn` — do not touch :1535 or the journey). Do NOT clamp negatives; do NOT special-case zero-baby coils (`balanceToRoll` naturally equals the full `coilWt`). Per locked decision, accept the known trace limitation: `bundleEntry.traceBabyCoilId` is only the bundle's first-row baby coil — do not redesign tracing.
+    5. Add a `subtotals` useMemo over `[inventorySummary]`: a single reduce producing the sums of all 12 numeric fields (`coilWt`, `babyCount`, `babyWt`, `convertedCount`, `convertedWt`, `tubePcs`, `tubesWt`, `dispatchedPcs`, `dispatchedWt`, `balanceToRoll`, `tubeInvWt`, `tubeInvPcs`) plus `coilCount` = `inventorySummary.length`. Summing the per-row deriveds directly is correct (linear formulas).
+    No other component, no Supabase/db.js, no schema changes.
+  </action>
+  <verify>
+    <automated>npm run build (fallback: node node_modules/vite/bin/vite.js build) exits 0; node -e formatter spot-checks below produce exact expected output; grep checks below pass.</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "const fmt2" src/App.jsx` returns 2 (SKUMaster's :1299 plus the new CoilTracker-local one) and `grep -c "fmtCount" src/App.jsx` returns >= 1.
+    - `grep -c "filteredCoils" src/App.jsx` returns >= 2 (definition + inventorySummary map source) and the filter body compares `c.dateOfInward` against `dateFrom` and `dateTo` with `<` / `>`.
+    - `grep -n "balanceToRoll\|tubeInvWt\|tubeInvPcs\|convertedWt\|dispatchedPcs\|tubesWt" src/App.jsx` shows all six new identifiers inside the inventorySummary memo.
+    - The inventorySummary useMemo body contains NO occurrence of `yieldPct`, `unbundledPcs`, or `bundledPcs`, and its dependency array is `[filteredCoils, ab, at, ad]`.
+    - A `subtotals` useMemo exists whose result includes `coilCount` and all 12 numeric sums.
+    - `node -e "const fmt2=v=>{const r=Math.round(Number(v||0)*100)/100;return r?r.toFixed(2):'-'};console.log(fmt2(0),fmt2(-0),fmt2(1e-15),fmt2(-17.894),fmt2(20.625))"` prints `- - - -17.89 20.63` (mirrors the implemented expression; if the implementation differs, run the actual expression — outputs must match these values).
+    - `node -e "const f=v=>{const n=Math.round(Number(v||0));return n?n.toLocaleString('en-US'):'-'};console.log(f(1011),f(0),f(147))"` prints `1,011 - 147`.
+    - `npm run build` exits 0.
+  </acceptance_criteria>
+  <done>R4 aggregation and R5 filter logic complete: 14 columns' raw values computed per filtered coil, subtotals memo recomputes from the filtered set, formatters implement the round-before-zero-test rule.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2 (R5 UI + R6 + R7): From/To inputs and custom Excel-style table with pinned subtotal replacing the DataTable</name>
+  <read_first>
+    src/App.jsx — CoilTracker region as modified by Task 1, especially the `summaryColumns` array and the `Section title="Inventory Summary — All Coils"` block (pre-Task-1 anchors :1637-1648 and :1654-1664).
+    src/App.jsx:138-203 (DataTable — highlight class :182, hover class, empty-state row :177-179; understand what is being replaced and why its px-4 py-3 / search / internal sort are unsuitable).
+    src/App.jsx:539-543 (date input markup to mirror), :128-134 (Section actions prop), :922-1010 (BundleFormation table + totals-row styling :999-1004), :2144 (app header sticky top-0 z-50 — the new table sticks within its OWN scrollport, so no z conflict).
+    02-CONTEXT.md §R6/§R7/§Placement and 02-RESEARCH.md §Sticky Header & Pinned Subtotal, §Formatting, §Table Markup Precedents, §Risks.
+  </read_first>
+  <action>
+    All edits inside `CoilTracker` in src/App.jsx:
+    1. R5 UI: add an `actions` prop to the `Section title="Inventory Summary — All Coils"` (keep the title): a `div` with `flex items-center gap-2` containing an optional `<span className="text-sm text-slate-500">Period:</span>`, an `<input type="date">` bound `value={dateFrom}` / `onChange={e => setDateFrom(e.target.value)}` with the exact :539-543 classes (`px-2 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100`), a `<span className="text-sm text-slate-500">to</span>`, and the same input bound to `dateTo`/`setDateTo`. No preset dropdown (locked: From/To only).
+    2. Replace the inner `<div className="overflow-x-auto"><DataTable ... /></div>` with custom markup:
+       - Wrapper div: `overflow-auto max-h-96 rounded-lg border border-slate-200 dark:border-slate-700` — the vertical scrollport (`max-h-96` + `overflow-auto`) is REQUIRED or sticky never engages (research: DataTable's sticky th is inert today for exactly this reason). Horizontal scroll comes free from `overflow-auto`.
+       - `<table className="min-w-full text-xs border-separate border-spacing-0">` — `border-separate border-spacing-0` is REQUIRED (assumption A2: default border-collapse drops sticky-cell borders while the body scrolls beneath them).
+       - Header: one `<thead>` row; 14 `<th>` cells in EXACTLY this order: `Coil ID`, `Grade`, `Coil Wt (T)`, `# Baby Coils`, `Baby Coil Wt (T)`, `# Converted`, `Converted Wt (T)`, `# Tubes`, `Tubes Wt (T)`, `# Dispatched`, `Dispatched Wt (T)`, `Balance to Roll (T)`, `Tube Inventory (T)`, `Tube Inventory (#)`. Each th: `sticky top-0 z-20 h-8 px-2 py-1 bg-slate-50 dark:bg-slate-700 text-xs font-medium text-slate-500 dark:text-slate-300 uppercase tracking-wider whitespace-nowrap border-b border-r border-slate-200 dark:border-slate-600`, plus `text-left` on cells 1-2 and `text-right` on cells 3-14. Sticky goes on CELLS (th/td), never on tr/thead (assumption A1). `h-8` fixes the header height so the subtotal can pin with the standard class `top-8` (no arbitrary values). Backgrounds MUST be opaque (no /70-style opacity) or data rows bleed through while scrolling.
+       - Subtotal row: the FIRST `<tr>` of `<tbody>`, ALWAYS rendered (even with 0 filtered rows). 14 `<td>` cells each with `sticky top-8 z-10 px-2 py-1 bg-slate-100 dark:bg-slate-800 text-xs font-semibold text-slate-700 dark:text-slate-200 whitespace-nowrap border-b-2 border-r border-slate-300 dark:border-slate-600`. Cell 1 (`text-left`): the literal `Total (` + `subtotals.coilCount` + `)`. Cell 2 (Grade): `-`. Cells 3-14 (`text-right tabular-nums`), in column order: `fmt2(subtotals.coilWt)`, `fmtCount(subtotals.babyCount)`, `fmt2(subtotals.babyWt)`, `fmtCount(subtotals.convertedCount)`, `fmt2(subtotals.convertedWt)`, `fmtCount(subtotals.tubePcs)`, `fmt2(subtotals.tubesWt)`, `fmtCount(subtotals.dispatchedPcs)`, `fmt2(subtotals.dispatchedWt)`, `fmt2(subtotals.balanceToRoll)`, `fmt2(subtotals.tubeInvWt)`, `fmtCount(subtotals.tubeInvPcs)`. No onClick, no hover class on this row.
+       - Empty state: when `inventorySummary.length === 0`, render after the subtotal row a single `<tr>` with one `<td colSpan={14}>` styled `px-2 py-8 text-center text-slate-400 border-b border-slate-200 dark:border-slate-600` and text like `No coils in the selected period` (DataTable :177-179 pattern).
+       - Data rows: `inventorySummary.map(row => ...)`, `key={row.hrCoilId}`. `<tr>` className: `cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-700/50` plus `bg-indigo-50 dark:bg-indigo-900/20` when `row.hrCoilId === selectedCoilId` (DataTable :182 highlight); `onClick={() => setSelectedCoilId(row.hrCoilId)}` — preserving the locked row-click → Journey behavior. Every `<td>` base: `px-2 py-1 whitespace-nowrap border-b border-r border-slate-200 dark:border-slate-600`. Cell 1: `text-left font-medium text-slate-900 dark:text-white` rendering `row.hrCoilId`. Cell 2: `text-left text-slate-700 dark:text-slate-300` rendering `row.grade || '-'`. Cells 3-14: `text-right tabular-nums text-slate-700 dark:text-slate-300` rendering, in order: `fmt2(row.coilWt)`, `fmtCount(row.babyCount)`, `fmt2(row.babyWt)`, `fmtCount(row.convertedCount)`, `fmt2(row.convertedWt)`, `fmtCount(row.tubePcs)`, `fmt2(row.tubesWt)`, `fmtCount(row.dispatchedPcs)`, `fmt2(row.dispatchedWt)`, `fmt2(row.balanceToRoll)`, `fmt2(row.tubeInvWt)`, `fmtCount(row.tubeInvPcs)`. A header-labels array constant mapped to `<th>` is fine; keep td order hand-written or driven by a small column config — executor's choice, as long as the locked order is exact.
+       - Documented discretion: NO SearchInput and NO column sorting on this table (avoids the subtotal-vs-sort pitfall; CONTEXT marks both as optional). Default order is the Task 1 sort (dateOfInward asc).
+    3. Delete the now-dead `summaryColumns` array entirely. Do NOT delete the shared `YieldBadge` component (:66) even though this removes its last JSX usage — shared UI components stay.
+    4. Do NOT touch the Coil Journey section, the journey/weightFlowData memos, or any other component. Note (accepted behavior, not a bug): narrowing the date filter while a coil is selected may hide its row, but the Journey stays open because it keys off unfiltered `ac`.
+  </action>
+  <verify>
+    <automated>npm run build (fallback: node node_modules/vite/bin/vite.js build) exits 0; grep checks below pass.</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "border-separate border-spacing-0" src/App.jsx` matches inside CoilTracker; `grep -n "max-h-96" src/App.jsx` matches the summary wrapper.
+    - `grep -c "sticky top-0 z-20" src/App.jsx` >= 1 (header cells) and `grep -c "sticky top-8" src/App.jsx` >= 1 (subtotal cells); both carry opaque `bg-slate-*` classes with `dark:` variants on the same element.
+    - All 14 locked header labels appear in src/App.jsx; in particular `grep -c "Tube Inventory" src/App.jsx` >= 2 and `grep -c "Balance to Roll" src/App.jsx` >= 1.
+    - The subtotal `<tr>` appears in the tbody JSX BEFORE `inventorySummary.map(` (source order), renders the literal `Total (` with `subtotals.coilCount`, and has no onClick.
+    - `grep -c "summaryColumns" src/App.jsx` returns 0 and `grep -c "data={inventorySummary}" src/App.jsx` returns 0 (DataTable no longer renders the summary; DataTable itself remains for other tabs).
+    - `grep -n "setSelectedCoilId(row.hrCoilId)" src/App.jsx` matches inside the new tbody and `bg-indigo-50 dark:bg-indigo-900/20` appears on the data-row className.
+    - `grep -c "setDateFrom(e.target.value)" src/App.jsx` and `grep -c "setDateTo(e.target.value)" src/App.jsx` each return 1, inside the Section actions.
+    - The empty-state `<tr>` uses `colSpan={14}`.
+    - `npm run build` exits 0.
+  </acceptance_criteria>
+  <done>R5 UI, R6, and R7 satisfied in markup: From/To inputs drive the filter; the 14-column Excel-density table renders with sticky header + sticky top subtotal, per-cell gridlines, locked alignment/formatting, preserved row-click Journey behavior, and dark-mode variants throughout.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Integrated verification, dead-code sweep, and manual-check handoff</name>
+  <read_first>
+    src/App.jsx — the full post-edit CoilTracker function (top of component through the end of the summary Section).
+    02-CONTEXT.md (success criteria + sample values: 20.63 − 20.51 = 0.12; 0 − 17.89 = −17.89; 1,011 − 864 = 147) and 02-RESEARCH.md §Risks / §Assumptions Log (A1, A2).
+    .planning/ROADMAP.md Phase 2 success criteria.
+  </read_first>
+  <action>
+    1. Run the production build: `npm run build` (fallback `node node_modules/vite/bin/vite.js build`) — must exit 0 with no warnings about App.jsx syntax.
+    2. Dead-code sweep with grep: `unbundledPcs` must have 0 occurrences file-wide (it existed only in the old summary at former :1546/:1562/:1644); `undispatchedBundles` occurrences must all be inside the Dispatch component (its own unrelated memo, former :1036/:1048/:1052 — the CoilTracker ones at former :1549/:1562/:1645 are gone); `yieldPct` occurrences must all be inside CoilInward (former :256-257 — CoilTracker's at former :1556/:1563/:1647 are gone). Confirm `const ac = ...` line (:1535) still declares `abn` (journey needs it) and the journey/weightFlowData memos are byte-identical to before this phase.
+    3. Sample-value reconciliation via node, replicating the implemented formatter expressions verbatim from src/App.jsx: `fmt2(20.63 - 20.51)` must print `0.12` (float dust 0.12000000000000099 rounds clean), `fmt2(0 - 17.89)` must print `-17.89`, `fmtCount(1011 - 864)` must print `147`, `fmt2(0)` and `fmtCount(0)` must print `-`.
+    4. Project-constraint checks: `git status --porcelain` shows `src/App.jsx` as the ONLY modified source file; no new files under src/; no density constants introduced (grep for `7.85` returns nothing new); every new element that sets a `bg-`, `border-`, or `text-slate` color class also carries a `dark:` variant on the same className string (spot-check the new thead/subtotal/td class strings).
+    5. Write `.planning/phases/02-coil-tracker-summary/02-01-SUMMARY.md` including a "Manual browser checks (required — CSS assumptions A1/A2)" section listing, for the user to run with `npm run dev`: (a) scroll the summary scrollport — header AND subtotal stay pinned, gridlines persist, in light AND dark mode; (b) no row bleed-through behind sticky cells; (c) set From/To — rows narrow by dateOfInward and the Total (N) row recomputes; clear them — all coils return; (d) click a coil row — indigo highlight + Journey opens below; subtotal row is not clickable; (e) reconcile one coil's 14 cells against manual sums of its Stage 2/3/5 records; (f) note the accepted quirk: a selected coil hidden by the filter keeps its Journey open.
+  </action>
+  <verify>
+    <automated>npm run build exits 0; grep -c "unbundledPcs" src/App.jsx returns 0; grep -c "summaryColumns" src/App.jsx returns 0; git status --porcelain shows only src/App.jsx among tracked source changes; node -e sample-value checks print 0.12 / -17.89 / 147 / - / -.</automated>
+  </verify>
+  <acceptance_criteria>
+    - `npm run build` exits 0.
+    - `grep -c "unbundledPcs" src/App.jsx` returns 0; remaining `undispatchedBundles` matches are only in Dispatch; remaining `yieldPct` matches are only in CoilInward.
+    - The journey useMemo and weightFlowData useMemo are unchanged (no diff hunks touch them in `git diff src/App.jsx`).
+    - Sample-value node checks print exactly `0.12`, `-17.89`, `147`, `-`, `-`.
+    - `git status --porcelain` lists `src/App.jsx` as the only modified source file.
+    - `02-01-SUMMARY.md` exists and contains the manual browser checklist covering sticky pinning, gridline persistence (A1/A2), filter + subtotal recompute, and row-click Journey.
+  </acceptance_criteria>
+  <done>Build green, dead code purged, formulas reconcile against the user's sample values, single-file constraint proven, and the un-automatable sticky/gridline checks handed to the user as an explicit checklist.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `npm run build` (or `node node_modules/vite/bin/vite.js build`) completes with no errors after each task and at the end.
+- R4: one row per non-deleted mother coil; 14 columns in the locked order; Balance to Roll = Coil Wt − Baby Coil Wt, Tube Inventory (T) = Tubes Wt − Dispatched Wt, Tube Inventory (#) = # Tubes − # Dispatched; negatives keep their minus sign; soft-deleted records excluded via the existing `active()` filter.
+- R5: From/To date inputs filter coils by `dateOfInward` (inclusive, lexicographic ISO compare, open-ended bounds); downstream quantities remain lifetime totals.
+- R6: subtotal row is the first tbody row, labelled `Total (N)`, sums columns 3–14 over the filtered rows, and recomputes when the filter changes.
+- R7: text-xs / px-2 py-1 density, per-cell gridlines via `border-separate border-spacing-0` + `border-b border-r`, right-aligned numerics, 2-dp weights via fmt2, 'en-US' thousands counts via fmtCount, `-` for rounded-zero/blank, dark-mode variants on every new element.
+- Manual browser checks (flagged [ASSUMED] in research — A1 sticky-on-cells, A2 border-separate; cannot be verified headlessly): with `npm run dev`, scroll the summary scrollport in light and dark mode and confirm the header AND subtotal row stay pinned with gridlines persisting and no bleed-through; confirm row-click opens the Journey with indigo highlight; confirm From/To narrows rows and recomputes the subtotal. These are listed in 02-01-SUMMARY.md for the user.
+- All edits confined to `src/App.jsx`; Journey section, other tabs, data model, and Supabase layer untouched; no density constants; single-file pattern preserved.
+</verification>
+
+<success_criteria>
+- R4, R5, R6, R7 each provable by the acceptance criteria above, a passing build, and the manual browser checklist.
+- The Coil Tracker summary reconciles against the user's 54-row sample semantics (0.12 / −17.89 / 147 spot values reproduce through the implemented formatters).
+- Existing behaviors preserved: row-click → `selectedCoilId` → Journey with highlight; Journey section byte-identical; DataTable still serves all other tabs.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-coil-tracker-summary/02-01-SUMMARY.md` when done (includes the manual browser checklist from Task 3).
+</output>

--- a/.planning/phases/02-coil-tracker-summary/02-RESEARCH.md
+++ b/.planning/phases/02-coil-tracker-summary/02-RESEARCH.md
@@ -1,0 +1,179 @@
+# Phase 2 — Coil Tracker Excel-Style Summary — Research
+
+**Researched:** 2026-06-10
+**Method:** Direct codebase analysis of `src/App.jsx` (single-file SPA, 2215 lines). No external libraries needed — React 18 + Tailwind 3.4 only.
+**Confidence:** HIGH (all line references verified this session)
+
+<user_constraints>
+## User Constraints (from 02-CONTEXT.md)
+
+### Locked Decisions
+
+**R4 — Columns (exact order) and formulas** (verified against user's 54-row sample):
+
+| # | Column | Source / Formula |
+|---|--------|------------------|
+| 1 | Coil ID | `coil.hrCoilId` |
+| 2 | Grade | `coil.coilGrade` |
+| 3 | Coil Wt (T) | `coil.actualWeight` |
+| 4 | # Baby Coils | count of non-deleted baby coils with `hrCoilId === coil.hrCoilId` |
+| 5 | Baby Coil Wt (T) | Σ `baby.weight` over those baby coils |
+| 6 | # Converted | count of those baby coils having ≥1 non-deleted tube record |
+| 7 | Converted Wt (T) | Σ `baby.weight` over the converted baby coils |
+| 8 | # Tubes | Σ `tube.numberOfPieces` over tube records of this coil's babies |
+| 9 | Tubes Wt (T) | Σ `tube.theoreticalWeight` over the same tube records |
+| 10 | # Dispatched | Σ `bundleEntry.pieces` over dispatch `bundleEntries` with `traceBabyCoilId` among this coil's babies |
+| 11 | Dispatched Wt (T) | Σ `bundleEntry.weight` over the same entries (existing CoilTracker logic) |
+| 12 | Balance to Roll (T) | `Coil Wt − Baby Coil Wt` (unslit coil shows its full weight) |
+| 13 | Tube Inventory (T) | `Tubes Wt − Dispatched Wt` (negative is legitimate, e.g., −17.89) |
+| 14 | Tube Inventory (#) | `# Tubes − # Dispatched` (e.g., 1,011 − 864 = 147) |
+
+- Negative derived values shown with minus sign — do not clamp to 0.
+- Soft-deleted records (`deleted: true`) excluded everywhere, matching the existing `active()` filter.
+
+**R5 — Date filter:** From/To `date` inputs above the table; selects **mother coils by `dateOfInward`**, inclusive; either bound may be empty (open-ended); both empty = all coils (default). Downstream quantities are lifetime totals — NOT clipped to the period.
+
+**R6 — Subtotals pinned at top:** single totals row ABOVE all data rows (first body row or second sticky header row), labelled `Total` (with coil count); sums columns 3–14 across currently filtered rows; recomputes on filter change; stays at top when the table scrolls (sticky alongside the header).
+
+**R7 — Excel-standard presentation:** compact density (text-xs, ~`px-2 py-1`, ~22–24px rows — NOT the roomy `px-4 py-3`); gridlines on all cells, light header fill; numerics right-aligned, Coil ID/Grade left-aligned; weights **2 dp** (differs from 3-dp `fmtT`); counts with thousands separators (`1,011`); zero/empty renders `-` in data AND subtotal rows; sticky header; horizontal scroll allowed; dark-mode variants.
+
+**Placement & behavior:** REPLACE the "Inventory Summary — All Coils" `DataTable` section inside `CoilTracker` with custom `<table>` markup (shared `DataTable` cannot render a pinned subtotal row or Excel density). Keep row-click → `selectedCoilId` → Journey behavior with selected-row highlight. Coil Journey detail section unchanged.
+
+### Claude's Discretion
+- Exact Tailwind classes for Excel styling; sticky implementation details.
+- Keep/add column sorting and a search box (nice to have, not required).
+- Default row order (coil ID or inward date ascending fine).
+- Formatter helpers (`fmt2`, `fmtCount`) local to component or hoisted next to `fmtT`.
+
+### Deferred Ideas (OUT OF SCOPE)
+- CSV/XLSX export of this summary.
+- Period-clipping downstream quantities (per-stage date filtering).
+- Grade-wise grouping/sub-subtotals.
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| R4 | 14-column per-coil summary with locked formulas | §Current State: existing `inventorySummary` already computes 7 of 14 columns; §Record Shapes verifies every source field |
+| R5 | From/To date filter on `dateOfInward` | §Date Filter Precedent: identical inclusive lexicographic pattern exists at `:448-471` |
+| R6 | Subtotals row pinned at top | §Sticky Header & Pinned Subtotal: technique + why DataTable can't do it |
+| R7 | Excel-standard formatting | §Formatting: existing formatter gaps, new `fmt2`/`fmtCount` shape, gridline technique |
+</phase_requirements>
+
+## Summary
+
+This is a contained rewrite of one `Section` inside `CoilTracker` (`src/App.jsx:1532-1832`). The existing `inventorySummary` useMemo (`:1538-1566`) already computes columns 1–5, 8, and 11 with the exact trace chain the spec locks; four new aggregations (# Converted, Converted Wt, Tubes Wt, # Dispatched pieces) reuse patterns that already exist in the `journey` useMemo, and columns 12–14 are arithmetic on row fields. The From/To filter has a verbatim precedent in `CoilToSlit`. The only genuinely new technique is the sticky header + sticky subtotal row with persistent gridlines, which requires a vertically scrollable wrapper and `border-separate` (sticky-cell borders vanish under default `border-collapse`).
+
+**Primary recommendation:** extend `inventorySummary` in place, replace the `DataTable` at `:1654-1664` with a custom `<table>` (`border-separate border-spacing-0`, sticky `th` + sticky subtotal `td` cells), and add two local formatters that treat rounded-zero as `-`.
+
+## Current State: CoilTracker & inventorySummary (R4)
+
+**Component:** `CoilTracker({ coils, babyCoils, tubes, bundles, dispatches })` at `:1532`. Already receives all five datasets as props (`:2193`) — **no prop threading needed** (unlike Phase 1's Dispatch gap).
+
+- `active()` soft-delete filter `:1534`; `ac/ab/at/abn/ad` `:1535`.
+- `inventorySummary` useMemo `:1538-1566` per coil already computes:
+  - `babies` (col 4 = `babies.length`) and `babyIds` `:1540-1541`
+  - `coilTubes = at.filter(t => babyIds.includes(t.babyCoilId))` `:1542`
+  - `totalTubePcs` (col 8) `:1544`
+  - `slitWt = babies.reduce(... Number(b.weight || 0))` (col 5) `:1561`
+  - `dispatchedWt` (col 11) via `ad.flatMap(d => d.bundleEntries || []).filter(be => babyIds.includes(be.traceBabyCoilId))` `:1553-1555`
+  - plus `unbundledPcs`, `undispatchedBundles`, `yieldPct` — dropped columns in the new spec (only used by the old table).
+- **Missing aggregations to add** (all from data already in scope):
+  - col 6 `# Converted`: `babies.filter(b => coilTubes.some(t => t.babyCoilId === b.babyCoilId)).length` — per-baby tube lookup pattern exists in `journey.babyDetails` `:1580-1588`
+  - col 7 `Converted Wt`: Σ `Number(b.weight || 0)` over those converted babies
+  - col 9 `Tubes Wt`: Σ `Number(t.theoreticalWeight || 0)` over `coilTubes` — same reduce at `:1584` and `:1614`
+  - col 10 `# Dispatched`: same flatMap/filter as `:1553-1555` but `reduce` on `Number(be.pieces || 0)`
+  - cols 12–14: derived arithmetic on the row.
+- `summaryColumns` `:1637-1648` and the Section being replaced `:1654-1664` (`DataTable` with `onRowClick={(row) => setSelectedCoilId(row.hrCoilId)}` and `highlightRow={(row) => row.hrCoilId === selectedCoilId}`).
+- Journey section `:1667-1830` reads only `selectedCoil`/`journey` — untouched by this phase.
+
+## Verified Record Shapes
+
+- **coil** — `emptyForm` `:209`: `dateOfInward` (ISO `yyyy-mm-dd` from `Input type="date"`), `coilGrade`, `thickness`, `width`, `invoiceWeight`, `actualWeight`, `costPrice`, `poNumber`; `hrCoilId` added at save `:229`; `deleted: false`.
+- **babyCoil** — save record `:367-373`: `babyCoilId`, `babyCoilEntry`, `hrCoilId`, `dateOfConversion`, `width`, `weight` (proportionate), `costPrice`, `thickness`, `poNumber`, `deleted`.
+- **tube** — save record `:602-609`: `dateOfConversion`, `skuCode`, `babyCoilId`, `numberOfPieces`, `theoreticalWeight` (T, `:579-581`), `thickness`, `width`, `length`, `deleted`.
+- **dispatch** — `emptyForm` `:1026` + save `:1075-1080`: `dateOfDispatch`, `vehicleNo`, `invoiceNo`, `vehicleWeight`, `bundleEntries` (= `selectedBundles`), `theoreticalWeight`, `variance`, `deleted`. **bundleEntry** `:1057-1063`: `{ bundleId, skuCode, pieces, weight, length, width, thickness, traceBabyCoilId }` — no per-entry `deleted` flag (entries of deleted dispatches drop out via `ad`).
+- Coercion convention everywhere: `Number(x || 0)` — fields can arrive as strings or `''`.
+
+## Date Filter Precedent (R5)
+
+`CoilToSlit` already implements exactly the R5 semantics:
+- State `:320-322` (`customFrom`, `customTo` as `''`).
+- Filter `:448-455`:
+  ```js
+  if (customFrom && b.dateOfConversion < customFrom) return false
+  if (customTo && b.dateOfConversion > customTo) return false
+  ```
+  Lexicographic compare on ISO strings — inclusive bounds, empty = open-ended. Apply the same to `c.dateOfInward`, memoized on `[ac, from, to]`, **before** the aggregation map so subtotals recompute automatically.
+- UI `:528-546`: raw `<input type="date">` with classes `px-2 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100`, separated by a `to` span, placed in the `Section` `actions` prop. Mirror this (just the From/To pair; the preset dropdown is not required).
+
+## Sticky Header & Pinned Subtotal (R6)
+
+- DataTable's `th` already carries `sticky top-0` (`:168`) but its wrapper (`:163`) is `overflow-x-auto` with **no max-height** — there is no vertical scrollport, so the sticky never engages today. For R6 the new wrapper needs both axes: e.g., `overflow-auto max-h-96` (or taller standard step) so the table scrolls within its own container; sticky then pins to that container, safely below the app header (`sticky top-0 z-50` `:2144`).
+- Apply `sticky` to **cells** (`th`/`td`), not `<tr>`/`<thead>` — sticky on table rows is unreliable across browsers [ASSUMED — standard CSS behavior; verify visually].
+- Two-tier pinning: header cells `sticky top-0 z-20`; subtotal-row cells `sticky z-10` with `top` = header row height. To honor frontend-design.md's "no arbitrary values": give the header row a fixed height (`h-8` = 32px) and use `top-8` on subtotal cells — both standard classes.
+- Sticky cells MUST have opaque backgrounds in both modes (e.g., header `bg-slate-50 dark:bg-slate-700`, subtotal `bg-slate-100 dark:bg-slate-800`) or data rows show through while scrolling.
+- Subtotal styling precedent — BundleFormation group totals row `:999-1004`: `bg-slate-100/70 dark:bg-slate-800/50 border-b-2 border-slate-300 dark:border-slate-600` + `font-semibold` (use opaque, not /70, since it's sticky).
+- **Why DataTable can't do this** (`:138-203`): hard-coded `px-4 py-3` cells (`:168`, `:185`), always-on search box (`:162`), internal sort over the full row array with no slot for a pinned row, and its own `!r.deleted` filter (`:144`). The locked decision to replace it with custom markup is correct.
+
+## Formatting (R7)
+
+- `fmtT` `:36` = `toFixed(3)`, `'—'` for null — wrong dp and wrong blank glyph for this table.
+- SKUMaster's local `fmt2` `:1299` = `toFixed(2)` but returns `''` for blank and `'0.00'` for zero — also doesn't match R7. (Note: 02-CONTEXT.md attributes it to Dashboard; it actually lives in `SKUMaster` `:1260-1299`. Same precedent, corrected location.)
+- **New helpers needed** (discretion: local to CoilTracker, or hoisted next to `fmtT` at `:36-37`):
+  - `fmt2(v)`: round first, then test zero — `const r = Math.round(Number(v || 0) * 100) / 100; return r ? r.toFixed(2) : '-'`. Handles float dust (1e-15 → `-`), `-0`, and preserves the minus on real negatives (−17.89).
+  - `fmtCount(v)`: `const n = Math.round(Number(v || 0)); return n ? n.toLocaleString('en-US') : '-'`. Explicit `'en-US'` matches the sample's `1,011` grouping and avoids en-IN lakh grouping on larger values (existing calls like `:270`, `:1729` use locale-default `toLocaleString()` — fine for ₹, ambiguous here).
+- Alignment: `text-right` on numeric `td`/`th` (cols 3–14), `text-left` on Coil ID/Grade; `tabular-nums` is available in Tailwind 3.4 core and helps column alignment (optional).
+- Gridlines: default `border-collapse` drops borders from sticky cells as content scrolls beneath them [ASSUMED — well-known CSS quirk; verify visually]. Use `border-separate border-spacing-0` on `<table>` (core utilities since Tailwind 3.1, no config change needed) and put `border-b border-r border-slate-200 dark:border-slate-600` on every `th`/`td`.
+
+## Table Markup Precedents (to mirror)
+
+- **BundleFormation accordion** `:922-1010`: `Section` + wrapper `overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700` (`:923`), header `tr bg-slate-50 dark:bg-slate-700`, `th` `text-xs font-medium text-slate-500 dark:text-slate-300 uppercase tracking-wider whitespace-nowrap` with optional click-sort (`:930-933`), `tbody divide-y divide-slate-200 dark:divide-slate-700` (replace divide-y with per-cell borders here).
+- **CoilTracker journey tables** `:1714-1739`, `:1747-1772`, `:1780-1804`: same header/body pattern, `hover:bg-slate-50 dark:hover:bg-slate-700/50` rows.
+- **Row click/highlight**: new rows get `cursor-pointer`, `onClick={() => setSelectedCoilId(row.hrCoilId)}`, highlight `bg-indigo-50 dark:bg-indigo-900/20` (DataTable's highlight class, `:182`).
+
+## Project Constraints (from CLAUDE.md)
+
+- Single-file `App.jsx` — all edits stay in `src/App.jsx`; do not decompose.
+- Functional components, `useMemo` for derived calculations.
+- Soft-delete pattern: filter `deleted: true` everywhere (already via `active()`).
+- No density constants — N/A here (pure aggregation of stored weights).
+- Dark mode `class` strategy — every new cell/control needs `dark:` variants.
+- Data via `useSupabaseStore` props — this phase is read-only over props; no storage/schema changes (also locked out of scope). Note: `.claude/skills/data-storage.md` still describes the old localStorage architecture — CLAUDE.md supersedes it.
+- `.claude/skills/frontend-design.md`: slate/indigo palette, text-xs for table headers, "no arbitrary [spacing] values" — prefer `h-8`/`top-8` pairing for the sticky offset.
+
+## Risks / Pitfalls
+
+- **Sticky borders vanish** under `border-collapse` — must use `border-separate border-spacing-0` + per-cell borders, or gridlines scroll away with the body (the one visual technique with no in-repo precedent; verify in browser, light + dark).
+- **Transparent sticky cells** — header/subtotal cells without opaque `bg-*` show data rows bleeding through on scroll.
+- **Float dust / `-0`** — `Tubes Wt − Dispatched Wt` can produce `1e-15` or `-0`; round to 2 dp **before** the zero→`-` test (see `fmt2` shape above) so subtotals and cells never show `0.00` or `-0.00`.
+- **Zero-baby coils** (fresh inward, e.g., `HYD-0426-09`): cols 4–11, 13, 14 are all 0 → render `-`; Balance to Roll = full `actualWeight` (formula yields this naturally — don't special-case).
+- **Negatives are legitimate** — `-` is only for rounded-zero/blank; `−17.89` must render with its minus sign. Don't clamp, don't `Math.abs`.
+- **String coercion** — `actualWeight`/`pieces`/`weight` may be strings or `''`; wrap every operand in `Number(x || 0)` like the rest of the file.
+- **Subtotal vs sort** — if optional sorting is added, the subtotal row must be rendered outside the sorted/mapped data array (and sum the filtered set, not the sorted slice).
+- **Known trace limitation** (accepted, locked): `bundleEntry.traceBabyCoilId` is only the bundle's first-row baby coil (`:1062`), so multi-coil bundles attribute all dispatched pieces/weight to that coil — col 10/11 inherit this. Do not redesign tracing.
+- **Empty filtered set** — From/To range matching no coils: render the subtotal row with `Total (0)` and `-` cells plus an empty-state row (DataTable's "No records found" pattern `:177-179`), not a bare table.
+- **Don't disturb the Journey** — `selectedCoilId` highlight must compare against `row.hrCoilId`; clearing/changing the date filter while a coil is selected may hide the selected row but the Journey section keys off `ac` (unfiltered), which is acceptable — note it in verification.
+
+## Recommendations for the planner
+
+1. Single task is feasible (one component section, ~120 lines changed); split at most into (a) aggregation + filter logic, (b) table markup/styling.
+2. Extend `inventorySummary` `:1538-1566` in place: add `convertedCount`, `convertedWt`, `tubesWt`, `dispatchedPcs`, and derived `balanceToRoll`, `tubeInvWt`, `tubeInvPcs`; gate the input `ac` through a `filteredCoils` memo on `dateFrom`/`dateTo` state.
+3. Compute subtotals in a separate `useMemo` over the summary rows (sum cols 3–11 raw; derive 12–14 as sums of row deriveds — same result either way since they're linear).
+4. Replace `:1654-1664` only; leave `summaryColumns` removal to the same edit (it becomes dead code otherwise).
+5. Keep old `yieldPct`/`unbundledPcs` logic only if something else consumes it (nothing does — safe to drop from the memo).
+6. Verification: browser check both modes, scroll the wrapper to confirm header + subtotal pin and gridlines persist, click a row to confirm Journey still opens, set From/To to confirm rows + subtotal narrow, and reconcile one coil's 14 values against manual sums.
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | `position: sticky` must go on cells, not `tr`/`thead`, for cross-browser reliability | Sticky Header | Minor — fallback is the same markup; verify visually |
+| A2 | Default `border-collapse` drops sticky-cell borders while scrolling (fix: `border-separate border-spacing-0`) | Formatting | Gridlines flicker/disappear on scroll; caught in browser verification |
+
+## Metadata
+
+**Confidence:** HIGH for all codebase findings (every line reference read this session). MEDIUM for the two CSS behavior claims above (training knowledge; both are verified trivially in the browser during execution).
+**Research date:** 2026-06-10 · Valid until source file changes (line refs are against current `src/App.jsx`, 2215 lines).

--- a/.planning/phases/02-coil-tracker-summary/02-UAT.md
+++ b/.planning/phases/02-coil-tracker-summary/02-UAT.md
@@ -1,0 +1,61 @@
+---
+status: testing
+phase: 02-coil-tracker-summary
+source: 02-01-SUMMARY.md
+started: 2026-06-10T06:28:21Z
+updated: 2026-06-10T06:28:21Z
+---
+
+## Current Test
+
+number: 1
+name: 14-Column Excel-Style Summary Renders
+expected: |
+  Open the Coil Tracker tab. The "Inventory Summary — All Coils" section shows
+  a compact Excel-style table with one row per mother coil and exactly 14
+  columns in this order: Coil ID, Grade, Coil Wt (T), # Baby Coils,
+  Baby Coil Wt (T), # Converted, Converted Wt (T), # Tubes, Tubes Wt (T),
+  # Dispatched, Dispatched Wt (T), Balance to Roll (T), Tube Inventory (T),
+  Tube Inventory (#). Rows are Excel-dense with gridlines on every cell,
+  numeric columns right-aligned, weights to 2 decimals, counts with thousands
+  separators (e.g. 1,011), and zero/blank cells rendered as "-".
+awaiting: user response
+
+## Tests
+
+### 1. 14-Column Excel-Style Summary Renders
+expected: Coil Tracker tab shows the Excel-style table — one row per mother coil, 14 columns in the locked order, gridlines, right-aligned numerics, 2-dp weights, thousands-separated counts, "-" for zero/blank.
+result: [pending]
+
+### 2. Subtotal Row Pinned at Top
+expected: The first row of the table reads "Total (N)" (N = number of coils shown), bold and shaded, summing every numeric column. Scrolling the table body keeps BOTH the header and the Total row pinned at the top, with gridlines persisting and no data rows bleeding through behind them.
+result: [pending]
+
+### 3. Date Period Filter
+expected: From/To date inputs sit in the section header. Setting them narrows rows to coils whose inward date falls in the range (inclusive) and the Total (N) row recomputes. Clearing both brings all coils back. A single bound works alone (open-ended).
+result: [pending]
+
+### 4. Row Click Opens Coil Journey
+expected: Clicking a coil row highlights it (indigo) and opens the Coil Journey detail below, exactly as before. Clicking the Total row does nothing (not clickable).
+result: [pending]
+
+### 5. Formulas Reconcile for a Sample Coil
+expected: Pick one coil with downstream activity. Its cells reconcile — Balance to Roll = Coil Wt − Baby Coil Wt; Tube Inventory (T) = Tubes Wt − Dispatched Wt; Tube Inventory (#) = # Tubes − # Dispatched — and match manual sums of its Stage 2 (baby coils), Stage 3 (tubes), and Stage 5 (dispatch) records. Negatives show a minus sign.
+result: [pending]
+
+### 6. Dark Mode Rendering
+expected: Toggling dark mode keeps the table fully styled — dark header and subtotal backgrounds, readable text, visible gridlines, no white patches behind sticky cells.
+result: [pending]
+
+## Summary
+
+total: 6
+passed: 0
+issues: 0
+pending: 6
+skipped: 0
+blocked: 0
+
+## Gaps
+
+[none yet]

--- a/.planning/phases/02-coil-tracker-summary/02-UAT.md
+++ b/.planning/phases/02-coil-tracker-summary/02-UAT.md
@@ -1,61 +1,57 @@
 ---
-status: testing
+status: complete
 phase: 02-coil-tracker-summary
 source: 02-01-SUMMARY.md
 started: 2026-06-10T06:28:21Z
-updated: 2026-06-10T06:28:21Z
+updated: 2026-06-10T07:55:00Z
 ---
 
 ## Current Test
 
-number: 1
-name: 14-Column Excel-Style Summary Renders
-expected: |
-  Open the Coil Tracker tab. The "Inventory Summary — All Coils" section shows
-  a compact Excel-style table with one row per mother coil and exactly 14
-  columns in this order: Coil ID, Grade, Coil Wt (T), # Baby Coils,
-  Baby Coil Wt (T), # Converted, Converted Wt (T), # Tubes, Tubes Wt (T),
-  # Dispatched, Dispatched Wt (T), Balance to Roll (T), Tube Inventory (T),
-  Tube Inventory (#). Rows are Excel-dense with gridlines on every cell,
-  numeric columns right-aligned, weights to 2 decimals, counts with thousands
-  separators (e.g. 1,011), and zero/blank cells rendered as "-".
-awaiting: user response
+[testing complete]
+
+> **Method note:** Tests 2–6 verified by Claude via headless-browser run
+> (puppeteer + @sparticuz/chromium) against the live dev server, with a local
+> fake Supabase REST server serving a 14-coil dataset mirroring the user's
+> sample sheet (incl. unslit coil, undispatched coil, fully-dispatched coil,
+> null-weight coil). 21/21 automated checks passed; screenshots reviewed and
+> sent to user. Test 1 also confirmed by user.
 
 ## Tests
 
 ### 1. 14-Column Excel-Style Summary Renders
 expected: Coil Tracker tab shows the Excel-style table — one row per mother coil, 14 columns in the locked order, gridlines, right-aligned numerics, 2-dp weights, thousands-separated counts, "-" for zero/blank.
-result: [pending]
+result: pass
 
 ### 2. Subtotal Row Pinned at Top
 expected: The first row of the table reads "Total (N)" (N = number of coils shown), bold and shaded, summing every numeric column. Scrolling the table body keeps BOTH the header and the Total row pinned at the top, with gridlines persisting and no data rows bleeding through behind them.
-result: [pending]
+result: pass
 
 ### 3. Date Period Filter
 expected: From/To date inputs sit in the section header. Setting them narrows rows to coils whose inward date falls in the range (inclusive) and the Total (N) row recomputes. Clearing both brings all coils back. A single bound works alone (open-ended).
-result: [pending]
+result: pass
 
 ### 4. Row Click Opens Coil Journey
 expected: Clicking a coil row highlights it (indigo) and opens the Coil Journey detail below, exactly as before. Clicking the Total row does nothing (not clickable).
-result: [pending]
+result: pass
 
 ### 5. Formulas Reconcile for a Sample Coil
 expected: Pick one coil with downstream activity. Its cells reconcile — Balance to Roll = Coil Wt − Baby Coil Wt; Tube Inventory (T) = Tubes Wt − Dispatched Wt; Tube Inventory (#) = # Tubes − # Dispatched — and match manual sums of its Stage 2 (baby coils), Stage 3 (tubes), and Stage 5 (dispatch) records. Negatives show a minus sign.
-result: [pending]
+result: pass
 
 ### 6. Dark Mode Rendering
 expected: Toggling dark mode keeps the table fully styled — dark header and subtotal backgrounds, readable text, visible gridlines, no white patches behind sticky cells.
-result: [pending]
+result: pass
 
 ## Summary
 
 total: 6
-passed: 0
+passed: 6
 issues: 0
-pending: 6
+pending: 0
 skipped: 0
 blocked: 0
 
 ## Gaps
 
-[none yet]
+[none]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1529,41 +1529,81 @@ function Dashboard({ coils, babyCoils, tubes, bundles, dispatches }) {
 const STAGE_NAMES = ['Inward', 'Slit', 'Tubes', 'Bundled', 'Dispatched']
 const STAGE_COLORS = ['#4f46e5', '#0891b2', '#059669', '#d97706', '#dc2626']
 
+// Excel-style summary: 14 locked columns (order is contractual — see .planning/phases/02-coil-tracker-summary)
+const SUMMARY_HEADERS = [
+  'Coil ID', 'Grade', 'Coil Wt (T)', '# Baby Coils', 'Baby Coil Wt (T)', '# Converted', 'Converted Wt (T)',
+  '# Tubes', 'Tubes Wt (T)', '# Dispatched', 'Dispatched Wt (T)', 'Balance to Roll (T)', 'Tube Inventory (T)', 'Tube Inventory (#)',
+]
+// Numeric columns 3-14 in header order: wt → 2-dp tonnes, count → thousands-separated integer
+const SUMMARY_COLS = [
+  { key: 'coilWt', fmt: 'wt' }, { key: 'babyCount', fmt: 'count' }, { key: 'babyWt', fmt: 'wt' },
+  { key: 'convertedCount', fmt: 'count' }, { key: 'convertedWt', fmt: 'wt' },
+  { key: 'tubePcs', fmt: 'count' }, { key: 'tubesWt', fmt: 'wt' },
+  { key: 'dispatchedPcs', fmt: 'count' }, { key: 'dispatchedWt', fmt: 'wt' },
+  { key: 'balanceToRoll', fmt: 'wt' }, { key: 'tubeInvWt', fmt: 'wt' }, { key: 'tubeInvPcs', fmt: 'count' },
+]
+const SUMMARY_TD = 'px-2 py-1 whitespace-nowrap border-b border-r border-slate-200 dark:border-slate-600'
+const SUBTOTAL_TD = 'sticky top-8 z-10 px-2 py-1 bg-slate-100 dark:bg-slate-800 text-xs font-semibold text-slate-700 dark:text-slate-200 whitespace-nowrap border-b-2 border-r border-slate-300 dark:border-slate-600'
+
 function CoilTracker({ coils, babyCoils, tubes, bundles, dispatches }) {
   const [selectedCoilId, setSelectedCoilId] = useState(null)
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
   const active = (arr) => arr.filter(x => !x.deleted)
   const ac = active(coils), ab = active(babyCoils), at = active(tubes), abn = active(bundles), ad = active(dispatches)
 
-  // ── Inventory summary for all coils ──
+  // Excel-style formatters: round BEFORE the zero-test so float dust and -0 render '-' while real negatives keep their sign
+  const fmt2 = (v) => { const r = Math.round(Number(v || 0) * 100) / 100; return r ? r.toFixed(2) : '-' }
+  const fmtCount = (v) => { const n = Math.round(Number(v || 0)); return n ? n.toLocaleString('en-US') : '-' }
+
+  // ── Period filter: coils by inward date (inclusive, open-ended bounds) ──
+  const filteredCoils = useMemo(() => {
+    return ac
+      .filter(c => {
+        if (dateFrom && c.dateOfInward < dateFrom) return false
+        if (dateTo && c.dateOfInward > dateTo) return false
+        return true
+      })
+      .sort((a, b) => (a.dateOfInward || '').localeCompare(b.dateOfInward || '') || (a.hrCoilId || '').localeCompare(b.hrCoilId || ''))
+  }, [ac, dateFrom, dateTo])
+
+  // ── Inventory summary for coils in the selected period (quantities are lifetime totals) ──
   const inventorySummary = useMemo(() => {
-    return ac.map(c => {
+    return filteredCoils.map(c => {
       const babies = ab.filter(b => b.hrCoilId === c.hrCoilId)
       const babyIds = babies.map(b => b.babyCoilId)
       const coilTubes = at.filter(t => babyIds.includes(t.babyCoilId))
-      const coilBundles = abn.filter(b => babyIds.includes(b.babyCoilId))
-      const totalTubePcs = coilTubes.reduce((s, t) => s + Number(t.numberOfPieces || 0), 0)
-      const bundledPcs = coilBundles.reduce((s, b) => s + Number(b.tubeCount || 0), 0)
-      const unbundledPcs = totalTubePcs - bundledPcs
-      // Count undispatched unique bundles linked to this coil
-      const bundleIds = [...new Set(coilBundles.map(b => b.bundleId))]
-      const undispatchedBundles = bundleIds.filter(bid => {
-        const rows = abn.filter(b => b.bundleId === bid)
-        return !rows.every(r => r.dispatched)
-      }).length
-      const dispatchedWt = ad.flatMap(d => (d.bundleEntries || []))
-        .filter(be => babyIds.includes(be.traceBabyCoilId))
-        .reduce((s, be) => s + Number(be.weight || 0), 0)
-      const yieldPct = c.actualWeight ? (dispatchedWt / c.actualWeight) * 100 : 0
+      const coilWt = Number(c.actualWeight || 0)
+      const babyWt = babies.reduce((s, b) => s + Number(b.weight || 0), 0)
+      const convertedBabies = babies.filter(b => coilTubes.some(t => t.babyCoilId === b.babyCoilId))
+      const convertedWt = convertedBabies.reduce((s, b) => s + Number(b.weight || 0), 0)
+      const tubePcs = coilTubes.reduce((s, t) => s + Number(t.numberOfPieces || 0), 0)
+      const tubesWt = coilTubes.reduce((s, t) => s + Number(t.theoreticalWeight || 0), 0)
+      const dispEntries = ad.flatMap(d => (d.bundleEntries || [])).filter(be => babyIds.includes(be.traceBabyCoilId))
+      const dispatchedPcs = dispEntries.reduce((s, be) => s + Number(be.pieces || 0), 0)
+      const dispatchedWt = dispEntries.reduce((s, be) => s + Number(be.weight || 0), 0)
 
       return {
-        hrCoilId: c.hrCoilId, grade: c.coilGrade, thickness: c.thickness, width: c.width,
-        actualWt: Number(c.actualWeight || 0), babyCount: babies.length,
-        slitWt: babies.reduce((s, b) => s + Number(b.weight || 0), 0),
-        totalTubePcs, unbundledPcs, undispatchedBundles,
-        dispatchedWt, yieldPct
+        hrCoilId: c.hrCoilId, grade: c.coilGrade,
+        coilWt, babyCount: babies.length, babyWt,
+        convertedCount: convertedBabies.length, convertedWt,
+        tubePcs, tubesWt, dispatchedPcs, dispatchedWt,
+        balanceToRoll: coilWt - babyWt,
+        tubeInvWt: tubesWt - dispatchedWt,
+        tubeInvPcs: tubePcs - dispatchedPcs,
       }
     })
-  }, [ac, ab, at, abn, ad])
+  }, [filteredCoils, ab, at, ad])
+
+  // ── Subtotals over the filtered set (rendered pinned at the top of the table) ──
+  const subtotals = useMemo(() => inventorySummary.reduce((s, r) => ({
+    coilCount: s.coilCount + 1,
+    coilWt: s.coilWt + r.coilWt, babyCount: s.babyCount + r.babyCount, babyWt: s.babyWt + r.babyWt,
+    convertedCount: s.convertedCount + r.convertedCount, convertedWt: s.convertedWt + r.convertedWt,
+    tubePcs: s.tubePcs + r.tubePcs, tubesWt: s.tubesWt + r.tubesWt,
+    dispatchedPcs: s.dispatchedPcs + r.dispatchedPcs, dispatchedWt: s.dispatchedWt + r.dispatchedWt,
+    balanceToRoll: s.balanceToRoll + r.balanceToRoll, tubeInvWt: s.tubeInvWt + r.tubeInvWt, tubeInvPcs: s.tubeInvPcs + r.tubeInvPcs,
+  }), { coilCount: 0, coilWt: 0, babyCount: 0, babyWt: 0, convertedCount: 0, convertedWt: 0, tubePcs: 0, tubesWt: 0, dispatchedPcs: 0, dispatchedWt: 0, balanceToRoll: 0, tubeInvWt: 0, tubeInvPcs: 0 }), [inventorySummary])
 
   // ── Selected coil journey ──
   const selectedCoil = ac.find(c => c.hrCoilId === selectedCoilId)
@@ -1633,33 +1673,60 @@ function CoilTracker({ coils, babyCoils, tubes, bundles, dispatches }) {
     ]
   }, [selectedCoil, journey])
 
-  // ── Inventory summary columns ──
-  const summaryColumns = [
-    { label: 'Mother Coil', key: 'hrCoilId' },
-    { label: 'Grade', key: 'grade' },
-    { label: 'Actual Wt (T)', key: 'actualWt', value: r => fmtT(r.actualWt) },
-    { label: 'Baby Coils', key: 'babyCount' },
-    { label: 'Slit Wt (T)', key: 'slitWt', value: r => fmtT(r.slitWt) },
-    { label: 'Tubes (pcs)', key: 'totalTubePcs' },
-    { label: 'Unbundled (pcs)', key: 'unbundledPcs' },
-    { label: 'Pending Bundles', key: 'undispatchedBundles' },
-    { label: 'Dispatched Wt (T)', key: 'dispatchedWt', value: r => fmtT(r.dispatchedWt) },
-    { label: 'Yield', key: 'yieldPct', render: r => <YieldBadge pct={r.yieldPct} /> },
-  ]
-
   return (
     <div className="space-y-6">
       <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Coil Tracker</h2>
 
-      {/* ── Section 1: Inventory Summary ── */}
-      <Section title="Inventory Summary — All Coils">
-        <div className="overflow-x-auto">
-          <DataTable
-            columns={summaryColumns}
-            data={inventorySummary}
-            onRowClick={(row) => setSelectedCoilId(row.hrCoilId)}
-            highlightRow={(row) => row.hrCoilId === selectedCoilId}
-          />
+      {/* ── Section 1: Inventory Summary (Excel-style, subtotals pinned at top) ── */}
+      <Section title="Inventory Summary — All Coils" actions={
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-slate-500">Period:</span>
+          <input type="date" value={dateFrom} onChange={e => setDateFrom(e.target.value)}
+            className="px-2 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100" />
+          <span className="text-sm text-slate-500">to</span>
+          <input type="date" value={dateTo} onChange={e => setDateTo(e.target.value)}
+            className="px-2 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100" />
+        </div>
+      }>
+        <div className="overflow-auto max-h-96 rounded-lg border border-slate-200 dark:border-slate-700">
+          <table className="min-w-full text-xs border-separate border-spacing-0">
+            <thead>
+              <tr>
+                {SUMMARY_HEADERS.map((h, i) => (
+                  <th key={h} className={`sticky top-0 z-20 h-8 px-2 py-1 bg-slate-50 dark:bg-slate-700 text-xs font-medium text-slate-500 dark:text-slate-300 uppercase tracking-wider whitespace-nowrap border-b border-r border-slate-200 dark:border-slate-600 ${i < 2 ? 'text-left' : 'text-right'}`}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {/* Subtotal row — pinned just below the header, recomputes with the period filter */}
+              <tr>
+                <td className={`${SUBTOTAL_TD} text-left`}>Total ({subtotals.coilCount})</td>
+                <td className={`${SUBTOTAL_TD} text-left`}>-</td>
+                {SUMMARY_COLS.map(col => (
+                  <td key={col.key} className={`${SUBTOTAL_TD} text-right tabular-nums`}>
+                    {col.fmt === 'wt' ? fmt2(subtotals[col.key]) : fmtCount(subtotals[col.key])}
+                  </td>
+                ))}
+              </tr>
+              {inventorySummary.length === 0 && (
+                <tr>
+                  <td colSpan={14} className="px-2 py-8 text-center text-slate-400 border-b border-slate-200 dark:border-slate-600">No coils in the selected period</td>
+                </tr>
+              )}
+              {inventorySummary.map(row => (
+                <tr key={row.hrCoilId} onClick={() => setSelectedCoilId(row.hrCoilId)}
+                  className={`cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-700/50 ${row.hrCoilId === selectedCoilId ? 'bg-indigo-50 dark:bg-indigo-900/20' : ''}`}>
+                  <td className={`${SUMMARY_TD} text-left font-medium text-slate-900 dark:text-white`}>{row.hrCoilId}</td>
+                  <td className={`${SUMMARY_TD} text-left text-slate-700 dark:text-slate-300`}>{row.grade || '-'}</td>
+                  {SUMMARY_COLS.map(col => (
+                    <td key={col.key} className={`${SUMMARY_TD} text-right tabular-nums text-slate-700 dark:text-slate-300`}>
+                      {col.fmt === 'wt' ? fmt2(row[col.key]) : fmtCount(row[col.key])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </Section>
 


### PR DESCRIPTION
## Summary

Rebuilds the Coil Tracker "Inventory Summary — All Coils" section as an Excel-style coil summary report (Phase 2 of the GSD roadmap).

- **14 locked columns** per mother coil: Coil ID, Grade, Coil Wt (T), # Baby Coils, Baby Coil Wt (T), # Converted, Converted Wt (T), # Tubes, Tubes Wt (T), # Dispatched, Dispatched Wt (T), Balance to Roll (T), Tube Inventory (T), Tube Inventory (#)
- **Derived formulas** (verified against the operations team's sample sheet): Balance to Roll = Coil Wt − Baby Coil Wt; Tube Inventory (T) = Tubes Wt − Dispatched Wt; Tube Inventory (#) = # Tubes − # Dispatched. Negatives are never clamped.
- **Subtotals pinned at the top** — a `Total (N)` row renders above all data rows and stays frozen (with the header) while the table body scrolls; recomputes with the filter.
- **Date period filter** — From/To inputs on coil inward date (inclusive, open-ended bounds); shown coils keep lifetime downstream totals so rows always reconcile.
- **Excel-standard presentation** — compact rows, gridlines on every cell, right-aligned numerics, 2-dp weights, thousands-separated counts (`1,011`), `-` for zero/blank, sticky header, dark-mode variants.
- Row-click → Coil Journey behavior preserved; Journey section unchanged. `src/App.jsx` is the only source file modified (single-file pattern preserved).

## Verification

- Production build passes.
- Headless-browser UAT (puppeteer against the live dev server with a stubbed Supabase REST backend mirroring the sample dataset): **21/21 checks passed**, including probes — inverted date range, open-ended single bound, clicking the Total row, dark-mode opacity of sticky cells, unslit/null-weight coil rows rendering `-`.
- Formatter spot-checks reproduce sample values exactly (`0.12`, `-17.89`, `147`, `1,011`).
- Full UAT record: `.planning/phases/02-coil-tracker-summary/02-UAT.md` (6/6 passed).

https://claude.ai/code/session_01YSTXvXTQ8xwWibpzviwcvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSTXvXTQ8xwWibpzviwcvB)_