### PR TITLE
Add customer order tracking & FG booking/free inventory metrics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import {
   weightPerPieceFromSku, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
   isOpenOrderStatus, skuBookingRows,
+  customerFulfilment, orderBacklog, skuDemandSupply,
 } from './lib/calc'
 import DEFAULT_SKUS from './data/skus'
 // Seed data imports kept for reference — all arrays are now empty
@@ -1951,6 +1952,87 @@ function Orders({ orders, setOrders }) {
 }
 
 // ═══════════════════════════════════════════════════════════════
+// FULFILMENT — orders ↔ dispatch reconciliation views (joined per order line)
+// ═══════════════════════════════════════════════════════════════
+function Fulfilment({ orders, dispatches, productions, skus }) {
+  const skuDesc = useCallback((code) => skus.find(s => s.skuCode === code)?.description || code, [skus])
+  const demand = useMemo(() => skuDemandSupply(productions, dispatches, orders, skus), [productions, dispatches, orders, skus])
+  const customers = useMemo(() => customerFulfilment(orders, dispatches), [orders, dispatches])
+  const backlog = useMemo(() => orderBacklog(orders, dispatches), [orders, dispatches])
+  const tot = (arr, k) => arr.reduce((s, r) => s + Number(r[k] || 0), 0)
+  const redIfNeg = (v) => <span className={Number(v) < 0 ? 'text-red-600 font-semibold' : ''}>{fmtT(v)}</span>
+
+  const demandCols = [
+    { label: 'SKU', value: r => r.skuCode },
+    { label: 'Description', key: 'description' },
+    { label: 'Ordered (T)', value: r => r.ordered, render: r => fmtT(r.ordered) },
+    { label: 'Produced (T)', value: r => r.produced, render: r => fmtT(r.produced) },
+    { label: 'Shipped (T)', value: r => r.shipped, render: r => fmtT(r.shipped) },
+    { label: 'Inventory (T)', value: r => r.inventory, render: r => fmtT(r.inventory) },
+    { label: 'Booked (T)', value: r => r.booked, render: r => fmtT(r.booked) },
+    { label: 'Free (T)', value: r => r.free, render: r => redIfNeg(r.free) },
+  ]
+  const custCols = [
+    { label: 'Customer', key: 'customer' },
+    { label: 'Ordered (T)', value: r => r.ordered, render: r => fmtT(r.ordered) },
+    { label: 'Shipped (T)', value: r => r.shipped, render: r => fmtT(r.shipped) },
+    { label: 'Outstanding (T)', value: r => r.outstanding, render: r => redIfNeg(r.outstanding) },
+    { label: 'Open Orders', key: 'openOrders' },
+  ]
+  const backlogCols = [
+    { label: 'Order ID', key: 'orderId' },
+    { label: 'Customer', key: 'customer' },
+    { label: 'SKU', value: r => skuDesc(r.skuCode) },
+    { label: 'Ordered (T)', value: r => r.ordered, render: r => fmtT(r.ordered) },
+    { label: 'Shipped (T)', value: r => r.shipped, render: r => fmtT(r.shipped) },
+    { label: 'Open (T)', value: r => r.open, render: r => fmtT(r.open) },
+    { label: 'Fulfilment', value: r => r.fulfilmentPct, render: r => `${r.fulfilmentPct.toFixed(0)}%` },
+    { label: 'Exp. Delivery', key: 'expectedDeliveryDate' },
+    { label: 'Status', key: 'orderStatus' },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Order Fulfilment</h2>
+      <p className="text-xs text-slate-400 -mt-3">
+        Reconciles the <strong>Orders</strong> upload (demand) against the <strong>Dispatch</strong> upload (invoiced shipments),
+        joined per order line (Sku ID). All weights in MT.
+      </p>
+
+      <Section title="SKU Demand vs Supply">
+        {demand.length ? (
+          <>
+            <p className="mb-3 text-xs text-slate-400">
+              Ordered {fmtT(tot(demand, 'ordered'))}T · Produced {fmtT(tot(demand, 'produced'))}T · Shipped {fmtT(tot(demand, 'shipped'))}T · Booked {fmtT(tot(demand, 'booked'))}T · Free {fmtT(tot(demand, 'free'))}T.
+              Inventory = produced − shipped; Booked = open orders (net of shipment); Free = inventory − booked (negative = over-committed).
+            </p>
+            <DataTable columns={demandCols} data={demand} highlightRow={r => r.free < 0} />
+          </>
+        ) : <p className="text-sm text-slate-400 py-8 text-center">No order / production / dispatch data yet</p>}
+      </Section>
+
+      <Section title="Customer-wise Outstanding">
+        {customers.length ? (
+          <>
+            <p className="mb-3 text-xs text-slate-400">Outstanding = ordered − shipped, per distributor. Ordered {fmtT(tot(customers, 'ordered'))}T · Shipped {fmtT(tot(customers, 'shipped'))}T.</p>
+            <DataTable columns={custCols} data={customers} />
+          </>
+        ) : <p className="text-sm text-slate-400 py-8 text-center">No order data yet</p>}
+      </Section>
+
+      <Section title={`Open Order Backlog (${backlog.length})`}>
+        {backlog.length ? (
+          <>
+            <p className="mb-3 text-xs text-slate-400">One row per still-open order line (open = ordered − shipped &gt; 0), oldest expected delivery first. Open total {fmtT(tot(backlog, 'open'))}T.</p>
+            <DataTable columns={backlogCols} data={backlog} />
+          </>
+        ) : <p className="text-sm text-slate-400 py-8 text-center">No open orders</p>}
+      </Section>
+    </div>
+  )
+}
+
+// ═══════════════════════════════════════════════════════════════
 // MAIN APP
 // ═══════════════════════════════════════════════════════════════
 const TABS = [
@@ -1963,6 +2045,7 @@ const TABS = [
   { key: 'skuMaster', label: 'SKU Master' },
   { key: 'poMaster', label: 'PO Master' },
   { key: 'orders', label: 'Orders' },
+  { key: 'fulfilment', label: 'Fulfilment' },
 ]
 
 const TABLE_LABELS = {
@@ -2101,6 +2184,7 @@ export default function App() {
         {tab === 'skuMaster' && <SKUMaster skus={skus} setSkus={setSkus} />}
         {tab === 'poMaster' && <POMaster purchaseOrders={purchaseOrders} setPurchaseOrders={setPurchaseOrders} />}
         {tab === 'orders' && <Orders orders={orders} setOrders={setOrders} />}
+        {tab === 'fulfilment' && <Fulfilment orders={orders} dispatches={dispatches} productions={productions} skus={skus} />}
       </main>
 
       {/* Footer */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -838,6 +838,10 @@ function mapDispatchRow(row) {
     diameter:       num(pick('diametermm', 'diameter')),
     vehicleNo:      String(pick('vehicleno', 'vehiclenumber', 'truckno', 'lorryno')).trim(),
     vehicleWeight:  num(pick('vehicleweight', 'grossweight', 'weighbridge', 'vehiclewt')),
+    // ERP order references — link a shipment back to its order line (orders ↔ dispatch).
+    orderLineId:    String(pick('skuid')).trim(),            // == orders "Sku ID" (exact per-line key)
+    orderId:        String(pick('orderid')).trim(),          // == orders "Order ID"
+    childOrderId:   String(pick('childorderid')).trim(),     // == orders "Child Order ID"
   }
 }
 
@@ -904,6 +908,7 @@ function Dispatch({ dispatches, setDispatches, coils, skus, setSkus, productions
           invoiceNo: r.invoiceNo, skuCode, pieces, weight,
           length: sku?.length || 6000, width: '', thickness: sku?.thickness ?? '',
           grade: r.grade || '', diameter: r.diameter || '', customer: r.customer || '',
+          orderLineId: r.orderLineId || '', orderId: r.orderId || '', childOrderId: r.childOrderId || '',
           coilAllocations: allocs, traceHrCoilId: allocs[0]?.hrCoilId || '',
         }
         builtEntries.push(entry); lineCount++
@@ -998,8 +1003,8 @@ function Dispatch({ dispatches, setDispatches, coils, skus, setSkus, productions
       <Section title="Upload dispatches from the ERP invoice Excel">
         <p className="text-sm text-slate-600 dark:text-slate-400">
           One row per invoice line. Recognised columns (case/spacing-insensitive):
-          <span className="font-mono text-xs"> Invoice date, Invoice number, MM ID, MM Description, Invoiced qty (MT), Distributor Name, Grade, Diameter mm</span>.
-          Rows group into one dispatch per invoice; already-imported invoices are skipped. SKUs match by MM ID — unknown catalog sizes are added automatically. Coil trace &amp; cost are inherited from Production FIFO.
+          <span className="font-mono text-xs"> Invoice date, Invoice number, MM ID, MM Description, Invoiced qty (MT), Distributor Name, Grade, Diameter mm, Sku ID / Order ID (order reconciliation)</span>.
+          Rows group into one dispatch per invoice; already-imported invoices are skipped. SKUs match by MM ID — unknown catalog sizes are added automatically. Order references (Sku ID / Order ID) are captured to reconcile shipments against orders; coil trace &amp; cost are inherited from Production FIFO.
         </p>
         {uploadMsg && (
           <div className={`mt-3 text-sm ${uploadMsg.kind === 'ok' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>{uploadMsg.text}</div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import {
   fmtT, genHRCoilId, tolerance,
   weightPerPieceFromSku, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
+  isOpenOrderStatus, skuBookingRows,
 } from './lib/calc'
 import DEFAULT_SKUS from './data/skus'
 // Seed data imports kept for reference — all arrays are now empty
@@ -1129,11 +1130,7 @@ const STAGE_BADGE = {
   Dispatch: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300',
 }
 
-// Booking/reservation is user-defined later; stub returns 0 per SKU for now.
-// TODO(user): replace with real booked-weight-per-SKU logic + data when provided.
-const reservedBySku = (skuCode) => 0
-
-function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyCoils }) {
+function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyCoils, orders }) {
   const active = (arr) => (arr || []).filter(x => !x.deleted)
   const ac = active(coils), ap = active(productions), ad = active(dispatches), apo = active(purchaseOrders)
   const skuDesc = useCallback((code) => skus.find(s => s.skuCode === code)?.description || code, [skus])
@@ -1169,21 +1166,10 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
     return { totalInward, fullDispatchedWt, fullDispatchedN, babyLeft, fullCoilLeft }
   }, [ac, ap, babyCoils, dispByCoil])
 
-  // ── SKU-wise inventory (all MT, no pieces) — inventory = produced − dispatched ──
-  const skuRows = useMemo(() => {
-    const pool = producedPool(ap, ad)
-    const rows = Object.entries(pool).filter(([code]) => code).map(([code, p]) => {
-      const inventory = p.availableWeight       // produced − dispatched (may be negative if over-dispatched)
-      const reserved = reservedBySku(code)      // booking logic supplied later (stub → 0)
-      const sku = skus.find(s => s.skuCode === code)
-      return { skuCode: code, description: sku?.description || code, inventory, reserved, free: inventory - reserved }
-    })
-    // Negative free inventory first (most-negative on top), then by SKU code.
-    rows.sort((a, b) => (a.free < 0) !== (b.free < 0)
-      ? (a.free < 0 ? -1 : 1)
-      : (a.free < 0 ? a.free - b.free : a.skuCode.localeCompare(b.skuCode)))
-    return rows
-  }, [ap, ad, skus])
+  // ── SKU-wise inventory + booking (all MT, no pieces). inventory = produced − dispatched;
+  // booked = max(0, open customer orders − dispatched); free = inventory − booked. Union of
+  // stocked SKUs and SKUs with open orders; negative-free rows sort first. ──
+  const skuRows = useMemo(() => skuBookingRows(ap, ad, orders, skus), [ap, ad, orders, skus])
 
   const skuTotals = useMemo(() => skuRows.reduce(
     (t, r) => ({ inventory: t.inventory + r.inventory, reserved: t.reserved + r.reserved, free: t.free + r.free }),
@@ -1289,7 +1275,7 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <Card title="Total FG Dispatched" value={`${fmtT(totalFgDispatched)} T`} sub="All dispatched weight" color="emerald" />
           <Card title="FG Left Inventory" value={`${fmtT(fgLeft)} T`} sub="Produced − dispatched" />
-          <Card title="FG Booked" value={`${fmtT(fgBooked)} T`} sub="Booking logic pending" color="cyan" />
+          <Card title="FG Booked" value={`${fmtT(fgBooked)} T`} sub="Open orders − dispatched" color="cyan" />
           <Card title="Free FG" value={`${fmtT(freeFg)} T`} sub="Inventory − booked" color="amber" />
         </div>
       </div>
@@ -1841,6 +1827,125 @@ function POMaster({ purchaseOrders, setPurchaseOrders }) {
 }
 
 // ═══════════════════════════════════════════════════════════════
+// CUSTOMER ORDERS (uploaded from ERP Orders Excel; drives FG Booked / Free FG)
+// ═══════════════════════════════════════════════════════════════
+function mapOrderRow(row) {
+  const norm = {}
+  for (const k of Object.keys(row)) norm[k.toLowerCase().replace(/[.\s_]+/g, '')] = row[k]
+  const pick = (...keys) => {
+    for (const k of keys) if (norm[k] !== undefined && norm[k] !== '') return norm[k]
+    return ''
+  }
+  const num = (v) => {
+    if (v === '' || v === null || v === undefined) return ''
+    const n = Number(String(v).replace(/[, ]/g, ''))
+    return isNaN(n) ? '' : n
+  }
+  return {
+    orderDate:            toISODate(pick('opportunitydate', 'orderdate', 'date')),
+    orderId:              String(pick('orderid')).trim(),
+    childOrderId:         String(pick('childorderid')).trim(),
+    lineId:               String(pick('skuid')).trim(),               // per-line id (reference)
+    customer:             String(pick('distributorname', 'customer', 'billtoname')).trim(),
+    mmId:                 String(pick('mmid', 'skucode', 'sku')).trim(), // == SKU master skuCode
+    description:          String(pick('mmdescription', 'description')).trim(),
+    quantity:             num(pick('quantity')),                       // ordered qty in MT
+    invoicedQty:          num(pick('invoicedqty')),                    // sheet reference only
+    orderStatus:          String(pick('orderstatus', 'status')).trim(),
+    expectedDeliveryDate: toISODate(pick('expecteddeliverydate')),
+  }
+}
+
+function Orders({ orders, setOrders }) {
+  const [uploadMsg, setUploadMsg] = useState(null)
+  const fileRef = useRef(null)
+
+  const onUpload = async (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    try {
+      const XLSX = await import('xlsx')
+      const buf = await file.arrayBuffer()
+      const wb = XLSX.read(buf, { type: 'array', cellDates: true })
+      const ws = wb.Sheets[wb.SheetNames[0]]
+      if (!ws) { setUploadMsg({ kind: 'err', text: 'Workbook has no sheets' }); return }
+      const rows = XLSX.utils.sheet_to_json(ws, { defval: '', raw: true })
+      const parsed = rows.map(mapOrderRow).filter(r => r.mmId)
+      if (!parsed.length) {
+        setUploadMsg({ kind: 'err', text: 'No valid order rows found (need an MM ID column)' })
+        return
+      }
+      // Replace-all: the uploaded sheet is the current snapshot of the order book.
+      const newRecords = parsed.map(r => ({ ...r, id: uid(), deleted: false }))
+      const openLines = newRecords.filter(r => isOpenOrderStatus(r.orderStatus))
+      const openMt = openLines.reduce((s, r) => s + Number(r.quantity || 0), 0)
+      setOrders(newRecords)
+      setUploadMsg({ kind: 'ok', text: `Imported ${newRecords.length} order line(s), replacing the previous set · ${openLines.length} open · ${fmtT(openMt)} MT booked (pre-dispatch)` })
+    } catch (err) {
+      console.error(err)
+      setUploadMsg({ kind: 'err', text: `Upload failed: ${err.message}` })
+    } finally {
+      if (fileRef.current) fileRef.current.value = ''
+    }
+  }
+
+  const statusBadge = (s) => {
+    const open = isOpenOrderStatus(s)
+    return <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium ${open ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300' : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'}`}>{s || '—'}</span>
+  }
+
+  const columns = [
+    { label: 'Order Date',    key: 'orderDate' },
+    { label: 'Order ID',      key: 'orderId' },
+    { label: 'Customer',      key: 'customer' },
+    { label: 'MM ID (SKU)',   key: 'mmId' },
+    { label: 'Description',   key: 'description' },
+    { label: 'Qty (MT)',      value: r => fmtT(r.quantity) },
+    { label: 'Invoiced (MT)', value: r => fmtT(r.invoicedQty) },
+    { label: 'Status',        render: r => statusBadge(r.orderStatus) },
+    { label: 'Exp. Delivery', key: 'expectedDeliveryDate' },
+  ]
+
+  const activeOrders = (orders || []).filter(o => !o.deleted)
+  const openCount = activeOrders.filter(o => isOpenOrderStatus(o.orderStatus)).length
+
+  const downloadOrdersCSV = () => {
+    downloadCSV(`orders-${today()}.csv`,
+      ['Order Date', 'Order ID', 'Child Order ID', 'Customer', 'MM ID', 'Description', 'Qty (MT)', 'Invoiced (MT)', 'Status', 'Expected Delivery'],
+      activeOrders.map(r => [r.orderDate, r.orderId, r.childOrderId, r.customer, r.mmId, r.description, r.quantity, r.invoicedQty, r.orderStatus, r.expectedDeliveryDate]))
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Orders</h2>
+        <div className="flex gap-2">
+          <input ref={fileRef} type="file" accept=".xlsx,.xls" onChange={onUpload} className="hidden" />
+          <Btn variant="ghost" onClick={downloadOrdersCSV} disabled={activeOrders.length === 0}>⬇ Download CSV</Btn>
+          <Btn onClick={() => fileRef.current?.click()}>Upload Orders Excel</Btn>
+        </div>
+      </div>
+
+      {uploadMsg && (
+        <div className={`px-3 py-2 rounded text-sm ${uploadMsg.kind === 'ok' ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300'}`}>
+          {uploadMsg.text}
+        </div>
+      )}
+
+      <p className="text-xs text-slate-400">
+        Uploading <strong>replaces the entire order book</strong> with the sheet's contents (current snapshot).
+        FG Booked = open-status orders (Confirmed / Delivery in progress) minus dispatched, per SKU.
+        {' '}{activeOrders.length} order line(s) · {openCount} open.
+      </p>
+
+      <Section title="Customer Orders">
+        <DataTable columns={columns} data={orders} />
+      </Section>
+    </div>
+  )
+}
+
+// ═══════════════════════════════════════════════════════════════
 // MAIN APP
 // ═══════════════════════════════════════════════════════════════
 const TABS = [
@@ -1852,6 +1957,7 @@ const TABS = [
   { key: 'dispatch', label: '4. Dispatch' },
   { key: 'skuMaster', label: 'SKU Master' },
   { key: 'poMaster', label: 'PO Master' },
+  { key: 'orders', label: 'Orders' },
 ]
 
 const TABLE_LABELS = {
@@ -1861,6 +1967,7 @@ const TABLE_LABELS = {
   dispatches: 'Dispatches',
   skus: 'SKU Master',
   purchase_orders: 'PO Master',
+  orders: 'Orders',
 }
 
 function SyncErrorBanner() {
@@ -1899,8 +2006,9 @@ export default function App() {
   const [dispatches, setDispatches, dispatchesLoading] = useSupabaseStore('jsw:dispatches', [])
   const [skus, setSkus, skusLoading] = useSupabaseStore('jsw:skus', DEFAULT_SKUS)
   const [purchaseOrders, setPurchaseOrders, poLoading] = useSupabaseStore('jsw:purchaseOrders', [])
+  const [orders, setOrders, ordersLoading] = useSupabaseStore('jsw:orders', [])
 
-  const loading = coilsLoading || babyCoilsLoading || productionsLoading || dispatchesLoading || skusLoading || poLoading
+  const loading = coilsLoading || babyCoilsLoading || productionsLoading || dispatchesLoading || skusLoading || poLoading || ordersLoading
 
   // Dark mode
   useEffect(() => {
@@ -1979,7 +2087,7 @@ export default function App() {
 
       {/* Content */}
       <main className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        {tab === 'dashboard' && <Dashboard coils={coils} productions={productions} dispatches={dispatches} skus={skus} purchaseOrders={purchaseOrders} babyCoils={babyCoils} />}
+        {tab === 'dashboard' && <Dashboard coils={coils} productions={productions} dispatches={dispatches} skus={skus} purchaseOrders={purchaseOrders} babyCoils={babyCoils} orders={orders} />}
         {tab === 'coilTracker' && <CoilTracker coils={coils} productions={productions} dispatches={dispatches} />}
         {tab === 'coilInward' && <CoilInward coils={coils} setCoils={setCoils} dispatches={dispatches} productions={productions} babyCoils={babyCoils} />}
         {tab === 'slitting' && <Slitting coils={coils} babyCoils={babyCoils} setBabyCoils={setBabyCoils} productions={productions} />}
@@ -1987,6 +2095,7 @@ export default function App() {
         {tab === 'dispatch' && <Dispatch dispatches={dispatches} setDispatches={setDispatches} coils={coils} skus={skus} setSkus={setSkus} productions={productions} />}
         {tab === 'skuMaster' && <SKUMaster skus={skus} setSkus={setSkus} />}
         {tab === 'poMaster' && <POMaster purchaseOrders={purchaseOrders} setPurchaseOrders={setPurchaseOrders} />}
+        {tab === 'orders' && <Orders orders={orders} setOrders={setOrders} />}
       </main>
 
       {/* Footer */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import {
-  BarChart, Bar, PieChart, Pie, Cell,
-  XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
+  BarChart, Bar, Cell,
+  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
 } from 'recharts'
 import { useSupabaseStore } from './lib/db'
 import {
-  fmtT, fmtPct, fmtINR, genHRCoilId, tolerance,
+  fmtT, genHRCoilId, tolerance,
   weightPerPieceFromSku, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
 } from './lib/calc'
@@ -66,12 +66,6 @@ const Badge = ({ ok, text }) => (
     {ok ? '✔' : '⚠'} {text}
   </span>
 )
-
-const YieldBadge = ({ pct }) => {
-  if (pct == null || isNaN(pct)) return <span className="text-slate-400">—</span>
-  const color = pct >= 95 ? 'bg-green-100 text-green-800' : pct >= 90 ? 'bg-yellow-100 text-yellow-800' : 'bg-red-100 text-red-800'
-  return <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium ${color}`}>{pct.toFixed(1)}%</span>
-}
 
 const Field = ({ label, children, auto, warn, helper }) => (
   <div>
@@ -262,8 +256,7 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils }) {
     const dispatchedWt = dispatches.filter(d => !d.deleted).flatMap(d => d.bundleEntries || [])
       .filter(be => be.traceHrCoilId === coil.hrCoilId)
       .reduce((s, be) => s + Number(be.weight || 0), 0)
-    const yieldPct = coil.actualWeight ? (dispatchedWt / coil.actualWeight) * 100 : 0
-    return { dispatchedWt, yieldPct }
+    return { dispatchedWt }
   }, [dispatches])
 
   const columns = [
@@ -276,15 +269,14 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils }) {
     { label: 'Invoice Wt (T)', value: r => fmtT(r.invoiceWeight) },
     { label: 'Actual Wt (T)', value: r => fmtT(r.actualWeight) },
     { label: 'Dispatched Wt (T)', render: r => { const s = getCoilStats(r); return s.dispatchedWt > 0 ? <span>{fmtT(s.dispatchedWt)}</span> : <span className="text-slate-400">—</span> } },
-    { label: 'Yield', render: r => { const s = getCoilStats(r); return s.dispatchedWt > 0 ? <YieldBadge pct={s.yieldPct} /> : <span className="text-slate-400">—</span> } },
     { label: 'Cost (₹)', value: r => r.costPrice ? `₹${Math.round(r.costPrice).toLocaleString()}` : '—' },
   ]
 
   const downloadCoilsCSV = () => {
-    const header = ['HR Coil ID', 'Date', 'Input Coil #', 'Grade', 'Thickness (mm)', 'Width (mm)', 'Invoice Wt (T)', 'Actual Wt (T)', 'Dispatched Wt (T)', 'Yield %', 'Cost (₹)']
+    const header = ['HR Coil ID', 'Date', 'Input Coil #', 'Grade', 'Thickness (mm)', 'Width (mm)', 'Invoice Wt (T)', 'Actual Wt (T)', 'Dispatched Wt (T)', 'Cost (₹)']
     downloadCSV(`coil-inward-${today()}.csv`, header, coils.filter(c => !c.deleted).map(r => {
       const s = getCoilStats(r)
-      return [r.hrCoilId, r.dateOfInward, r.inputCoilNumber, r.coilGrade, r.thickness, r.width, fmtT(r.invoiceWeight), fmtT(r.actualWeight), fmtT(s.dispatchedWt), s.dispatchedWt > 0 ? s.yieldPct.toFixed(1) : '', r.costPrice ? Math.round(r.costPrice) : '']
+      return [r.hrCoilId, r.dateOfInward, r.inputCoilNumber, r.coilGrade, r.thickness, r.width, fmtT(r.invoiceWeight), fmtT(r.actualWeight), fmtT(s.dispatchedWt), r.costPrice ? Math.round(r.costPrice) : '']
     }))
   }
 
@@ -1137,220 +1129,72 @@ const STAGE_BADGE = {
   Dispatch: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300',
 }
 
-const PERIOD_DAYS = { '7d': 7, '30d': 30, '90d': 90 }
+// Booking/reservation is user-defined later; stub returns 0 per SKU for now.
+// TODO(user): replace with real booked-weight-per-SKU logic + data when provided.
+const reservedBySku = (skuCode) => 0
 
-function Dashboard({ coils, productions, dispatches, skus, purchaseOrders }) {
+function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyCoils }) {
   const active = (arr) => (arr || []).filter(x => !x.deleted)
   const ac = active(coils), ap = active(productions), ad = active(dispatches), apo = active(purchaseOrders)
   const skuDesc = useCallback((code) => skus.find(s => s.skuCode === code)?.description || code, [skus])
   const todayStr = today()
 
-  // ── Period filter: presets + custom date range ──
-  const [period, setPeriod] = useState('30d')
-  const [customFrom, setCustomFrom] = useState('')
-  const [customTo, setCustomTo] = useState('')
-  const range = useMemo(() => {
-    if (period === 'all') return { from: '', to: '' }
-    if (period === 'custom') return { from: customFrom, to: customTo }
-    return { from: new Date(Date.now() - (PERIOD_DAYS[period] - 1) * 86400000).toISOString().split('T')[0], to: '' }
-  }, [period, customFrom, customTo])
-  const inRange = useCallback((d) => {
-    if (!range.from && !range.to) return true
-    if (!d) return false
-    if (range.from && d < range.from) return false
-    if (range.to && d > range.to) return false
-    return true
-  }, [range])
-  const periodLabel = period === 'all' ? 'All Time' : period === 'custom' ? 'Custom Range' : `Last ${PERIOD_DAYS[period]} Days`
-
-  // ── Production flow KPIs (period-scoped) ──
-  const coilsInPeriod = ac.filter(c => inRange(c.dateOfInward))
-  const coilsInWt = coilsInPeriod.reduce((s, c) => s + Number(c.actualWeight || 0), 0)
-  const prodInPeriod = ap.filter(p => inRange(p.dateOfProduction))
-  const producedPcsPeriod = prodInPeriod.reduce((s, p) => s + Number(p.tubeCount || 0), 0)
-  const producedWtPeriod = prodInPeriod.reduce((s, p) => s + Number(p.totalWeight || 0), 0)
-  const dispInPeriod = ad.filter(d => inRange(d.dateOfDispatch))
-  const dispWtPeriod = dispInPeriod.reduce((s, d) => s + (d.bundleEntries || []).reduce((x, e) => x + Number(e.weight || 0), 0), 0)
-  const dispLinesPeriod = dispInPeriod.reduce((s, d) => s + (d.bundleEntries || []).length, 0)
-  const productionsAllTime = ap.length
-
-  // Active SKUs in period + top by pieces (produced)
-  const skuPcsInPeriod = useMemo(() => {
-    const counts = {}
-    prodInPeriod.forEach(p => { counts[p.skuCode] = (counts[p.skuCode] || 0) + Number(p.tubeCount || 0) })
-    return counts
-  }, [prodInPeriod])
-  const activeSkuCount = Object.keys(skuPcsInPeriod).length
-  const topSkuPeriod = Object.entries(skuPcsInPeriod).sort((a, b) => b[1] - a[1])[0]?.[0]
-
-  // ── Stock in hand (point-in-time) with ₹ value via mother-coil cost rate ──
-  const stock = useMemo(() => {
-    const rateOf = {}
-    ac.forEach(c => { rateOf[c.hrCoilId] = Number(c.actualWeight) > 0 ? Number(c.costPrice || 0) / Number(c.actualWeight) : 0 })
-
-    // Raw coil stock = coil weight not yet consumed by Production (the new consumption point).
-    const consumed = coilConsumption(ap)
-    let rawWt = 0, rawVal = 0
-    ac.forEach(c => {
-      const used = Number(consumed[c.hrCoilId]?.weight || 0)
-      const rem = Math.max(0, Number(c.actualWeight || 0) - used)
-      rawWt += rem; rawVal += rem * (rateOf[c.hrCoilId] || 0)
-    })
-
-    // Ready to dispatch = produced − dispatched, attributed per mother coil.
-    const dispByCoil = {}
+  // ── Coil metrics (current snapshot, all MT) ──
+  // Dispatched weight per mother coil (entry coilAllocations; legacy traceHrCoilId fallback).
+  const dispByCoil = useMemo(() => {
+    const out = {}
     ad.flatMap(d => d.bundleEntries || []).forEach(be => {
       const allocs = (be.coilAllocations && be.coilAllocations.length) ? be.coilAllocations
-        : (be.traceHrCoilId ? [{ hrCoilId: be.traceHrCoilId, weight: be.weight, pieces: be.pieces }] : [])
-      allocs.forEach(a => {
-        const cur = dispByCoil[a.hrCoilId] || { weight: 0, pieces: 0 }
-        cur.weight += Number(a.weight || 0); cur.pieces += Number(a.pieces || 0)
-        dispByCoil[a.hrCoilId] = cur
-      })
+        : (be.traceHrCoilId ? [{ hrCoilId: be.traceHrCoilId, weight: be.weight }] : [])
+      allocs.forEach(a => { out[a.hrCoilId] = (out[a.hrCoilId] || 0) + Number(a.weight || 0) })
     })
-    let readyWt = 0, readyPcs = 0, readyVal = 0
+    return out
+  }, [ad])
+
+  const coil = useMemo(() => {
+    const activeBaby = (babyCoils || []).filter(b => !b.deleted)
+    const consumedBaby = coilConsumption(ap, null, 'babyCoilId') // baby-coil weight consumed by production
+    const slitMothers = new Set(activeBaby.map(b => b.hrCoilId))
+    let totalInward = 0, fullDispatchedWt = 0, fullDispatchedN = 0, fullCoilLeft = 0
     ac.forEach(c => {
-      const prod = consumed[c.hrCoilId] || { weight: 0, pieces: 0 }
-      const disp = dispByCoil[c.hrCoilId] || { weight: 0, pieces: 0 }
-      const remWt = Math.max(0, Number(prod.weight) - Number(disp.weight))
-      readyWt += remWt
-      readyPcs += Math.max(0, Number(prod.pieces) - Number(disp.pieces))
-      readyVal += remWt * (rateOf[c.hrCoilId] || 0)
+      const aw = Number(c.actualWeight || 0)
+      totalInward += aw
+      // ≥95% dispatched → treat the whole coil as dispatched.
+      if (aw > 0 && (dispByCoil[c.hrCoilId] || 0) / aw >= 0.95) { fullDispatchedWt += aw; fullDispatchedN++ }
+      // Full coil left = whole, unslit mother coils only (no baby coils yet).
+      if (!slitMothers.has(c.hrCoilId)) fullCoilLeft += aw
     })
+    const babyLeft = activeBaby.reduce((s, b) =>
+      s + Math.max(0, Number(b.weight || 0) - Number(consumedBaby[b.babyCoilId]?.weight || 0)), 0)
+    return { totalInward, fullDispatchedWt, fullDispatchedN, babyLeft, fullCoilLeft }
+  }, [ac, ap, babyCoils, dispByCoil])
 
-    return {
-      rawWt, rawVal,
-      readyWt, readyPcs, readyVal,
-      totalVal: rawVal + readyVal,
-    }
-  }, [ac, ap, ad])
-
-  // ── PO summary ──
-  const poStats = useMemo(() => {
-    const in7 = new Date(Date.now() + 7 * 86400000).toISOString().split('T')[0]
-    const open = apo.filter(p => !p.poEndDate || p.poEndDate >= todayStr)
-    const expiring = open.filter(p => p.poEndDate && p.poEndDate <= in7)
-    return { open: open.length, expiring: expiring.length }
-  }, [apo, todayStr])
-
-  // Coil stage breakdown (furthest stage each coil has reached)
-  const coilStages = useMemo(() => {
-    const idsOf = (rec, fallback) => (rec.coilAllocations && rec.coilAllocations.length)
-      ? rec.coilAllocations.map(a => a.hrCoilId) : (fallback ? [fallback] : [])
-    const producedIds = new Set(ap.flatMap(p => (p.coilAllocations || []).map(a => a.hrCoilId)).filter(Boolean))
-    const dispatchedIds = new Set(ad.flatMap(d => (d.bundleEntries || []).flatMap(be => idsOf(be, be.traceHrCoilId))).filter(Boolean))
-
-    return [
-      { name: 'In Stock', value: ac.filter(c => !producedIds.has(c.hrCoilId)).length },
-      { name: 'Produced', value: ac.filter(c => producedIds.has(c.hrCoilId) && !dispatchedIds.has(c.hrCoilId)).length },
-      { name: 'Dispatched', value: ac.filter(c => dispatchedIds.has(c.hrCoilId)).length },
-    ]
-  }, [ac, ap, ad])
-
-  // ── Production vs dispatch trend (daily ≤31 days, else weekly) ──
-  const trend = useMemo(() => {
-    const toStr = range.to || todayStr
-    let fromStr = range.from
-    if (!fromStr) {
-      const dates = [...ap.map(p => p.dateOfProduction), ...ad.map(d => d.dateOfDispatch)].filter(Boolean)
-      fromStr = dates.length ? dates.reduce((a, b) => (a < b ? a : b)) : toStr
-    }
-    if (fromStr > toStr) return { data: [], weekly: false }
-    const from = new Date(fromStr), to = new Date(toStr)
-    const spanDays = Math.max(1, Math.round((to - from) / 86400000) + 1)
-    const weekly = spanDays > 31
-    const bucketKey = (dStr) => {
-      if (!weekly) return dStr
-      const d = new Date(dStr)
-      const day = d.getDay()
-      d.setDate(d.getDate() - (day === 0 ? 6 : day - 1)) // Monday of that week
-      return d.toISOString().split('T')[0]
-    }
-    const buckets = {}
-    for (let ms = from.getTime(); ms <= to.getTime(); ms += 86400000 * (weekly ? 7 : 1)) {
-      buckets[bucketKey(new Date(ms).toISOString().split('T')[0])] = { produced: 0, dispatched: 0 }
-    }
-    ap.forEach(p => {
-      if (!inRange(p.dateOfProduction)) return
-      const b = buckets[bucketKey(p.dateOfProduction)]
-      if (b) b.produced += Number(p.totalWeight || 0)
+  // ── SKU-wise inventory (all MT, no pieces) — inventory = produced − dispatched ──
+  const skuRows = useMemo(() => {
+    const pool = producedPool(ap, ad)
+    const rows = Object.entries(pool).filter(([code]) => code).map(([code, p]) => {
+      const inventory = p.availableWeight       // produced − dispatched (may be negative if over-dispatched)
+      const reserved = reservedBySku(code)      // booking logic supplied later (stub → 0)
+      const sku = skus.find(s => s.skuCode === code)
+      return { skuCode: code, description: sku?.description || code, inventory, reserved, free: inventory - reserved }
     })
-    ad.forEach(d => {
-      if (!inRange(d.dateOfDispatch)) return
-      const b = buckets[bucketKey(d.dateOfDispatch)]
-      if (b) b.dispatched += (d.bundleEntries || []).reduce((s, e) => s + Number(e.weight || 0), 0)
-    })
-    let keys = Object.keys(buckets).sort()
-    if (keys.length > 31) keys = keys.slice(-31)
-    return {
-      weekly,
-      data: keys.map(k => ({
-        name: (weekly ? 'Wk ' : '') + k.slice(5),
-        produced: +buckets[k].produced.toFixed(3),
-        dispatched: +buckets[k].dispatched.toFixed(3),
-      })),
-    }
-  }, [ap, ad, range, todayStr, inRange])
+    // Negative free inventory first (most-negative on top), then by SKU code.
+    rows.sort((a, b) => (a.free < 0) !== (b.free < 0)
+      ? (a.free < 0 ? -1 : 1)
+      : (a.free < 0 ? a.free - b.free : a.skuCode.localeCompare(b.skuCode)))
+    return rows
+  }, [ap, ad, skus])
 
-  // Yield per coil
-  const yieldData = useMemo(() => {
-    return ac.map(c => {
-      const dispWt = ad.flatMap(d => (d.bundleEntries || []))
-        .filter(be => be.traceHrCoilId === c.hrCoilId)
-        .reduce((s, be) => s + Number(be.weight || 0), 0)
-      return { name: c.hrCoilId, yield: c.actualWeight ? (dispWt / c.actualWeight) * 100 : 0, actualWt: c.actualWeight, dispWt }
-    }).filter(d => d.dispWt > 0)
-  }, [ac, ad])
+  const skuTotals = useMemo(() => skuRows.reduce(
+    (t, r) => ({ inventory: t.inventory + r.inventory, reserved: t.reserved + r.reserved, free: t.free + r.free }),
+    { inventory: 0, reserved: 0, free: 0 }
+  ), [skuRows])
 
-  const avgYield = yieldData.length ? yieldData.reduce((s, d) => s + d.yield, 0) / yieldData.length : 0
-
-  // Top SKUs
-  const topSkus = useMemo(() => {
-    const counts = {}
-    ap.forEach(p => { counts[p.skuCode] = (counts[p.skuCode] || 0) + Number(p.tubeCount || 0) })
-    return Object.entries(counts).map(([name, value]) => ({ name, value })).sort((a, b) => b.value - a.value).slice(0, 5)
-  }, [ap])
-
-  // ── SKU-wise summary (produced/dispatched follow the period; WIP/ready are current) ──
-  const skuSummary = useMemo(() => {
-    const map = {}
-    const get = (code) => (map[code] = map[code] || {
-      skuCode: code, producedPcs: 0, producedWt: 0, readyPcs: 0, readyWt: 0, dispPcs: 0, dispWt: 0,
-      _allProdPcs: 0, _allProdWt: 0, _allDispPcs: 0, _allDispWt: 0,
-    })
-    ap.forEach(p => {
-      const r = get(p.skuCode)
-      r._allProdPcs += Number(p.tubeCount || 0); r._allProdWt += Number(p.totalWeight || 0)
-      if (inRange(p.dateOfProduction)) { r.producedPcs += Number(p.tubeCount || 0); r.producedWt += Number(p.totalWeight || 0) }
-    })
-    ad.forEach(d => (d.bundleEntries || []).forEach(e => {
-      const r = get(e.skuCode)
-      r._allDispPcs += Number(e.pieces || 0); r._allDispWt += Number(e.weight || 0)
-      if (inRange(d.dateOfDispatch)) { r.dispPcs += Number(e.pieces || 0); r.dispWt += Number(e.weight || 0) }
-    }))
-    return Object.values(map).filter(r => r.skuCode).map(r => {
-      const sku = skus.find(s => s.skuCode === r.skuCode)
-      return {
-        ...r, id: r.skuCode,
-        readyPcs: Math.max(0, r._allProdPcs - r._allDispPcs),
-        readyWt: Math.max(0, r._allProdWt - r._allDispWt),
-        description: sku?.description || r.skuCode,
-        type: sku?.productType || '—',
-      }
-    })
-  }, [ap, ad, skus, inRange])
-
-  const skuColumns = [
-    { label: 'SKU Code', key: 'skuCode' },
-    { label: 'Description', key: 'description' },
-    { label: 'Type', key: 'type' },
-    { label: 'Produced (pcs)', key: 'producedPcs' },
-    { label: 'Produced (T)', value: r => fmtT(r.producedWt) },
-    { label: 'Ready (pcs)', key: 'readyPcs' },
-    { label: 'Ready (T)', value: r => fmtT(r.readyWt) },
-    { label: 'Dispatched (pcs)', key: 'dispPcs' },
-    { label: 'Dispatched (T)', value: r => fmtT(r.dispWt) },
-  ]
+  // ── FG metrics (all MT) — totals reconcile with the SKU table ──
+  const totalFgDispatched = ad.flatMap(d => d.bundleEntries || []).reduce((s, e) => s + Number(e.weight || 0), 0)
+  const fgLeft = skuTotals.inventory
+  const fgBooked = skuTotals.reserved
+  const freeFg = skuTotals.free
 
   // ── Alerts ──
   const alerts = useMemo(() => {
@@ -1395,9 +1239,6 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders }) {
     return ev.filter(e => e.date).sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0)).slice(0, 10)
   }, [ac, ap, ad, skuDesc])
 
-  const totalInvoiceWt = ac.reduce((s, c) => s + Number(c.invoiceWeight || 0), 0)
-  const totalActualWt = ac.reduce((s, c) => s + Number(c.actualWeight || 0), 0)
-
   // ── CSV exports ──
   const downloadStockCSV = () => {
     const rows = ac.map(c => {
@@ -1409,147 +1250,86 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders }) {
       const stockVal = (rawRem + readyWt) * rate
       return [
         c.hrCoilId, c.coilGrade || '', c.thickness ?? '', c.width ?? '', fmtT(c.actualWeight),
-        fmtT(rawRem), fmtT(readyWt), fmtT(dispWt),
-        (c.actualWeight ? ((dispWt / Number(c.actualWeight)) * 100).toFixed(1) : '0.0') + '%', stockVal.toFixed(2),
+        fmtT(rawRem), fmtT(readyWt), fmtT(dispWt), stockVal.toFixed(2),
       ]
     })
     downloadCSV(`stock-report-${todayStr}.csv`,
-      ['Mother Coil', 'Grade', 'Thickness (mm)', 'Width (mm)', 'Actual Wt (T)', 'Raw Remaining (T)', 'Ready Wt (T)', 'Dispatched Wt (T)', 'Yield %', 'Stock Value (INR)'],
+      ['Mother Coil', 'Grade', 'Thickness (mm)', 'Width (mm)', 'Actual Wt (T)', 'Raw Remaining (T)', 'Ready Wt (T)', 'Dispatched Wt (T)', 'Stock Value (INR)'],
       rows)
   }
 
   const downloadSkuCSV = () => {
     downloadCSV(`sku-report-${todayStr}.csv`,
-      ['SKU Code', 'Description', 'Type', 'Produced (pcs)', 'Produced (T)', 'Ready (pcs)', 'Ready (T)', 'Dispatched (pcs)', 'Dispatched (T)'],
-      skuSummary.map(r => [r.skuCode, r.description, r.type, r.producedPcs, fmtT(r.producedWt), r.readyPcs, fmtT(r.readyWt), r.dispPcs, fmtT(r.dispWt)]))
+      ['SKU Code', 'Description', 'Inventory (T)', 'Inventory Reserved (T)', 'Free Inventory (T)'],
+      skuRows.map(r => [r.skuCode, r.description, fmtT(r.inventory), fmtT(r.reserved), fmtT(r.free)]))
   }
-
-  const dateInputCls = 'px-2 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100'
 
   return (
     <div className="space-y-6">
-      {/* Header: title + period selector + export */}
+      {/* Header: title + stock export */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Dashboard</h2>
-        <div className="flex flex-wrap items-center gap-2">
-          <select value={period} onChange={e => setPeriod(e.target.value)}
-            className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100">
-            <option value="7d">Last 7 Days</option>
-            <option value="30d">Last 30 Days</option>
-            <option value="90d">Last 90 Days</option>
-            <option value="all">All Time</option>
-            <option value="custom">Custom Range</option>
-          </select>
-          {period === 'custom' && <>
-            <input type="date" value={customFrom} onChange={e => setCustomFrom(e.target.value)} className={dateInputCls} />
-            <span className="text-sm text-slate-500">to</span>
-            <input type="date" value={customTo} onChange={e => setCustomTo(e.target.value)} className={dateInputCls} />
-          </>}
-          <Btn size="sm" variant="ghost" onClick={downloadStockCSV}>⬇ Stock CSV</Btn>
-        </div>
+        <Btn size="sm" variant="ghost" onClick={downloadStockCSV}>⬇ Stock CSV</Btn>
       </div>
 
-      {/* Production Flow KPIs */}
+      {/* Coil metrics (MT) */}
       <div>
-        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Production Flow — {periodLabel}</p>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Coil</p>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <Card title="Coils Inward" value={coilsInPeriod.length} sub={`${fmtT(coilsInWt)}T actual · ${ac.length} total (Inv: ${fmtT(totalInvoiceWt)}T / Act: ${fmtT(totalActualWt)}T)`} />
-          <Card title="Pieces Produced" value={producedPcsPeriod} sub={`${fmtT(producedWtPeriod)}T`} color="cyan" />
-          <Card title="Dispatched" value={`${fmtT(dispWtPeriod)}T`} sub={`${dispInPeriod.length} dispatch(es) · ${dispLinesPeriod} line(s)`} color="emerald" />
-          <Card title="Avg. Yield (All Time)" value={fmtPct(avgYield)} sub={`${yieldData.length} coils with dispatches`} color="amber" />
+          <Card title="Total Coil Inward" value={`${fmtT(coil.totalInward)} T`} sub="All mother coil received" />
+          <Card title="Full Coil Dispatched" value={`${fmtT(coil.fullDispatchedWt)} T`} sub={`${coil.fullDispatchedN} coil(s) ≥95% dispatched`} color="emerald" />
+          <Card title="Baby Coils Left" value={`${fmtT(coil.babyLeft)} T`} sub="Slit, not yet produced" color="cyan" />
+          <Card title="Full Coil Left" value={`${fmtT(coil.fullCoilLeft)} T`} sub="Whole, unslit coils" color="amber" />
         </div>
       </div>
 
-      {/* Stock in Hand KPIs */}
+      {/* Finished Goods metrics (MT) */}
       <div>
-        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Stock in Hand — Current</p>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Card title="Raw Coil Stock" value={`${fmtT(stock.rawWt)}T`} sub={`${fmtINR(stock.rawVal)} · unproduced coil weight`} />
-          <Card title="Ready to Dispatch" value={`${fmtT(stock.readyWt)}T`} sub={`${stock.readyPcs} pcs · ${fmtINR(stock.readyVal)} · produced − dispatched`} color="amber" />
-        </div>
-      </div>
-
-      {/* Commercial KPIs */}
-      <div>
-        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Commercial</p>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Finished Goods (FG)</p>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <Card title="Total Stock Value" value={fmtINR(stock.totalVal)} sub="Raw + Ready" />
-          <Card title="Open POs" value={poStats.open} sub={`${poStats.expiring} ending ≤7 days`} color="cyan" />
-          <Card title="Production Batches" value={productionsAllTime} sub="All-time production records" color="emerald" />
-          <Card title="Active SKUs" value={activeSkuCount} sub={topSkuPeriod ? `Top: ${skuDesc(topSkuPeriod)}` : '—'} color="amber" />
+          <Card title="Total FG Dispatched" value={`${fmtT(totalFgDispatched)} T`} sub="All dispatched weight" color="emerald" />
+          <Card title="FG Left Inventory" value={`${fmtT(fgLeft)} T`} sub="Produced − dispatched" />
+          <Card title="FG Booked" value={`${fmtT(fgBooked)} T`} sub="Booking logic pending" color="cyan" />
+          <Card title="Free FG" value={`${fmtT(freeFg)} T`} sub="Inventory − booked" color="amber" />
         </div>
       </div>
 
-      {/* Pipeline */}
-      <Section title="Coil Pipeline">
-        <div className="flex items-center gap-1 overflow-x-auto pb-2">
-          {coilStages.map((s, i) => (
-            <React.Fragment key={s.name}>
-              <div className="flex-1 min-w-[120px] text-center p-4 rounded-lg" style={{ backgroundColor: `${CHART_COLORS[i]}15`, borderLeft: `4px solid ${CHART_COLORS[i]}` }}>
-                <p className="text-2xl font-bold" style={{ color: CHART_COLORS[i] }}>{s.value}</p>
-                <p className="text-xs text-slate-500 mt-1">{s.name}</p>
-              </div>
-              {i < coilStages.length - 1 && <span className="text-slate-300 text-xl">→</span>}
-            </React.Fragment>
-          ))}
-        </div>
-      </Section>
-
-      {/* Production & Dispatch Trend */}
-      <Section title={`Production & Dispatch Trend — ${periodLabel}${trend.weekly ? ' (weekly)' : ''}`}>
-        {trend.data.some(d => d.produced > 0 || d.dispatched > 0) ? (
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={trend.data}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" tick={{ fontSize: 11 }} />
-              <YAxis tick={{ fontSize: 11 }} />
-              <Tooltip formatter={(v) => `${fmtT(v)}T`} />
-              <Legend />
-              <Bar dataKey="produced" name="Produced (T)" fill="#4f46e5" radius={[4, 4, 0, 0]} />
-              <Bar dataKey="dispatched" name="Dispatched (T)" fill="#059669" radius={[4, 4, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
-        ) : <p className="text-sm text-slate-400 py-8 text-center">No production or dispatch activity in this period</p>}
-      </Section>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {/* Yield Chart */}
-        <Section title="Yield by Coil">
-          {yieldData.length > 0 ? (
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={yieldData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="name" tick={{ fontSize: 11 }} />
-                <YAxis domain={[0, 100]} tick={{ fontSize: 11 }} />
-                <Tooltip formatter={(v) => `${Number(v).toFixed(1)}%`} />
-                <Bar dataKey="yield" fill="#4f46e5" radius={[4, 4, 0, 0]} />
-              </BarChart>
-            </ResponsiveContainer>
-          ) : <p className="text-sm text-slate-400 py-8 text-center">No dispatch data yet</p>}
-        </Section>
-
-        {/* Top SKUs */}
-        <Section title="Top SKUs by Volume (All Time)">
-          {topSkus.length > 0 ? (
-            <ResponsiveContainer width="100%" height={300}>
-              <PieChart>
-                <Pie data={topSkus} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={100} label={({ name, value }) => `${name}: ${value}`}>
-                  {topSkus.map((_, i) => <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />)}
-                </Pie>
-                <Tooltip />
-              </PieChart>
-            </ResponsiveContainer>
-          ) : <p className="text-sm text-slate-400 py-8 text-center">No production data yet</p>}
-        </Section>
-      </div>
-
-      {/* SKU-wise Summary */}
-      <Section title={`SKU-wise Summary — ${periodLabel}`} actions={<Btn size="sm" variant="ghost" onClick={downloadSkuCSV}>⬇ SKU CSV</Btn>}>
-        {skuSummary.length > 0 ? (
-          <>
-            <p className="mb-3 text-xs text-slate-400">Produced & Dispatched columns follow the selected period; Ready is current stock (produced − dispatched).</p>
-            <DataTable columns={skuColumns} data={skuSummary} />
-          </>
+      {/* SKU-wise Inventory (MT) — totals on top; negative free inventory surfaced + highlighted */}
+      <Section title="SKU-wise Inventory" actions={<Btn size="sm" variant="ghost" onClick={downloadSkuCSV}>⬇ SKU CSV</Btn>}>
+        {skuRows.length > 0 ? (
+          <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="bg-slate-50 dark:bg-slate-700">
+                  {['SKU Code', 'Description', 'Inventory (T)', 'Inventory Reserved (T)', 'Free Inventory (T)'].map((h, i) => (
+                    <th key={i} className={`sticky top-0 px-4 py-3 text-xs font-medium text-slate-500 dark:text-slate-300 uppercase tracking-wider whitespace-nowrap ${i >= 2 ? 'text-right' : 'text-left'}`}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+                {/* Totals row pinned at the top */}
+                <tr className="bg-slate-100 dark:bg-slate-700/50 font-semibold text-slate-900 dark:text-slate-100">
+                  <td className="px-4 py-3 whitespace-nowrap">TOTAL</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-slate-400">{skuRows.length} SKU(s)</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-right">{fmtT(skuTotals.inventory)}</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-right">{fmtT(skuTotals.reserved)}</td>
+                  <td className={`px-4 py-3 whitespace-nowrap text-right ${skuTotals.free < 0 ? 'text-red-600' : ''}`}>{fmtT(skuTotals.free)}</td>
+                </tr>
+                {skuRows.map((r) => {
+                  const neg = r.free < 0
+                  return (
+                    <tr key={r.skuCode} className={`hover:bg-slate-50 dark:hover:bg-slate-700/50 ${neg ? 'bg-red-50 dark:bg-red-900/30' : ''}`}>
+                      <td className="px-4 py-3 whitespace-nowrap text-slate-700 dark:text-slate-300">{r.skuCode}</td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{r.description}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-right text-slate-700 dark:text-slate-300">{fmtT(r.inventory)}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-right text-slate-700 dark:text-slate-300">{fmtT(r.reserved)}</td>
+                      <td className={`px-4 py-3 whitespace-nowrap text-right ${neg ? 'text-red-600 font-semibold' : 'text-slate-700 dark:text-slate-300'}`}>{fmtT(r.free)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
         ) : <p className="text-sm text-slate-400 py-8 text-center">No SKU activity yet</p>}
       </Section>
 
@@ -1754,11 +1534,10 @@ function CoilTracker({ coils, productions, dispatches }) {
             <Btn size="sm" variant="ghost" onClick={() => setSelectedCoilId(null)}>Clear Selection</Btn>
           </div>
 
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
             <Card title="Coil ID" value={selectedCoilId} sub={`Grade: ${selectedCoil.coilGrade || '—'}`} />
             <Card title="Dimensions" value={`${selectedCoil.thickness || '—'} × ${selectedCoil.width || '—'} mm`} sub={`PO: ${selectedCoil.poNumber || '—'}`} color="cyan" />
             <Card title="Actual Weight" value={`${fmtT(selectedCoil.actualWeight)} T`} sub={`Invoice: ${fmtT(selectedCoil.invoiceWeight)} T`} color="emerald" />
-            <Card title="Yield" value={fmtPct(selectedCoil.actualWeight ? (journey.totalDispatchWt / selectedCoil.actualWeight) * 100 : 0)} sub={`Dispatched: ${fmtT(journey.totalDispatchWt)} T`} color="amber" />
           </div>
 
           {/* 2b: Stage Progress Bar */}
@@ -2200,7 +1979,7 @@ export default function App() {
 
       {/* Content */}
       <main className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        {tab === 'dashboard' && <Dashboard coils={coils} productions={productions} dispatches={dispatches} skus={skus} purchaseOrders={purchaseOrders} />}
+        {tab === 'dashboard' && <Dashboard coils={coils} productions={productions} dispatches={dispatches} skus={skus} purchaseOrders={purchaseOrders} babyCoils={babyCoils} />}
         {tab === 'coilTracker' && <CoilTracker coils={coils} productions={productions} dispatches={dispatches} />}
         {tab === 'coilInward' && <CoilInward coils={coils} setCoils={setCoils} dispatches={dispatches} productions={productions} babyCoils={babyCoils} />}
         {tab === 'slitting' && <Slitting coils={coils} babyCoils={babyCoils} setBabyCoils={setBabyCoils} productions={productions} />}

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -165,6 +165,58 @@ export function producedPool(productions, dispatches, excludeDispatchId = null) 
   return out
 }
 
+// ── Customer-order booking (FG Booked / Free FG). An order line is "open" (still committed
+// against inventory) when its Order Status is not a terminal one. Delivered/Cancelled/Rejected
+// (and blank) are excluded — delivered demand is already reflected in dispatched FG. ──
+export const isOpenOrderStatus = (status) => {
+  const s = String(status || '').trim().toLowerCase()
+  return s !== '' && !['delivered', 'cancelled', 'canceled', 'rejected'].includes(s)
+}
+
+// ── Open ordered quantity (MT) per SKU, keyed by mmId (== SKU master skuCode). Sums the
+// Quantity of non-deleted, open-status order lines. ──
+export function openOrderQtyBySku(orders) {
+  const out = {}
+  ;(orders || []).filter(o => !o.deleted && isOpenOrderStatus(o.orderStatus)).forEach(o => {
+    const code = String(o.mmId || '').trim()
+    if (!code) return
+    out[code] = (out[code] || 0) + Number(o.quantity || 0)
+  })
+  return out
+}
+
+// ── SKU-wise inventory / booked / free rows for the dashboard. Union of SKUs with
+// production/dispatch activity AND SKUs with open orders. All weights in MT:
+//   inventory = produced − dispatched           (producedPool.availableWeight)
+//   booked    = max(0, openOrdered − dispatched) (open customer orders net of app dispatch)
+//   free      = inventory − booked               (negative ⇒ over-committed, surfaced in red)
+// Rows are sorted negative-free first (most-negative on top), then by SKU code. ──
+export function skuBookingRows(productions, dispatches, orders, skus) {
+  const pool = producedPool(productions, dispatches)
+  const openQty = openOrderQtyBySku(orders)
+  const descByCode = {}
+  ;(orders || []).filter(o => !o.deleted).forEach(o => {
+    const c = String(o.mmId || '').trim()
+    if (c && !descByCode[c]) descByCode[c] = o.description || ''
+  })
+  const codes = new Set([...Object.keys(pool), ...Object.keys(openQty)])
+  const rows = [...codes].filter(Boolean).map(code => {
+    const inventory = pool[code]?.availableWeight || 0
+    const dispatched = pool[code]?.dispatchedWeight || 0
+    const booked = Math.max(0, (openQty[code] || 0) - dispatched)
+    const sku = (skus || []).find(s => s.skuCode === code)
+    return {
+      skuCode: code,
+      description: sku?.description || descByCode[code] || code,
+      inventory, reserved: booked, free: inventory - booked,
+    }
+  })
+  rows.sort((a, b) => (a.free < 0) !== (b.free < 0)
+    ? (a.free < 0 ? -1 : 1)
+    : (a.free < 0 ? a.free - b.free : a.skuCode.localeCompare(b.skuCode)))
+  return rows
+}
+
 // ── Inherit a dispatch entry's coil attribution from production FIFO. Maps `pieces` of an
 // SKU onto that SKU's production coilAllocations (oldest production first), skipping pieces
 // already taken by other (non-deleted) dispatches of the SKU. Carries BOTH babyCoilId and

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -185,25 +185,44 @@ export function openOrderQtyBySku(orders) {
   return out
 }
 
+// ── Shipped (invoiced) weight per order line, from dispatch entries' orderLineId
+// (== orders `lineId`, the ERP "Sku ID"). Lets us net an order line by exactly the
+// shipments made against it, rather than aggregating dispatch per SKU. ──
+export function shippedByOrderLine(dispatches) {
+  const out = {}
+  ;(dispatches || []).filter(d => !d.deleted).flatMap(d => d.bundleEntries || []).forEach(be => {
+    const lid = String(be.orderLineId || '').trim()
+    if (lid) out[lid] = (out[lid] || 0) + Number(be.weight || 0)
+  })
+  return out
+}
+
 // ── SKU-wise inventory / booked / free rows for the dashboard. Union of SKUs with
 // production/dispatch activity AND SKUs with open orders. All weights in MT:
-//   inventory = produced − dispatched           (producedPool.availableWeight)
-//   booked    = max(0, openOrdered − dispatched) (open customer orders net of app dispatch)
-//   free      = inventory − booked               (negative ⇒ over-committed, surfaced in red)
+//   inventory = produced − dispatched                       (producedPool.availableWeight)
+//   booked    = Σ over open order lines of max(0, ordered − shipped-for-that-line)
+//               (open = Order Status not Delivered/Cancelled/Rejected; shipped is matched
+//                per order line via orderLineId, so already-delivered demand doesn't subtract
+//                from a *different* SKU's still-open orders)
+//   free      = inventory − booked                          (negative ⇒ over-committed, red)
 // Rows are sorted negative-free first (most-negative on top), then by SKU code. ──
 export function skuBookingRows(productions, dispatches, orders, skus) {
   const pool = producedPool(productions, dispatches)
-  const openQty = openOrderQtyBySku(orders)
+  const shipped = shippedByOrderLine(dispatches)
+  const bookedBySku = {}
   const descByCode = {}
   ;(orders || []).filter(o => !o.deleted).forEach(o => {
-    const c = String(o.mmId || '').trim()
-    if (c && !descByCode[c]) descByCode[c] = o.description || ''
+    const code = String(o.mmId || '').trim()
+    if (!code) return
+    if (!descByCode[code]) descByCode[code] = o.description || ''
+    if (!isOpenOrderStatus(o.orderStatus)) return
+    const lineShipped = shipped[String(o.lineId || '').trim()] || 0
+    bookedBySku[code] = (bookedBySku[code] || 0) + Math.max(0, Number(o.quantity || 0) - lineShipped)
   })
-  const codes = new Set([...Object.keys(pool), ...Object.keys(openQty)])
+  const codes = new Set([...Object.keys(pool), ...Object.keys(bookedBySku)])
   const rows = [...codes].filter(Boolean).map(code => {
     const inventory = pool[code]?.availableWeight || 0
-    const dispatched = pool[code]?.dispatchedWeight || 0
-    const booked = Math.max(0, (openQty[code] || 0) - dispatched)
+    const booked = bookedBySku[code] || 0
     const sku = (skus || []).find(s => s.skuCode === code)
     return {
       skuCode: code,

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -236,6 +236,75 @@ export function skuBookingRows(productions, dispatches, orders, skus) {
   return rows
 }
 
+// ── Per-customer fulfilment (orders ↔ dispatch joined by Distributor Name). All MT:
+// ordered = Σ ordered (all order lines), shipped = Σ dispatched, outstanding = ordered − shipped.
+// Sorted by outstanding desc. ──
+export function customerFulfilment(orders, dispatches) {
+  const out = {}
+  const ensure = (c) => (out[c] = out[c] || { customer: c, ordered: 0, shipped: 0, openOrders: 0 })
+  ;(orders || []).filter(o => !o.deleted).forEach(o => {
+    const e = ensure(String(o.customer || '').trim() || '—')
+    e.ordered += Number(o.quantity || 0)
+    if (isOpenOrderStatus(o.orderStatus)) e.openOrders += 1
+  })
+  ;(dispatches || []).filter(d => !d.deleted).flatMap(d => d.bundleEntries || []).forEach(be => {
+    ensure(String(be.customer || '').trim() || '—').shipped += Number(be.weight || 0)
+  })
+  return Object.values(out)
+    .map(e => ({ ...e, outstanding: e.ordered - e.shipped }))
+    .sort((a, b) => b.outstanding - a.outstanding)
+}
+
+// ── Open order backlog — one row per still-open order line, netted by its own per-line
+// shipped (orderLineId). Only lines with open > 0 are returned, oldest expected-delivery first. ──
+export function orderBacklog(orders, dispatches) {
+  const shipped = shippedByOrderLine(dispatches)
+  return (orders || [])
+    .filter(o => !o.deleted && isOpenOrderStatus(o.orderStatus))
+    .map(o => {
+      const ordered = Number(o.quantity || 0)
+      const ship = shipped[String(o.lineId || '').trim()] || 0
+      const open = Math.max(0, ordered - ship)
+      return {
+        orderId: o.orderId || o.childOrderId || '', customer: o.customer || '',
+        skuCode: o.mmId || '', description: o.description || o.mmId || '',
+        ordered, shipped: ship, open,
+        fulfilmentPct: ordered > 0 ? (ship / ordered) * 100 : 0,
+        orderStatus: o.orderStatus || '', expectedDeliveryDate: o.expectedDeliveryDate || '',
+      }
+    })
+    .filter(r => r.open > 0)
+    .sort((a, b) => String(a.expectedDeliveryDate).localeCompare(String(b.expectedDeliveryDate)))
+}
+
+// ── Per-SKU demand vs supply: ordered (all order lines) · produced · shipped · inventory
+// (produced − shipped) · booked (open, per-line) · free. Union of SKUs seen in any pipeline.
+// Sorted negative-free first, then by SKU code. ──
+export function skuDemandSupply(productions, dispatches, orders, skus) {
+  const booking = skuBookingRows(productions, dispatches, orders, skus) // inventory, reserved(=booked), free, description
+  const byCode = Object.fromEntries(booking.map(r => [r.skuCode, r]))
+  const sumBy = (rows, keyFn, valFn) => {
+    const m = {}
+    ;(rows || []).forEach(r => { const k = keyFn(r); if (k) m[k] = (m[k] || 0) + valFn(r) })
+    return m
+  }
+  const ordered = sumBy((orders || []).filter(o => !o.deleted), o => String(o.mmId || '').trim(), o => Number(o.quantity || 0))
+  const produced = sumBy((productions || []).filter(p => !p.deleted), p => String(p.skuCode || '').trim(), p => Number(p.totalWeight || 0))
+  const shipped = sumBy((dispatches || []).filter(d => !d.deleted).flatMap(d => d.bundleEntries || []), e => String(e.skuCode || '').trim(), e => Number(e.weight || 0))
+  const codes = new Set([...booking.map(r => r.skuCode), ...Object.keys(ordered)])
+  return [...codes].filter(Boolean).map(code => {
+    const b = byCode[code] || { inventory: 0, reserved: 0, free: 0, description: null }
+    const sku = (skus || []).find(s => s.skuCode === code)
+    return {
+      skuCode: code, description: b.description || sku?.description || code,
+      ordered: ordered[code] || 0, produced: produced[code] || 0, shipped: shipped[code] || 0,
+      inventory: b.inventory, booked: b.reserved, free: b.free,
+    }
+  }).sort((a, b) => (a.free < 0) !== (b.free < 0)
+    ? (a.free < 0 ? -1 : 1)
+    : (a.free < 0 ? a.free - b.free : a.skuCode.localeCompare(b.skuCode)))
+}
+
 // ── Inherit a dispatch entry's coil attribution from production FIFO. Maps `pieces` of an
 // SKU onto that SKU's production coilAllocations (oldest production first), skipping pieces
 // already taken by other (non-deleted) dispatches of the SKU. Carries BOTH babyCoilId and

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -3,6 +3,7 @@ import {
   fmtT, fmtPct, fmtINR, genHRCoilId, tolerance,
   weightPerPieceFromSku, bundleWeightCap, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
+  isOpenOrderStatus, openOrderQtyBySku, skuBookingRows,
 } from './calc'
 
 describe('format helpers', () => {
@@ -363,5 +364,69 @@ describe('coilInventoryRow', () => {
     expect(r.balanceToProduce).toBeCloseTo(4)  // 10 − 6
     expect(r.producedInvWt).toBeCloseTo(3.6)   // 6 − 2.4
     expect(r.producedInvPcs).toBe(90)          // 150 − 60
+  })
+})
+
+describe('isOpenOrderStatus', () => {
+  it('treats Confirmed / Delivery in progress as open', () => {
+    expect(isOpenOrderStatus('Confirmed')).toBe(true)
+    expect(isOpenOrderStatus('Delivery in progress')).toBe(true)
+  })
+  it('treats Delivered / Cancelled / Rejected / blank as closed', () => {
+    expect(isOpenOrderStatus('Delivered')).toBe(false)
+    expect(isOpenOrderStatus('CANCELLED')).toBe(false)
+    expect(isOpenOrderStatus('Rejected')).toBe(false)
+    expect(isOpenOrderStatus('')).toBe(false)
+    expect(isOpenOrderStatus(null)).toBe(false)
+  })
+})
+
+describe('openOrderQtyBySku', () => {
+  it('sums Quantity of open, non-deleted lines per mmId', () => {
+    const orders = [
+      { mmId: 'A', quantity: 6, orderStatus: 'Confirmed' },
+      { mmId: 'A', quantity: 4, orderStatus: 'Delivery in progress' },
+      { mmId: 'A', quantity: 9, orderStatus: 'Delivered' },        // closed → ignored
+      { mmId: 'B', quantity: 3, orderStatus: 'Confirmed' },
+      { mmId: 'B', quantity: 5, orderStatus: 'Confirmed', deleted: true }, // deleted → ignored
+    ]
+    expect(openOrderQtyBySku(orders)).toEqual({ A: 10, B: 3 })
+  })
+})
+
+describe('skuBookingRows', () => {
+  const skus = [{ skuCode: 'A', description: 'SKU A' }]
+  // A: produced 5 MT, dispatched 1.5 → inventory 3.5
+  const productions = [{ deleted: false, skuCode: 'A', tubeCount: 100, totalWeight: 5 }]
+  const dispatches = [{ deleted: false, bundleEntries: [{ skuCode: 'A', pieces: 30, weight: 1.5 }] }]
+
+  it('booked = max(0, openOrdered − dispatched); free = inventory − booked', () => {
+    const orders = [{ mmId: 'A', quantity: 4, orderStatus: 'Confirmed' }] // open 4 − dispatched 1.5 = 2.5 booked
+    const [a] = skuBookingRows(productions, dispatches, orders, skus)
+    expect(a.skuCode).toBe('A')
+    expect(a.description).toBe('SKU A')
+    expect(a.inventory).toBeCloseTo(3.5)
+    expect(a.reserved).toBeCloseTo(2.5)
+    expect(a.free).toBeCloseTo(1.0)
+  })
+
+  it('floors booked at 0 when dispatched ≥ open orders', () => {
+    const orders = [{ mmId: 'A', quantity: 1, orderStatus: 'Confirmed' }] // 1 − 1.5 → max(0,−0.5)=0
+    const [a] = skuBookingRows(productions, dispatches, orders, skus)
+    expect(a.reserved).toBe(0)
+    expect(a.free).toBeCloseTo(3.5) // = inventory
+  })
+
+  it('includes ordered-but-unstocked SKUs and sorts negative free first', () => {
+    const orders = [
+      { mmId: 'A', quantity: 1, orderStatus: 'Confirmed' },                  // stocked, free positive
+      { mmId: 'Z', quantity: 8, orderStatus: 'Confirmed', description: 'SKU Z' }, // never produced → free −8
+    ]
+    const rows = skuBookingRows(productions, dispatches, orders, skus)
+    expect(rows[0].skuCode).toBe('Z')          // most-negative free on top
+    expect(rows[0].inventory).toBe(0)
+    expect(rows[0].reserved).toBe(8)
+    expect(rows[0].free).toBe(-8)
+    expect(rows[0].description).toBe('SKU Z')   // falls back to order description
   })
 })

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -3,7 +3,7 @@ import {
   fmtT, fmtPct, fmtINR, genHRCoilId, tolerance,
   weightPerPieceFromSku, bundleWeightCap, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
-  isOpenOrderStatus, openOrderQtyBySku, skuBookingRows,
+  isOpenOrderStatus, openOrderQtyBySku, shippedByOrderLine, skuBookingRows,
 } from './calc'
 
 describe('format helpers', () => {
@@ -394,35 +394,50 @@ describe('openOrderQtyBySku', () => {
   })
 })
 
+describe('shippedByOrderLine', () => {
+  it('sums dispatch entry weight by orderLineId; ignores entries without one and deleted dispatches', () => {
+    const dispatches = [
+      { deleted: false, bundleEntries: [{ orderLineId: 'L1', weight: 1.5 }, { orderLineId: 'L1', weight: 0.5 }] },
+      { deleted: false, bundleEntries: [{ skuCode: 'A', weight: 9 }] },        // no orderLineId → ignored
+      { deleted: true, bundleEntries: [{ orderLineId: 'L1', weight: 99 }] },   // deleted → ignored
+    ]
+    expect(shippedByOrderLine(dispatches)).toEqual({ L1: 2 })
+  })
+})
+
 describe('skuBookingRows', () => {
   const skus = [{ skuCode: 'A', description: 'SKU A' }]
-  // A: produced 5 MT, dispatched 1.5 → inventory 3.5
+  // A: produced 5 MT
   const productions = [{ deleted: false, skuCode: 'A', tubeCount: 100, totalWeight: 5 }]
-  const dispatches = [{ deleted: false, bundleEntries: [{ skuCode: 'A', pieces: 30, weight: 1.5 }] }]
 
-  it('booked = max(0, openOrdered − dispatched); free = inventory − booked', () => {
-    const orders = [{ mmId: 'A', quantity: 4, orderStatus: 'Confirmed' }] // open 4 − dispatched 1.5 = 2.5 booked
+  it('nets each open order line by its own shipped (orderLineId); free = inventory − booked', () => {
+    const dispatches = [{ deleted: false, bundleEntries: [{ skuCode: 'A', orderLineId: 'L1', weight: 1.5 }] }]
+    const orders = [{ mmId: 'A', lineId: 'L1', quantity: 4, orderStatus: 'Confirmed' }] // 4 − 1.5 shipped = 2.5
     const [a] = skuBookingRows(productions, dispatches, orders, skus)
-    expect(a.skuCode).toBe('A')
-    expect(a.description).toBe('SKU A')
-    expect(a.inventory).toBeCloseTo(3.5)
+    expect(a.inventory).toBeCloseTo(3.5)   // produced 5 − dispatched 1.5
     expect(a.reserved).toBeCloseTo(2.5)
     expect(a.free).toBeCloseTo(1.0)
   })
 
-  it('floors booked at 0 when dispatched ≥ open orders', () => {
-    const orders = [{ mmId: 'A', quantity: 1, orderStatus: 'Confirmed' }] // 1 − 1.5 → max(0,−0.5)=0
+  it('does NOT subtract a delivered shipment from a different open line of the same SKU', () => {
+    // Delivered line L1 (shipped 5) + still-open line L2 (ordered 4, unshipped).
+    const dispatches = [{ deleted: false, bundleEntries: [{ skuCode: 'A', orderLineId: 'L1', weight: 5 }] }]
+    const orders = [
+      { mmId: 'A', lineId: 'L1', quantity: 5, orderStatus: 'Delivered' },  // closed → excluded
+      { mmId: 'A', lineId: 'L2', quantity: 4, orderStatus: 'Confirmed' },  // open, unshipped → booked 4
+    ]
     const [a] = skuBookingRows(productions, dispatches, orders, skus)
-    expect(a.reserved).toBe(0)
-    expect(a.free).toBeCloseTo(3.5) // = inventory
+    expect(a.inventory).toBeCloseTo(0)    // produced 5 − dispatched 5
+    expect(a.reserved).toBeCloseTo(4)     // NOT reduced by L1's delivered 5
+    expect(a.free).toBeCloseTo(-4)
   })
 
   it('includes ordered-but-unstocked SKUs and sorts negative free first', () => {
     const orders = [
-      { mmId: 'A', quantity: 1, orderStatus: 'Confirmed' },                  // stocked, free positive
-      { mmId: 'Z', quantity: 8, orderStatus: 'Confirmed', description: 'SKU Z' }, // never produced → free −8
+      { mmId: 'A', lineId: 'La', quantity: 1, orderStatus: 'Confirmed' },                      // stocked, free positive
+      { mmId: 'Z', lineId: 'Lz', quantity: 8, orderStatus: 'Confirmed', description: 'SKU Z' }, // never produced → free −8
     ]
-    const rows = skuBookingRows(productions, dispatches, orders, skus)
+    const rows = skuBookingRows(productions, [], orders, skus)
     expect(rows[0].skuCode).toBe('Z')          // most-negative free on top
     expect(rows[0].inventory).toBe(0)
     expect(rows[0].reserved).toBe(8)

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -4,6 +4,7 @@ import {
   weightPerPieceFromSku, bundleWeightCap, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
   isOpenOrderStatus, openOrderQtyBySku, shippedByOrderLine, skuBookingRows,
+  customerFulfilment, orderBacklog, skuDemandSupply,
 } from './calc'
 
 describe('format helpers', () => {
@@ -443,5 +444,64 @@ describe('skuBookingRows', () => {
     expect(rows[0].reserved).toBe(8)
     expect(rows[0].free).toBe(-8)
     expect(rows[0].description).toBe('SKU Z')   // falls back to order description
+  })
+})
+
+describe('customerFulfilment', () => {
+  it('rolls up ordered vs shipped per customer; outstanding = ordered − shipped', () => {
+    const orders = [
+      { customer: 'Acme', mmId: 'A', quantity: 10, orderStatus: 'Confirmed' },
+      { customer: 'Acme', mmId: 'B', quantity: 5, orderStatus: 'Delivered' },
+      { customer: 'Bolt', mmId: 'A', quantity: 4, orderStatus: 'Confirmed' },
+    ]
+    const dispatches = [{ deleted: false, bundleEntries: [
+      { customer: 'Acme', skuCode: 'B', weight: 5 },   // Acme shipped 5
+    ] }]
+    const rows = customerFulfilment(orders, dispatches)
+    expect(rows[0].customer).toBe('Acme')              // highest outstanding first
+    expect(rows[0].ordered).toBe(15)
+    expect(rows[0].shipped).toBe(5)
+    expect(rows[0].outstanding).toBe(10)
+    expect(rows[0].openOrders).toBe(1)
+    const bolt = rows.find(r => r.customer === 'Bolt')
+    expect(bolt.outstanding).toBe(4)
+  })
+})
+
+describe('orderBacklog', () => {
+  it('returns open lines only, netted per line, oldest expected-delivery first', () => {
+    const orders = [
+      { orderId: 'O1', customer: 'Acme', mmId: 'A', lineId: 'L1', quantity: 10, orderStatus: 'Confirmed', expectedDeliveryDate: '2026-06-30' },
+      { orderId: 'O2', customer: 'Bolt', mmId: 'B', lineId: 'L2', quantity: 6, orderStatus: 'Confirmed', expectedDeliveryDate: '2026-06-10' },
+      { orderId: 'O3', customer: 'Acme', mmId: 'C', lineId: 'L3', quantity: 3, orderStatus: 'Delivered', expectedDeliveryDate: '2026-06-01' }, // closed → excluded
+      { orderId: 'O4', customer: 'Bolt', mmId: 'D', lineId: 'L4', quantity: 2, orderStatus: 'Confirmed', expectedDeliveryDate: '2026-06-20' }, // fully shipped → open 0 → excluded
+    ]
+    const dispatches = [{ deleted: false, bundleEntries: [
+      { orderLineId: 'L1', weight: 4 },   // L1 partially shipped
+      { orderLineId: 'L4', weight: 2 },   // L4 fully shipped
+    ] }]
+    const rows = orderBacklog(orders, dispatches)
+    expect(rows.map(r => r.orderId)).toEqual(['O2', 'O1']) // L4/L3 excluded; sorted by exp delivery
+    expect(rows[1].open).toBe(6)          // L1: 10 − 4
+    expect(rows[1].fulfilmentPct).toBeCloseTo(40)
+  })
+})
+
+describe('skuDemandSupply', () => {
+  it('combines ordered / produced / shipped / inventory / booked / free per SKU', () => {
+    const skus = [{ skuCode: 'A', description: 'SKU A' }]
+    const productions = [{ deleted: false, skuCode: 'A', tubeCount: 100, totalWeight: 12 }]
+    const dispatches = [{ deleted: false, bundleEntries: [{ skuCode: 'A', orderLineId: 'L1', weight: 5 }] }]
+    const orders = [
+      { mmId: 'A', lineId: 'L1', quantity: 5, orderStatus: 'Delivered' },   // shipped via L1
+      { mmId: 'A', lineId: 'L2', quantity: 4, orderStatus: 'Confirmed' },   // open
+    ]
+    const [a] = skuDemandSupply(productions, dispatches, orders, skus)
+    expect(a.ordered).toBe(9)             // 5 + 4
+    expect(a.produced).toBe(12)
+    expect(a.shipped).toBe(5)
+    expect(a.inventory).toBeCloseTo(7)    // 12 − 5
+    expect(a.booked).toBeCloseTo(4)       // open L2 (L1 delivered, excluded)
+    expect(a.free).toBeCloseTo(3)         // 7 − 4
   })
 })

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -39,6 +39,7 @@ const TABLE_MAP = {
   'jsw:dispatches': 'dispatches',
   'jsw:skus': 'skus',
   'jsw:purchaseOrders': 'purchase_orders',
+  'jsw:orders': 'orders',
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -128,6 +128,29 @@ create table if not exists purchase_orders (
   created_at timestamptz default now()
 );
 
+-- Customer Orders (uploaded from the ERP "Orders" Excel; drives FG Booked / Free FG).
+-- Quantity is in MT; mm_id == SKU master sku_code (join key shared with the dispatch upload).
+-- Booked = open-status ordered − dispatched (per SKU); invoiced_qty is kept for reference only.
+create table if not exists orders (
+  id uuid primary key default gen_random_uuid(),
+  order_date date,
+  order_id text,
+  child_order_id text,
+  line_id text,
+  customer text,
+  mm_id text,
+  description text,
+  quantity numeric,
+  invoiced_qty numeric,
+  order_status text,
+  expected_delivery_date date,
+  deleted boolean default false,
+  created_at timestamptz default now()
+);
+alter table orders enable row level security;
+drop policy if exists "Allow all access" on orders;
+create policy "Allow all access" on orders for all using (true) with check (true);
+
 -- SKU Master
 create table if not exists skus (
   id text primary key,


### PR DESCRIPTION
## Summary
Introduces customer order management and finished goods (FG) inventory booking logic to track committed vs. free inventory. Replaces yield-focused dashboard with demand-supply reconciliation, enabling visibility into over-committed SKUs and per-customer fulfilment status.

## Key Changes

### Data Model & Storage
- **New `orders` table** (Supabase): Captures customer orders with order/line IDs, SKU (mmId), quantity (MT), status, and expected delivery date
- **Order references in dispatch**: Dispatch entries now capture `orderLineId`, `orderId`, `childOrderId` to link shipments back to their source orders
- **Updated `mapDispatchRow`**: Extracts order references from Excel upload columns (case-insensitive: `skuid`, `orderid`, `childorderid`)

### Order & Booking Logic (`src/lib/calc.js`)
New helper functions for demand-supply reconciliation:
- **`isOpenOrderStatus(status)`**: Classifies orders as open (Confirmed, Delivery in progress) vs. closed (Delivered, Cancelled, Rejected, blank)
- **`openOrderQtyBySku(orders)`**: Aggregates open order quantity per SKU (mmId)
- **`shippedByOrderLine(dispatches)`**: Tracks shipped weight per order line (via `orderLineId`), enabling per-line netting
- **`skuBookingRows(productions, dispatches, orders, skus)`**: Core booking logic
  - **Inventory** = produced − dispatched (per SKU)
  - **Reserved (booked)** = Σ open order lines, each netted by its own shipped weight (not aggregated per SKU)
  - **Free** = inventory − booked (negative = over-committed, highlighted in red)
  - Rows sorted negative-free first (most-critical on top), then by SKU code
- **`customerFulfilment(orders, dispatches)`**: Per-customer rollup (ordered, shipped, outstanding, open order count)
- **`orderBacklog(orders, dispatches)`**: Open order lines only, netted per line, sorted by expected delivery date
- **`skuDemandSupply(productions, dispatches, orders, skus)`**: Comprehensive per-SKU demand vs. supply view (ordered, produced, shipped, inventory, booked, free)

### Dashboard Refactor
**Removed:**
- Period filter (7d/30d/90d/custom) and trend charts
- Yield badge component and yield-by-coil chart
- Production flow KPIs (coils inward, pieces produced, avg yield)
- Stock-in-hand KPIs (raw coil stock, ready to dispatch, stock value)
- Commercial KPIs (total stock value, open POs, production batches, active SKUs)
- Top SKUs pie chart
- SKU-wise summary table (produced/dispatched/ready columns)

**Added:**
- **Coil metrics** (current snapshot, all MT):
  - Total coil inward
  - Full coil dispatched (≥95% threshold)
  - Baby coils left (slit, not yet produced)
  - Full coil left (whole, unslit)
- **Finished Goods (FG) metrics**:
  - Total FG dispatched
  - FG left inventory (produced − dispatched)
  - FG booked (open orders − dispatched per line)
  - Free FG (inventory − booked; negative = over-committed)
- **SKU-wise inventory table** (MT only, no pieces):
  - Totals row pinned at top
  - Rows sorted negative-free first (red highlight for over-committed)
  - Columns: SKU Code, Description, Inventory (T), Inventory Reserved (T), Free Inventory (T)

### Dispatch Upload
- Updated help text to mention order reconciliation columns (Sku ID / Order ID)
- Dispatch entries now carry `orderLineId`, `orderId`, `childOrderId` fields
- Order references are optional; existing dispatches without them continue to work

### CSV Exports
- **Stock CSV**: Removed "Yield %" column
- **SKU CSV

https://claude.ai/code/session_01LzLJy1WhGUXHNgmV8TrHcJ