### PR TITLE
Dashboard: orders/invoiced SKU table, trend chart, 1-decimal weights, time-period filter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,10 +5,10 @@ import {
 } from 'recharts'
 import { useSupabaseStore } from './lib/db'
 import {
-  fmtT, genHRCoilId, tolerance,
+  fmtT, genHRCoilId, tolerance, periodRange, inDateRange,
   weightPerPieceFromSku, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
-  isOpenOrderStatus, skuBookingRows, skuInventoryRows,
+  isOpenOrderStatus, skuInventoryRows,
   customerFulfilment, orderBacklog, skuDemandSupply,
 } from './lib/calc'
 import DEFAULT_SKUS from './data/skus'
@@ -1142,6 +1142,43 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
   const skuDesc = useCallback((code) => skus.find(s => s.skuCode === code)?.description || code, [skus])
   const todayStr = today()
 
+  // ── Period filter (scopes ACTIVITY + trend; on-hand stock stays current). ──
+  const [period, setPeriod] = useState('all')
+  const [monthSel, setMonthSel] = useState(todayStr.slice(0, 7))
+  const [customFrom, setCustomFrom] = useState('')
+  const [customTo, setCustomTo] = useState('')
+  const range = useMemo(() => periodRange(period, { today: todayStr, monthSel, customFrom, customTo }),
+    [period, todayStr, monthSel, customFrom, customTo])
+  const inRange = useCallback((d) => inDateRange(d, range), [range])
+  const monthLabel = (key) => new Date(key + '-01T00:00:00Z').toLocaleString('en-US', { month: 'long', year: 'numeric' })
+  const periodLabel = period === 'all' ? 'All Time' : period === '7d' ? 'Last 7 Days'
+    : period === 'mtd' ? 'Month to Date' : period === 'custom' ? 'Custom Range' : monthLabel(monthSel)
+  // Calendar months that actually have data (earliest activity → current month), newest first.
+  const monthOptions = useMemo(() => {
+    const dates = [
+      ...ac.map(c => c.dateOfInward), ...ap.map(p => p.dateOfProduction),
+      ...ad.map(d => d.dateOfDispatch), ...(orders || []).filter(o => !o.deleted).map(o => o.orderDate),
+    ].filter(Boolean)
+    const minKey = (dates.length ? dates.reduce((a, b) => (a < b ? a : b)) : todayStr).slice(0, 7)
+    const out = []
+    const d = new Date(todayStr.slice(0, 7) + '-01T00:00:00Z')
+    const floor = new Date(minKey + '-01T00:00:00Z')
+    while (d >= floor && out.length < 36) {
+      const key = d.toISOString().slice(0, 7)
+      out.push({ key, label: monthLabel(key) })
+      d.setUTCMonth(d.getUTCMonth() - 1)
+    }
+    return out
+  }, [ac, ap, ad, orders, todayStr])
+
+  // ── Activity KPIs (all MT) — scoped to the selected period. ──
+  const activity = useMemo(() => ({
+    coilInward: ac.filter(c => inRange(c.dateOfInward)).reduce((s, c) => s + Number(c.actualWeight || 0), 0),
+    produced: ap.filter(p => inRange(p.dateOfProduction)).reduce((s, p) => s + Number(p.totalWeight || 0), 0),
+    invoiced: ad.filter(d => inRange(d.dateOfDispatch)).flatMap(d => d.bundleEntries || []).reduce((s, e) => s + Number(e.weight || 0), 0),
+    ordered: (orders || []).filter(o => !o.deleted && !/cancel|reject/i.test(o.orderStatus || '') && inRange(o.orderDate)).reduce((s, o) => s + Number(o.quantity || 0), 0),
+  }), [ac, ap, ad, orders, inRange])
+
   // ── Coil metrics (current snapshot, all MT) ──
   // Dispatched weight per mother coil (entry coilAllocations; legacy traceHrCoilId fallback).
   const dispByCoil = useMemo(() => {
@@ -1192,12 +1229,15 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
   const fgBooked = skuTotals.pendingToInvoice
   const freeFg = skuTotals.free
 
-  // ── Production vs dispatch trend (all-time; daily ≤31 days, else weekly). No date-range
-  // selector — buckets span the earliest production/dispatch date through today. ──
+  // ── Production vs dispatch trend, scoped to the period filter (daily ≤31 days, else weekly).
+  // When period = All Time the window spans the earliest production/dispatch date → today. ──
   const trend = useMemo(() => {
-    const toStr = todayStr
-    const dates = [...ap.map(p => p.dateOfProduction), ...ad.map(d => d.dateOfDispatch)].filter(Boolean)
-    const fromStr = dates.length ? dates.reduce((a, b) => (a < b ? a : b)) : toStr
+    const toStr = range.to || todayStr
+    let fromStr = range.from
+    if (!fromStr) {
+      const dates = [...ap.map(p => p.dateOfProduction), ...ad.map(d => d.dateOfDispatch)].filter(Boolean)
+      fromStr = dates.length ? dates.reduce((a, b) => (a < b ? a : b)) : toStr
+    }
     if (fromStr > toStr) return { data: [], weekly: false }
     const from = new Date(fromStr), to = new Date(toStr)
     const spanDays = Math.max(1, Math.round((to - from) / 86400000) + 1)
@@ -1214,12 +1254,12 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
       buckets[bucketKey(new Date(ms).toISOString().split('T')[0])] = { produced: 0, dispatched: 0 }
     }
     ap.forEach(p => {
-      if (!p.dateOfProduction) return
+      if (!inRange(p.dateOfProduction)) return
       const b = buckets[bucketKey(p.dateOfProduction)]
       if (b) b.produced += Number(p.totalWeight || 0)
     })
     ad.forEach(d => {
-      if (!d.dateOfDispatch) return
+      if (!inRange(d.dateOfDispatch)) return
       const b = buckets[bucketKey(d.dateOfDispatch)]
       if (b) b.dispatched += (d.bundleEntries || []).reduce((s, e) => s + Number(e.weight || 0), 0)
     })
@@ -1233,7 +1273,7 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
         dispatched: +buckets[k].dispatched.toFixed(1),
       })),
     }
-  }, [ap, ad, todayStr])
+  }, [ap, ad, range, todayStr, inRange])
 
   // ── Alerts ──
   const alerts = useMemo(() => {
@@ -1305,10 +1345,46 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
 
   return (
     <div className="space-y-6">
-      {/* Header: title + stock export */}
+      {/* Header: title + period filter + stock export */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Dashboard</h2>
-        <Btn size="sm" variant="ghost" onClick={downloadStockCSV}>⬇ Stock CSV</Btn>
+        <div className="flex flex-wrap items-center gap-2">
+          <select value={period} onChange={e => setPeriod(e.target.value)}
+            className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100">
+            <option value="all">All Time</option>
+            <option value="7d">Last 7 Days</option>
+            <option value="mtd">Month to Date</option>
+            <option value="month">Month…</option>
+            <option value="custom">Custom Range</option>
+          </select>
+          {period === 'month' && (
+            <select value={monthSel} onChange={e => setMonthSel(e.target.value)}
+              className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100">
+              {monthOptions.map(m => <option key={m.key} value={m.key}>{m.label}</option>)}
+            </select>
+          )}
+          {period === 'custom' && (
+            <>
+              <input type="date" value={customFrom} onChange={e => setCustomFrom(e.target.value)}
+                className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100" />
+              <span className="text-sm text-slate-500">to</span>
+              <input type="date" value={customTo} onChange={e => setCustomTo(e.target.value)}
+                className="px-3 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100" />
+            </>
+          )}
+          <Btn size="sm" variant="ghost" onClick={downloadStockCSV}>⬇ Stock CSV</Btn>
+        </div>
+      </div>
+
+      {/* Activity (MT) — scoped to the selected period */}
+      <div>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Activity — {periodLabel}</p>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <Card title="Coil Inward" value={`${fmtT(activity.coilInward)} T`} sub="Mother coil received" />
+          <Card title="Produced" value={`${fmtT(activity.produced)} T`} sub="Tubes produced" color="cyan" />
+          <Card title="Invoiced" value={`${fmtT(activity.invoiced)} T`} sub="Dispatched / invoiced" color="emerald" />
+          <Card title="Ordered" value={`${fmtT(activity.ordered)} T`} sub="New customer orders" color="amber" />
+        </div>
       </div>
 
       {/* Coil metrics (MT) */}
@@ -1377,7 +1453,7 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
       </Section>
 
       {/* Production & Dispatch Trend (all-time; daily ≤31 days, else weekly) */}
-      <Section title={`Production & Dispatch Trend${trend.weekly ? ' (weekly)' : ''}`}>
+      <Section title={`Production & Dispatch Trend — ${periodLabel}${trend.weekly ? ' (weekly)' : ''}`}>
         {trend.data.some(d => d.produced > 0 || d.dispatched > 0) ? (
           <ResponsiveContainer width="100%" height={300}>
             <BarChart data={trend.data}>
@@ -1390,7 +1466,7 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
               <Bar dataKey="dispatched" name="Dispatched (T)" fill="#059669" radius={[4, 4, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
-        ) : <p className="text-sm text-slate-400 py-8 text-center">No production or dispatch activity yet</p>}
+        ) : <p className="text-sm text-slate-400 py-8 text-center">No production or dispatch activity in this period</p>}
       </Section>
 
       {/* Alerts */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import {
   BarChart, Bar, Cell,
-  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts'
 import { useSupabaseStore } from './lib/db'
 import {
   fmtT, genHRCoilId, tolerance,
   weightPerPieceFromSku, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
-  isOpenOrderStatus, skuBookingRows,
+  isOpenOrderStatus, skuBookingRows, skuInventoryRows,
   customerFulfilment, orderBacklog, skuDemandSupply,
 } from './lib/calc'
 import DEFAULT_SKUS from './data/skus'
@@ -1172,21 +1172,68 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
     return { totalInward, fullDispatchedWt, fullDispatchedN, babyLeft, fullCoilLeft }
   }, [ac, ap, babyCoils, dispByCoil])
 
-  // ── SKU-wise inventory + booking (all MT, no pieces). inventory = produced − dispatched;
-  // booked = max(0, open customer orders − dispatched); free = inventory − booked. Union of
-  // stocked SKUs and SKUs with open orders; negative-free rows sort first. ──
-  const skuRows = useMemo(() => skuBookingRows(ap, ad, orders, skus), [ap, ad, orders, skus])
+  // ── SKU-wise inventory (all MT, no pieces). Per SKU: totalOrders, totalInvoiced,
+  // pendingToInvoice (orders − invoiced), inventory (produced − invoiced), free (inventory −
+  // pending). Union of stocked ∪ ordered SKUs; negative-free rows sort first. ──
+  const skuRows = useMemo(() => skuInventoryRows(ap, ad, orders, skus), [ap, ad, orders, skus])
 
   const skuTotals = useMemo(() => skuRows.reduce(
-    (t, r) => ({ inventory: t.inventory + r.inventory, reserved: t.reserved + r.reserved, free: t.free + r.free }),
-    { inventory: 0, reserved: 0, free: 0 }
+    (t, r) => ({
+      totalOrders: t.totalOrders + r.totalOrders, totalInvoiced: t.totalInvoiced + r.totalInvoiced,
+      pendingToInvoice: t.pendingToInvoice + r.pendingToInvoice, inventory: t.inventory + r.inventory,
+      free: t.free + r.free,
+    }),
+    { totalOrders: 0, totalInvoiced: 0, pendingToInvoice: 0, inventory: 0, free: 0 }
   ), [skuRows])
 
   // ── FG metrics (all MT) — totals reconcile with the SKU table ──
-  const totalFgDispatched = ad.flatMap(d => d.bundleEntries || []).reduce((s, e) => s + Number(e.weight || 0), 0)
+  const totalFgDispatched = skuTotals.totalInvoiced
   const fgLeft = skuTotals.inventory
-  const fgBooked = skuTotals.reserved
+  const fgBooked = skuTotals.pendingToInvoice
   const freeFg = skuTotals.free
+
+  // ── Production vs dispatch trend (all-time; daily ≤31 days, else weekly). No date-range
+  // selector — buckets span the earliest production/dispatch date through today. ──
+  const trend = useMemo(() => {
+    const toStr = todayStr
+    const dates = [...ap.map(p => p.dateOfProduction), ...ad.map(d => d.dateOfDispatch)].filter(Boolean)
+    const fromStr = dates.length ? dates.reduce((a, b) => (a < b ? a : b)) : toStr
+    if (fromStr > toStr) return { data: [], weekly: false }
+    const from = new Date(fromStr), to = new Date(toStr)
+    const spanDays = Math.max(1, Math.round((to - from) / 86400000) + 1)
+    const weekly = spanDays > 31
+    const bucketKey = (dStr) => {
+      if (!weekly) return dStr
+      const d = new Date(dStr)
+      const day = d.getDay()
+      d.setDate(d.getDate() - (day === 0 ? 6 : day - 1)) // Monday of that week
+      return d.toISOString().split('T')[0]
+    }
+    const buckets = {}
+    for (let ms = from.getTime(); ms <= to.getTime(); ms += 86400000 * (weekly ? 7 : 1)) {
+      buckets[bucketKey(new Date(ms).toISOString().split('T')[0])] = { produced: 0, dispatched: 0 }
+    }
+    ap.forEach(p => {
+      if (!p.dateOfProduction) return
+      const b = buckets[bucketKey(p.dateOfProduction)]
+      if (b) b.produced += Number(p.totalWeight || 0)
+    })
+    ad.forEach(d => {
+      if (!d.dateOfDispatch) return
+      const b = buckets[bucketKey(d.dateOfDispatch)]
+      if (b) b.dispatched += (d.bundleEntries || []).reduce((s, e) => s + Number(e.weight || 0), 0)
+    })
+    let keys = Object.keys(buckets).sort()
+    if (keys.length > 31) keys = keys.slice(-31)
+    return {
+      weekly,
+      data: keys.map(k => ({
+        name: (weekly ? 'Wk ' : '') + k.slice(5),
+        produced: +buckets[k].produced.toFixed(1),
+        dispatched: +buckets[k].dispatched.toFixed(1),
+      })),
+    }
+  }, [ap, ad, todayStr])
 
   // ── Alerts ──
   const alerts = useMemo(() => {
@@ -1252,8 +1299,8 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
 
   const downloadSkuCSV = () => {
     downloadCSV(`sku-report-${todayStr}.csv`,
-      ['SKU Code', 'Description', 'Inventory (T)', 'Inventory Reserved (T)', 'Free Inventory (T)'],
-      skuRows.map(r => [r.skuCode, r.description, fmtT(r.inventory), fmtT(r.reserved), fmtT(r.free)]))
+      ['SKU Code', 'Description', 'Total Orders (T)', 'Total Invoiced (T)', 'Pending to Invoice (T)', 'Inventory (T)', 'Free Inventory (T)'],
+      skuRows.map(r => [r.skuCode, r.description, fmtT(r.totalOrders), fmtT(r.totalInvoiced), fmtT(r.pendingToInvoice), fmtT(r.inventory), fmtT(r.free)]))
   }
 
   return (
@@ -1279,10 +1326,10 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
       <div>
         <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Finished Goods (FG)</p>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <Card title="Total FG Dispatched" value={`${fmtT(totalFgDispatched)} T`} sub="All dispatched weight" color="emerald" />
-          <Card title="FG Left Inventory" value={`${fmtT(fgLeft)} T`} sub="Produced − dispatched" />
-          <Card title="FG Booked" value={`${fmtT(fgBooked)} T`} sub="Open orders − dispatched" color="cyan" />
-          <Card title="Free FG" value={`${fmtT(freeFg)} T`} sub="Inventory − booked" color="amber" />
+          <Card title="Total FG Dispatched" value={`${fmtT(totalFgDispatched)} T`} sub="All invoiced weight" color="emerald" />
+          <Card title="FG Left Inventory" value={`${fmtT(fgLeft)} T`} sub="Produced − invoiced" />
+          <Card title="FG Booked" value={`${fmtT(fgBooked)} T`} sub="Orders − invoiced (pending)" color="cyan" />
+          <Card title="Free FG" value={`${fmtT(freeFg)} T`} sub="Inventory − pending" color="amber" />
         </div>
       </div>
 
@@ -1293,7 +1340,7 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
             <table className="min-w-full text-sm">
               <thead>
                 <tr className="bg-slate-50 dark:bg-slate-700">
-                  {['SKU Code', 'Description', 'Inventory (T)', 'Inventory Reserved (T)', 'Free Inventory (T)'].map((h, i) => (
+                  {['SKU Code', 'Description', 'Total Orders (T)', 'Total Invoiced (T)', 'Pending to Invoice (T)', 'Inventory (T)', 'Free Inventory (T)'].map((h, i) => (
                     <th key={i} className={`sticky top-0 px-4 py-3 text-xs font-medium text-slate-500 dark:text-slate-300 uppercase tracking-wider whitespace-nowrap ${i >= 2 ? 'text-right' : 'text-left'}`}>{h}</th>
                   ))}
                 </tr>
@@ -1303,8 +1350,10 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
                 <tr className="bg-slate-100 dark:bg-slate-700/50 font-semibold text-slate-900 dark:text-slate-100">
                   <td className="px-4 py-3 whitespace-nowrap">TOTAL</td>
                   <td className="px-4 py-3 whitespace-nowrap text-slate-400">{skuRows.length} SKU(s)</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-right">{fmtT(skuTotals.totalOrders)}</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-right">{fmtT(skuTotals.totalInvoiced)}</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-right">{fmtT(skuTotals.pendingToInvoice)}</td>
                   <td className="px-4 py-3 whitespace-nowrap text-right">{fmtT(skuTotals.inventory)}</td>
-                  <td className="px-4 py-3 whitespace-nowrap text-right">{fmtT(skuTotals.reserved)}</td>
                   <td className={`px-4 py-3 whitespace-nowrap text-right ${skuTotals.free < 0 ? 'text-red-600' : ''}`}>{fmtT(skuTotals.free)}</td>
                 </tr>
                 {skuRows.map((r) => {
@@ -1313,8 +1362,10 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
                     <tr key={r.skuCode} className={`hover:bg-slate-50 dark:hover:bg-slate-700/50 ${neg ? 'bg-red-50 dark:bg-red-900/30' : ''}`}>
                       <td className="px-4 py-3 whitespace-nowrap text-slate-700 dark:text-slate-300">{r.skuCode}</td>
                       <td className="px-4 py-3 text-slate-700 dark:text-slate-300">{r.description}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-right text-slate-700 dark:text-slate-300">{fmtT(r.totalOrders)}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-right text-slate-700 dark:text-slate-300">{fmtT(r.totalInvoiced)}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-right text-slate-700 dark:text-slate-300">{fmtT(r.pendingToInvoice)}</td>
                       <td className="px-4 py-3 whitespace-nowrap text-right text-slate-700 dark:text-slate-300">{fmtT(r.inventory)}</td>
-                      <td className="px-4 py-3 whitespace-nowrap text-right text-slate-700 dark:text-slate-300">{fmtT(r.reserved)}</td>
                       <td className={`px-4 py-3 whitespace-nowrap text-right ${neg ? 'text-red-600 font-semibold' : 'text-slate-700 dark:text-slate-300'}`}>{fmtT(r.free)}</td>
                     </tr>
                   )
@@ -1323,6 +1374,23 @@ function Dashboard({ coils, productions, dispatches, skus, purchaseOrders, babyC
             </table>
           </div>
         ) : <p className="text-sm text-slate-400 py-8 text-center">No SKU activity yet</p>}
+      </Section>
+
+      {/* Production & Dispatch Trend (all-time; daily ≤31 days, else weekly) */}
+      <Section title={`Production & Dispatch Trend${trend.weekly ? ' (weekly)' : ''}`}>
+        {trend.data.some(d => d.produced > 0 || d.dispatched > 0) ? (
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={trend.data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+              <YAxis tick={{ fontSize: 11 }} />
+              <Tooltip formatter={(v) => `${fmtT(v)}T`} />
+              <Legend />
+              <Bar dataKey="produced" name="Produced (T)" fill="#4f46e5" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="dispatched" name="Dispatched (T)" fill="#059669" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : <p className="text-sm text-slate-400 py-8 text-center">No production or dispatch activity yet</p>}
       </Section>
 
       {/* Alerts */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1940,7 +1940,7 @@ function Orders({ orders, setOrders }) {
 
       <p className="text-xs text-slate-400">
         Uploading <strong>replaces the entire order book</strong> with the sheet's contents (current snapshot).
-        FG Booked = open-status orders (Confirmed / Delivery in progress) minus dispatched, per SKU.
+        FG Booked = open-status orders (Confirmed / Delivery in progress) minus what's shipped against each order line.
         {' '}{activeOrders.length} order line(s) · {openCount} open.
       </p>
 

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -8,6 +8,36 @@ export const fmtT = (v) => v != null ? Number(v).toFixed(1) : '—'
 export const fmtPct = (v) => v != null ? Number(v).toFixed(1) + '%' : '—'
 export const fmtINR = (v) => v != null && !isNaN(v) ? '₹' + Number(v).toLocaleString('en-IN', { maximumFractionDigits: 0 }) : '—'
 
+// ── Dashboard period filter. `periodRange` maps a preset to an inclusive ISO {from,to}
+// window (empty string ⇒ open-ended on that side). period ∈
+// 'all' | '7d' | 'mtd' | 'month' | 'custom'. `today` is 'YYYY-MM-DD', `monthSel` is 'YYYY-MM'.
+// All date math in UTC so month boundaries / leap years don't drift with the local TZ. ──
+const isoShiftDays = (iso, days) => {
+  const d = new Date(iso + 'T00:00:00Z'); d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+export function periodRange(period, { today, monthSel = '', customFrom = '', customTo = '' } = {}) {
+  const t = today || new Date().toISOString().slice(0, 10)
+  if (period === '7d') return { from: isoShiftDays(t, -6), to: '' }       // last 7 days incl. today
+  if (period === 'mtd') return { from: t.slice(0, 7) + '-01', to: '' }    // month-to-date
+  if (period === 'month') {
+    if (!monthSel) return { from: '', to: '' }
+    const end = new Date(monthSel + '-01T00:00:00Z')
+    end.setUTCMonth(end.getUTCMonth() + 1); end.setUTCDate(0)             // last day of monthSel
+    return { from: monthSel + '-01', to: end.toISOString().slice(0, 10) }
+  }
+  if (period === 'custom') return { from: customFrom || '', to: customTo || '' }
+  return { from: '', to: '' }                                            // 'all'
+}
+export const inDateRange = (d, range) => {
+  const { from, to } = range || {}
+  if (!from && !to) return true
+  if (!d) return false
+  if (from && d < from) return false
+  if (to && d > to) return false
+  return true
+}
+
 // ── HR coil ID generator: HYD-MMYY-NN ──
 export function genHRCoilId(dateStr, num) {
   const d = new Date(dateStr)

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -4,7 +4,7 @@
 // ═══════════════════════════════════════════════════════════════
 
 // ── Formatting ──
-export const fmtT = (v) => v != null ? Number(v).toFixed(3) : '—'
+export const fmtT = (v) => v != null ? Number(v).toFixed(1) : '—'
 export const fmtPct = (v) => v != null ? Number(v).toFixed(1) + '%' : '—'
 export const fmtINR = (v) => v != null && !isNaN(v) ? '₹' + Number(v).toLocaleString('en-IN', { maximumFractionDigits: 0 }) : '—'
 
@@ -228,6 +228,40 @@ export function skuBookingRows(productions, dispatches, orders, skus) {
       skuCode: code,
       description: sku?.description || descByCode[code] || code,
       inventory, reserved: booked, free: inventory - booked,
+    }
+  })
+  rows.sort((a, b) => (a.free < 0) !== (b.free < 0)
+    ? (a.free < 0 ? -1 : 1)
+    : (a.free < 0 ? a.free - b.free : a.skuCode.localeCompare(b.skuCode)))
+  return rows
+}
+
+// ── SKU-wise inventory table (dashboard). Per SKU, all MT:
+//   totalOrders      = Σ ordered quantity over non-deleted, non-cancelled order lines
+//   totalInvoiced    = Σ dispatched (= invoiced) weight                (producedPool.dispatchedWeight)
+//   pendingToInvoice = max(0, totalOrders − totalInvoiced)             (ordered but not yet invoiced)
+//   inventory        = produced − invoiced                            (producedPool.availableWeight)
+//   free             = inventory − pendingToInvoice                    (negative ⇒ over-committed, red)
+// Union of stocked ∪ ordered SKUs; negative-free first, then by SKU code. ──
+export function skuInventoryRows(productions, dispatches, orders, skus) {
+  const pool = producedPool(productions, dispatches)
+  const orderedBySku = {}, descByCode = {}
+  ;(orders || []).filter(o => !o.deleted).forEach(o => {
+    const code = String(o.mmId || '').trim(); if (!code) return
+    if (!descByCode[code]) descByCode[code] = o.description || ''
+    if (/cancel|reject/i.test(o.orderStatus || '')) return
+    orderedBySku[code] = (orderedBySku[code] || 0) + Number(o.quantity || 0)
+  })
+  const codes = new Set([...Object.keys(pool), ...Object.keys(orderedBySku)])
+  const rows = [...codes].filter(Boolean).map(code => {
+    const totalInvoiced = pool[code]?.dispatchedWeight || 0
+    const inventory = pool[code]?.availableWeight || 0
+    const totalOrders = orderedBySku[code] || 0
+    const pendingToInvoice = Math.max(0, totalOrders - totalInvoiced)
+    const sku = (skus || []).find(s => s.skuCode === code)
+    return {
+      skuCode: code, description: sku?.description || descByCode[code] || code,
+      totalOrders, totalInvoiced, pendingToInvoice, inventory, free: inventory - pendingToInvoice,
     }
   })
   rows.sort((a, b) => (a.free < 0) !== (b.free < 0)

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  fmtT, fmtPct, fmtINR, genHRCoilId, tolerance,
+  fmtT, fmtPct, fmtINR, genHRCoilId, tolerance, periodRange, inDateRange,
   weightPerPieceFromSku, bundleWeightCap, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
   isOpenOrderStatus, openOrderQtyBySku, shippedByOrderLine, skuBookingRows,
@@ -25,6 +25,46 @@ describe('format helpers', () => {
     expect(fmtINR(1234567)).toBe('₹12,34,567') // en-IN grouping
     expect(fmtINR(null)).toBe('—')
     expect(fmtINR(NaN)).toBe('—')
+  })
+})
+
+describe('periodRange', () => {
+  const today = '2026-06-23'
+  it('all → open range', () => {
+    expect(periodRange('all', { today })).toEqual({ from: '', to: '' })
+  })
+  it('7d → last 7 days inclusive of today', () => {
+    expect(periodRange('7d', { today })).toEqual({ from: '2026-06-17', to: '' })
+  })
+  it('mtd → first of current month, open end', () => {
+    expect(periodRange('mtd', { today })).toEqual({ from: '2026-06-01', to: '' })
+  })
+  it('month → full calendar month (last day correct)', () => {
+    expect(periodRange('month', { today, monthSel: '2026-05' })).toEqual({ from: '2026-05-01', to: '2026-05-31' })
+    expect(periodRange('month', { today, monthSel: '2026-02' })).toEqual({ from: '2026-02-01', to: '2026-02-28' })
+    expect(periodRange('month', { today, monthSel: '2024-02' })).toEqual({ from: '2024-02-01', to: '2024-02-29' }) // leap
+  })
+  it('custom → passes through from/to', () => {
+    expect(periodRange('custom', { today, customFrom: '2026-01-10', customTo: '2026-03-04' }))
+      .toEqual({ from: '2026-01-10', to: '2026-03-04' })
+  })
+})
+
+describe('inDateRange', () => {
+  it('open range matches everything (incl. only-from / only-to)', () => {
+    expect(inDateRange('2026-06-01', { from: '', to: '' })).toBe(true)
+    expect(inDateRange('2026-06-01', { from: '2026-06-01', to: '' })).toBe(true)
+    expect(inDateRange('2026-05-31', { from: '2026-06-01', to: '' })).toBe(false)
+    expect(inDateRange('2026-06-30', { from: '', to: '2026-06-30' })).toBe(true)
+    expect(inDateRange('2026-07-01', { from: '', to: '2026-06-30' })).toBe(false)
+  })
+  it('bounded range is inclusive; empty date never matches a bounded range', () => {
+    const r = { from: '2026-06-01', to: '2026-06-30' }
+    expect(inDateRange('2026-06-15', r)).toBe(true)
+    expect(inDateRange('2026-06-01', r)).toBe(true)
+    expect(inDateRange('2026-06-30', r)).toBe(true)
+    expect(inDateRange('2026-05-31', r)).toBe(false)
+    expect(inDateRange('', r)).toBe(false)
   })
 })
 

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -4,13 +4,14 @@ import {
   weightPerPieceFromSku, bundleWeightCap, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
   isOpenOrderStatus, openOrderQtyBySku, shippedByOrderLine, skuBookingRows,
-  customerFulfilment, orderBacklog, skuDemandSupply,
+  customerFulfilment, orderBacklog, skuDemandSupply, skuInventoryRows,
 } from './calc'
 
 describe('format helpers', () => {
-  it('fmtT renders 3 decimals, em-dash for null/undefined', () => {
-    expect(fmtT(1.5)).toBe('1.500')
-    expect(fmtT(0)).toBe('0.000')
+  it('fmtT renders 1 decimal, em-dash for null/undefined', () => {
+    expect(fmtT(1.5)).toBe('1.5')
+    expect(fmtT(0)).toBe('0.0')
+    expect(fmtT(7.295)).toBe('7.3')
     expect(fmtT(null)).toBe('—')
     expect(fmtT(undefined)).toBe('—')
   })
@@ -503,5 +504,49 @@ describe('skuDemandSupply', () => {
     expect(a.inventory).toBeCloseTo(7)    // 12 − 5
     expect(a.booked).toBeCloseTo(4)       // open L2 (L1 delivered, excluded)
     expect(a.free).toBeCloseTo(3)         // 7 − 4
+  })
+})
+
+describe('skuInventoryRows', () => {
+  const skus = [{ skuCode: 'A', description: 'SKU A' }]
+  const productions = [{ deleted: false, skuCode: 'A', tubeCount: 100, totalWeight: 12 }]
+
+  it('computes totalOrders / totalInvoiced / pendingToInvoice / inventory / free per SKU', () => {
+    const dispatches = [{ deleted: false, bundleEntries: [{ skuCode: 'A', weight: 5 }] }]  // invoiced 5
+    const orders = [
+      { mmId: 'A', quantity: 5, orderStatus: 'Delivered' },
+      { mmId: 'A', quantity: 4, orderStatus: 'Confirmed' },
+      { mmId: 'A', quantity: 3, orderStatus: 'Cancelled' },   // excluded from demand
+    ]
+    const [a] = skuInventoryRows(productions, dispatches, orders, skus)
+    expect(a.totalOrders).toBe(9)               // 5 + 4 (cancelled excluded)
+    expect(a.totalInvoiced).toBe(5)
+    expect(a.pendingToInvoice).toBeCloseTo(4)   // max(0, 9 − 5)
+    expect(a.inventory).toBeCloseTo(7)          // produced 12 − invoiced 5
+    expect(a.free).toBeCloseTo(3)               // 7 − 4
+  })
+
+  it('floors pendingToInvoice at 0 when invoiced exceeds orders', () => {
+    const dispatches = [{ deleted: false, bundleEntries: [{ skuCode: 'A', weight: 10 }] }]
+    const orders = [{ mmId: 'A', quantity: 6, orderStatus: 'Delivered' }]
+    const [a] = skuInventoryRows(productions, dispatches, orders, skus)
+    expect(a.pendingToInvoice).toBe(0)          // max(0, 6 − 10)
+    expect(a.inventory).toBeCloseTo(2)          // 12 − 10
+    expect(a.free).toBeCloseTo(2)               // inventory − 0
+  })
+
+  it('includes ordered-but-unstocked SKUs and sorts negative free first', () => {
+    const orders = [
+      { mmId: 'A', quantity: 1, orderStatus: 'Confirmed' },                       // stocked, free positive
+      { mmId: 'Z', quantity: 8, orderStatus: 'Confirmed', description: 'SKU Z' },  // never produced → free −8
+    ]
+    const rows = skuInventoryRows(productions, [], orders, skus)
+    expect(rows[0].skuCode).toBe('Z')
+    expect(rows[0].totalOrders).toBe(8)
+    expect(rows[0].totalInvoiced).toBe(0)
+    expect(rows[0].inventory).toBe(0)
+    expect(rows[0].pendingToInvoice).toBe(8)
+    expect(rows[0].free).toBe(-8)
+    expect(rows[0].description).toBe('SKU Z')
   })
 })


### PR DESCRIPTION
### Summary
Follow-up to the merged orders/FG-booking work (#30) — a focused dashboard pass:
- **SKU-wise Inventory table** reframed around the orders↔invoice reconciliation: per SKU **Total Orders · Total Invoiced · Pending to Invoice · Inventory · Free Inventory**. The FG cards derive from the same helper so they tie out to the table.
- **Production & Dispatch trend chart** restored (grouped Produced vs Dispatched; daily ≤31 days, else weekly).
- **Time-period filter** at the top — All Time · Last 7 Days · Month to Date · Month (picker) · Custom — scoping a new **Activity** KPI row (Coil Inward · Produced · Invoiced · Ordered) and the trend chart; on-hand stock (Inventory / Free / Pending) stays current.
- **All MT weights render to 1 decimal** (shared `fmtT`).
- Orders-tab "booked" help text corrected (per order line, not per SKU).

### Verification
- `npm run build` green; `npm test` **63/63** pass — new tests: `fmtT` 1-decimal, `skuInventoryRows`, and `periodRange`/`inDateRange` (incl. leap-year month boundaries).
- Real-data cross-checks: SKU totals **Total Orders 2857.0 · Total Invoiced 1560.0 · Pending 1301.9 MT**; period scoping partitions invoiced weight by month (Apr 288.9 + May 612.0 + Jun 642.6; All Time 1560.0 = total).

### Notes
- `fmtT → 1 decimal` is global (all tabs, incl. coil/baby-coil weights); cost CSVs keep their own precision.
- **FG Booked** card was realigned to **Pending to Invoice** so the cards reconcile with the new table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzLJy1WhGUXHNgmV8TrHcJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzLJy1WhGUXHNgmV8TrHcJ)_