### PR TITLE
Refactor Fulfilment → Sales Dashboard with distributor-wise matrix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import {
   weightPerPieceFromSku, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
   isOpenOrderStatus, skuBookingRows,
-  customerFulfilment, orderBacklog, skuDemandSupply,
+  orderBacklog, skuDemandSupply, distributorSalesRows,
 } from './lib/calc'
 import DEFAULT_SKUS from './data/skus'
 // Seed data imports kept for reference — all arrays are now empty
@@ -1952,32 +1952,71 @@ function Orders({ orders, setOrders }) {
 }
 
 // ═══════════════════════════════════════════════════════════════
-// FULFILMENT — orders ↔ dispatch reconciliation views (joined per order line)
+// SALES — distributor-wise sales matrix with SKU drill-down + distributor & period filters.
+// Absorbs the former Fulfilment views (Open Order Backlog, SKU Demand vs Supply).
 // ═══════════════════════════════════════════════════════════════
-function Fulfilment({ orders, dispatches, productions, skus }) {
+function SalesDashboard({ orders, dispatches, productions, skus }) {
   const skuDesc = useCallback((code) => skus.find(s => s.skuCode === code)?.description || code, [skus])
-  const demand = useMemo(() => skuDemandSupply(productions, dispatches, orders, skus), [productions, dispatches, orders, skus])
-  const customers = useMemo(() => customerFulfilment(orders, dispatches), [orders, dispatches])
-  const backlog = useMemo(() => orderBacklog(orders, dispatches), [orders, dispatches])
   const tot = (arr, k) => arr.reduce((s, r) => s + Number(r[k] || 0), 0)
   const redIfNeg = (v) => <span className={Number(v) < 0 ? 'text-red-600 font-semibold' : ''}>{fmtT(v)}</span>
 
-  const demandCols = [
-    { label: 'SKU', value: r => r.skuCode },
-    { label: 'Description', key: 'description' },
-    { label: 'Ordered (T)', value: r => r.ordered, render: r => fmtT(r.ordered) },
-    { label: 'Produced (T)', value: r => r.produced, render: r => fmtT(r.produced) },
-    { label: 'Shipped (T)', value: r => r.shipped, render: r => fmtT(r.shipped) },
+  // ── Filters ──
+  const [period, setPeriod] = useState('')          // '' = All Time · 'YYYY-MM' · 'custom'
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+  const [distributor, setDistributor] = useState('') // '' = All distributors
+  const [selectedCustomer, setSelectedCustomer] = useState(null)
+
+  // Month options from order + dispatch dates (string slice — dates are already YYYY-MM-DD).
+  const monthOptions = useMemo(() => {
+    const set = new Set()
+    ;(orders || []).forEach(o => { const m = String(o.orderDate || '').slice(0, 7); if (m) set.add(m) })
+    ;(dispatches || []).forEach(d => { const m = String(d.dateOfDispatch || '').slice(0, 7); if (m) set.add(m) })
+    return [...set].sort().reverse()
+  }, [orders, dispatches])
+
+  const inPeriod = useCallback((dateStr) => {
+    const s = String(dateStr || '')
+    if (period === '') return true
+    if (period === 'custom') return s !== '' && (!from || s >= from) && (!to || s <= to)
+    return s.slice(0, 7) === period
+  }, [period, from, to])
+
+  const ordersF = useMemo(() => (orders || []).filter(o => inPeriod(o.orderDate)), [orders, inPeriod])
+  const dispatchesF = useMemo(() => (dispatches || []).filter(d => inPeriod(d.dateOfDispatch)), [dispatches, inPeriod])
+
+  // Inventory/Free are LIVE — always derived from UNFILTERED data (point-in-time stock).
+  const demand = useMemo(() => skuDemandSupply(productions, dispatches, orders, skus), [productions, dispatches, orders, skus])
+  const invByCode = useMemo(() => Object.fromEntries(demand.map(r => [r.skuCode, r])), [demand])
+
+  const allRows = useMemo(() => distributorSalesRows(ordersF, dispatchesF, invByCode), [ordersF, dispatchesF, invByCode])
+  const rows = useMemo(() => distributor ? allRows.filter(r => r.id === distributor) : allRows, [allRows, distributor])
+  const selected = useMemo(() => allRows.find(r => r.id === selectedCustomer) || null, [allRows, selectedCustomer])
+  const backlog = useMemo(() => orderBacklog(ordersF, dispatchesF), [ordersF, dispatchesF])
+
+  const distOptions = useMemo(() => allRows.map(r => r.customer).filter(c => c && c !== '—').sort(), [allRows])
+  const todayStr = today()
+  const globalFree = tot(demand, 'free')
+  const periodLabel = period === '' ? 'All Time' : period === 'custom' ? `${from || '…'} → ${to || '…'}` : period
+  const fillRate = tot(rows, 'validOrders') > 0 ? (tot(rows, 'dispatched') / tot(rows, 'validOrders')) * 100 : 0
+
+  const salesCols = [
+    { label: 'Distributor', key: 'customer' },
+    { label: 'Valid Orders (T)', value: r => r.validOrders, render: r => fmtT(r.validOrders) },
+    { label: 'Dispatched/Invoiced (T)', value: r => r.dispatched, render: r => fmtT(r.dispatched) },
+    { label: 'Pending to Invoice (T)', value: r => r.pending, render: r => redIfNeg(r.pending) },
     { label: 'Inventory (T)', value: r => r.inventory, render: r => fmtT(r.inventory) },
-    { label: 'Booked (T)', value: r => r.booked, render: r => fmtT(r.booked) },
-    { label: 'Free (T)', value: r => r.free, render: r => redIfNeg(r.free) },
+    { label: 'Free Stock (T)', value: r => r.free, render: r => redIfNeg(r.free) },
+    { label: 'Open Orders', value: r => r.openOrders },
   ]
-  const custCols = [
-    { label: 'Customer', key: 'customer' },
-    { label: 'Ordered (T)', value: r => r.ordered, render: r => fmtT(r.ordered) },
-    { label: 'Shipped (T)', value: r => r.shipped, render: r => fmtT(r.shipped) },
-    { label: 'Outstanding (T)', value: r => r.outstanding, render: r => redIfNeg(r.outstanding) },
-    { label: 'Open Orders', key: 'openOrders' },
+  const skuCols = [
+    { label: 'SKU', key: 'skuCode' },
+    { label: 'Description', key: 'description' },
+    { label: 'Valid Orders (T)', value: r => r.validOrders, render: r => fmtT(r.validOrders) },
+    { label: 'Dispatched/Invoiced (T)', value: r => r.dispatched, render: r => fmtT(r.dispatched) },
+    { label: 'Pending to Invoice (T)', value: r => r.pending, render: r => redIfNeg(r.pending) },
+    { label: 'Inventory (T)', value: r => r.inventory, render: r => fmtT(r.inventory) },
+    { label: 'Free Stock (T)', value: r => r.free, render: r => redIfNeg(r.free) },
   ]
   const backlogCols = [
     { label: 'Order ID', key: 'orderId' },
@@ -1990,43 +2029,108 @@ function Fulfilment({ orders, dispatches, productions, skus }) {
     { label: 'Exp. Delivery', key: 'expectedDeliveryDate' },
     { label: 'Status', key: 'orderStatus' },
   ]
+  const demandCols = [
+    { label: 'SKU', value: r => r.skuCode },
+    { label: 'Description', key: 'description' },
+    { label: 'Ordered (T)', value: r => r.ordered, render: r => fmtT(r.ordered) },
+    { label: 'Produced (T)', value: r => r.produced, render: r => fmtT(r.produced) },
+    { label: 'Shipped (T)', value: r => r.shipped, render: r => fmtT(r.shipped) },
+    { label: 'Inventory (T)', value: r => r.inventory, render: r => fmtT(r.inventory) },
+    { label: 'Booked (T)', value: r => r.booked, render: r => fmtT(r.booked) },
+    { label: 'Free (T)', value: r => r.free, render: r => redIfNeg(r.free) },
+  ]
+
+  const inputCls = 'px-2 py-2 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100'
 
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Order Fulfilment</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Sales Dashboard</h2>
+        <Btn size="sm" variant="ghost" onClick={() => downloadCSV(`distributor-sales-${todayStr}.csv`,
+          ['Distributor', 'Valid Orders (T)', 'Dispatched/Invoiced (T)', 'Pending to Invoice (T)', 'Inventory (T)', 'Free Stock (T)', 'Open Orders'],
+          rows.map(r => [r.customer, fmtT(r.validOrders), fmtT(r.dispatched), fmtT(r.pending), fmtT(r.inventory), fmtT(r.free), r.openOrders]))}>⬇ Sales CSV</Btn>
+      </div>
       <p className="text-xs text-slate-400 -mt-3">
-        Reconciles the <strong>Orders</strong> upload (demand) against the <strong>Dispatch</strong> upload (invoiced shipments),
-        joined per order line (Sku ID). All weights in MT.
+        Distributor-wise demand vs invoiced shipments. <strong>Valid Orders</strong> = open-status order qty;
+        <strong> Dispatched/Invoiced</strong> = shipped weight; <strong>Pending to Invoice</strong> = valid orders − dispatched.
+        Flow columns follow the period filter (<strong>{periodLabel}</strong>); <strong>Inventory &amp; Free Stock are live</strong> (current
+        global pool, not period-scoped) shown as the shared pool for each distributor's ordered SKUs — not exclusive, not additive. All weights in MT.
       </p>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card title="Valid Orders" value={`${fmtT(tot(rows, 'validOrders'))} T`} sub="Open-status order qty" color="indigo" />
+        <Card title="Dispatched / Invoiced" value={`${fmtT(tot(rows, 'dispatched'))} T`} sub={`Fill rate ${fillRate.toFixed(0)}%`} color="emerald" />
+        <Card title="Pending to Invoice" value={<>{redIfNeg(tot(rows, 'pending'))} T</>} sub="Valid orders − dispatched" color="amber" />
+        <Card title="Free Stock (live)" value={<>{redIfNeg(globalFree)} T</>} sub="Global inventory − booked" color="cyan" />
+      </div>
+
+      <Section title="Distributor-wise Sales" actions={
+        <div className="flex items-center gap-2 flex-wrap">
+          <select value={distributor} onChange={e => setDistributor(e.target.value)} className={inputCls}>
+            <option value="">All Distributors</option>
+            {distOptions.map(c => <option key={c} value={c}>{c}</option>)}
+          </select>
+          <select value={period} onChange={e => setPeriod(e.target.value)} className={inputCls}>
+            <option value="">All Time</option>
+            {monthOptions.map(m => <option key={m} value={m}>{m}</option>)}
+            <option value="custom">Custom range…</option>
+          </select>
+          {period === 'custom' && <>
+            <input type="date" value={from} onChange={e => setFrom(e.target.value)} className={inputCls} />
+            <span className="text-sm text-slate-500">to</span>
+            <input type="date" value={to} onChange={e => setTo(e.target.value)} className={inputCls} />
+          </>}
+        </div>
+      }>
+        {rows.length ? (
+          <>
+            <DataTable columns={salesCols} data={rows}
+              onRowClick={r => setSelectedCustomer(r.id)}
+              highlightRow={r => r.id === selectedCustomer} />
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              <strong>Total</strong> — Valid Orders {fmtT(tot(rows, 'validOrders'))}T · Dispatched/Invoiced {fmtT(tot(rows, 'dispatched'))}T · Pending {fmtT(tot(rows, 'pending'))}T.
+              {' '}Inventory &amp; Free omitted from the total (shared pool — would double-count across distributors).
+              {' '}Click a distributor for its SKU-wise breakdown.
+            </p>
+          </>
+        ) : <p className="text-sm text-slate-400 py-8 text-center">No order / dispatch data for this period</p>}
+      </Section>
+
+      {selected && (
+        <Section title={`SKU Breakdown — ${selected.customer}`} actions={
+          <Btn size="sm" variant="ghost" onClick={() => setSelectedCustomer(null)}>× Close</Btn>
+        }>
+          {selected.skuRows.length ? (
+            <>
+              <DataTable columns={skuCols} data={selected.skuRows} />
+              <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                <strong>Total</strong> — Valid Orders {fmtT(tot(selected.skuRows, 'validOrders'))}T · Dispatched/Invoiced {fmtT(tot(selected.skuRows, 'dispatched'))}T · Pending {fmtT(tot(selected.skuRows, 'pending'))}T.
+                {' '}Inventory &amp; Free are the live global pool per SKU.
+              </p>
+            </>
+          ) : <p className="text-sm text-slate-400 py-8 text-center">No SKU rows for this distributor</p>}
+        </Section>
+      )}
+
+      <Section title={`Open Order Backlog (${backlog.length})`}>
+        {backlog.length ? (
+          <>
+            <p className="mb-3 text-xs text-slate-400">One row per still-open order line (open = ordered − shipped &gt; 0), oldest expected delivery first; <span className="text-red-600 font-semibold">overdue</span> rows highlighted. Open total {fmtT(tot(backlog, 'open'))}T.</p>
+            <DataTable columns={backlogCols} data={backlog} highlightRow={r => r.expectedDeliveryDate && r.expectedDeliveryDate < todayStr} />
+          </>
+        ) : <p className="text-sm text-slate-400 py-8 text-center">No open orders for this period</p>}
+      </Section>
 
       <Section title="SKU Demand vs Supply">
         {demand.length ? (
           <>
             <p className="mb-3 text-xs text-slate-400">
               Ordered {fmtT(tot(demand, 'ordered'))}T · Produced {fmtT(tot(demand, 'produced'))}T · Shipped {fmtT(tot(demand, 'shipped'))}T · Booked {fmtT(tot(demand, 'booked'))}T · Free {fmtT(tot(demand, 'free'))}T.
-              Inventory = produced − shipped; Booked = open orders (net of shipment); Free = inventory − booked (negative = over-committed).
+              Inventory = produced − shipped; Booked = open orders (net of shipment); Free = inventory − booked (negative = over-committed). Live, not period-scoped.
             </p>
             <DataTable columns={demandCols} data={demand} highlightRow={r => r.free < 0} />
           </>
         ) : <p className="text-sm text-slate-400 py-8 text-center">No order / production / dispatch data yet</p>}
-      </Section>
-
-      <Section title="Customer-wise Outstanding">
-        {customers.length ? (
-          <>
-            <p className="mb-3 text-xs text-slate-400">Outstanding = ordered − shipped, per distributor. Ordered {fmtT(tot(customers, 'ordered'))}T · Shipped {fmtT(tot(customers, 'shipped'))}T.</p>
-            <DataTable columns={custCols} data={customers} />
-          </>
-        ) : <p className="text-sm text-slate-400 py-8 text-center">No order data yet</p>}
-      </Section>
-
-      <Section title={`Open Order Backlog (${backlog.length})`}>
-        {backlog.length ? (
-          <>
-            <p className="mb-3 text-xs text-slate-400">One row per still-open order line (open = ordered − shipped &gt; 0), oldest expected delivery first. Open total {fmtT(tot(backlog, 'open'))}T.</p>
-            <DataTable columns={backlogCols} data={backlog} />
-          </>
-        ) : <p className="text-sm text-slate-400 py-8 text-center">No open orders</p>}
       </Section>
     </div>
   )
@@ -2045,7 +2149,7 @@ const TABS = [
   { key: 'skuMaster', label: 'SKU Master' },
   { key: 'poMaster', label: 'PO Master' },
   { key: 'orders', label: 'Orders' },
-  { key: 'fulfilment', label: 'Fulfilment' },
+  { key: 'sales', label: 'Sales' },
 ]
 
 const TABLE_LABELS = {
@@ -2184,7 +2288,7 @@ export default function App() {
         {tab === 'skuMaster' && <SKUMaster skus={skus} setSkus={setSkus} />}
         {tab === 'poMaster' && <POMaster purchaseOrders={purchaseOrders} setPurchaseOrders={setPurchaseOrders} />}
         {tab === 'orders' && <Orders orders={orders} setOrders={setOrders} />}
-        {tab === 'fulfilment' && <Fulfilment orders={orders} dispatches={dispatches} productions={productions} skus={skus} />}
+        {tab === 'sales' && <SalesDashboard orders={orders} dispatches={dispatches} productions={productions} skus={skus} />}
       </main>
 
       {/* Footer */}

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -305,6 +305,60 @@ export function skuDemandSupply(productions, dispatches, orders, skus) {
     : (a.free < 0 ? a.free - b.free : a.skuCode.localeCompare(b.skuCode)))
 }
 
+// ── Per-distributor sales matrix (Sales dashboard). Joins the Orders upload (demand) and the
+// Dispatch upload (invoiced shipments) by Distributor Name, with a nested per-SKU breakdown for
+// drill-down. Customers are unioned from BOTH orders and dispatches, so a customer shipped
+// against a now-closed order still appears (pending goes negative). All weights in MT:
+//   validOrders = Σ quantity of open-status order lines (isOpenOrderStatus)
+//   dispatched  = Σ dispatch bundleEntries weight
+//   pending     = validOrders − dispatched   (simple subtraction; negative ⇒ over-shipped)
+// inventory/free are looked up from invByCode (a skuCode → skuDemandSupply row map the caller
+// builds from UNFILTERED data, so they stay live snapshots). Distributor-level inventory/free is
+// the Σ of the global pool over that customer's open-ordered SKUs — a SHARED pool that overlaps
+// across customers, so callers must NOT total those two columns. Per-SKU rows carry the exact
+// global value. Sorted by pending desc at both levels; rows carry `id` for DataTable/drill-down. ──
+export function distributorSalesRows(orders, dispatches, invByCode = {}) {
+  const key = (c) => String(c || '').trim() || '—'
+  const map = {}
+  const cust = (c) => (map[c] = map[c] || { id: c, customer: c, validOrders: 0, dispatched: 0, openOrders: 0, _sku: {} })
+  const sku = (c, code) => (c._sku[code] = c._sku[code] || { id: code, skuCode: code, description: '', validOrders: 0, dispatched: 0 })
+
+  ;(orders || []).filter(o => !o.deleted).forEach(o => {
+    const c = cust(key(o.customer))
+    if (!isOpenOrderStatus(o.orderStatus)) return
+    const code = String(o.mmId || '').trim()
+    const q = Number(o.quantity || 0)
+    c.validOrders += q
+    c.openOrders += 1
+    if (code) { const s = sku(c, code); s.validOrders += q; if (!s.description) s.description = o.description || '' }
+  })
+  ;(dispatches || []).filter(d => !d.deleted).flatMap(d => d.bundleEntries || []).forEach(be => {
+    const c = cust(key(be.customer))
+    const code = String(be.skuCode || '').trim()
+    const w = Number(be.weight || 0)
+    c.dispatched += w
+    if (code) sku(c, code).dispatched += w
+  })
+
+  return Object.values(map).map(c => {
+    const skuRows = Object.values(c._sku).map(s => {
+      const inv = invByCode[s.skuCode] || {}
+      return {
+        id: s.id, skuCode: s.skuCode,
+        description: inv.description || s.description || s.skuCode,
+        validOrders: s.validOrders, dispatched: s.dispatched,
+        pending: s.validOrders - s.dispatched,
+        inventory: Number(inv.inventory || 0), free: Number(inv.free || 0),
+      }
+    }).sort((a, b) => b.pending - a.pending)
+    const orderedCodes = Object.values(c._sku).filter(s => s.validOrders > 0).map(s => s.skuCode)
+    const inventory = orderedCodes.reduce((t, code) => t + Number(invByCode[code]?.inventory || 0), 0)
+    const free = orderedCodes.reduce((t, code) => t + Number(invByCode[code]?.free || 0), 0)
+    const { _sku, ...rest } = c
+    return { ...rest, pending: c.validOrders - c.dispatched, inventory, free, skuRows }
+  }).sort((a, b) => b.pending - a.pending)
+}
+
 // ── Inherit a dispatch entry's coil attribution from production FIFO. Maps `pieces` of an
 // SKU onto that SKU's production coilAllocations (oldest production first), skipping pieces
 // already taken by other (non-deleted) dispatches of the SKU. Carries BOTH babyCoilId and

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -4,7 +4,7 @@ import {
   weightPerPieceFromSku, bundleWeightCap, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
   isOpenOrderStatus, openOrderQtyBySku, shippedByOrderLine, skuBookingRows,
-  customerFulfilment, orderBacklog, skuDemandSupply,
+  customerFulfilment, orderBacklog, skuDemandSupply, distributorSalesRows,
 } from './calc'
 
 describe('format helpers', () => {
@@ -503,5 +503,78 @@ describe('skuDemandSupply', () => {
     expect(a.inventory).toBeCloseTo(7)    // 12 − 5
     expect(a.booked).toBeCloseTo(4)       // open L2 (L1 delivered, excluded)
     expect(a.free).toBeCloseTo(3)         // 7 − 4
+  })
+})
+
+describe('distributorSalesRows', () => {
+  const invByCode = {
+    A: { skuCode: 'A', description: 'SKU A', inventory: 7, free: 3 },
+    B: { skuCode: 'B', description: 'SKU B', inventory: 4, free: -2 },
+  }
+
+  it('per-distributor validOrders (open only) / dispatched / pending, with nested per-SKU rows + live inventory/free', () => {
+    const orders = [
+      { customer: 'Acme', mmId: 'A', quantity: 10, orderStatus: 'Confirmed', description: 'SKU A' },
+      { customer: 'Acme', mmId: 'B', quantity: 5, orderStatus: 'Delivered' },   // closed → excluded from valid
+      { customer: 'Bolt', mmId: 'A', quantity: 4, orderStatus: 'Confirmed' },
+    ]
+    const dispatches = [{ deleted: false, bundleEntries: [
+      { customer: 'Acme', skuCode: 'A', weight: 6 },
+    ] }]
+    const rows = distributorSalesRows(orders, dispatches, invByCode)
+    const acme = rows.find(r => r.customer === 'Acme')
+    expect(acme.id).toBe('Acme')
+    expect(acme.validOrders).toBe(10)        // delivered B excluded
+    expect(acme.dispatched).toBe(6)
+    expect(acme.pending).toBe(4)             // 10 − 6
+    expect(acme.openOrders).toBe(1)
+    expect(acme.inventory).toBe(7)           // Σ over open-ordered SKUs (only A)
+    expect(acme.free).toBe(3)
+    const skuA = acme.skuRows.find(s => s.skuCode === 'A')
+    expect(skuA.id).toBe('A')
+    expect(skuA.validOrders).toBe(10)
+    expect(skuA.dispatched).toBe(6)
+    expect(skuA.pending).toBe(4)
+    expect(skuA.inventory).toBe(7)           // exact global per-SKU value
+    expect(skuA.free).toBe(3)
+    expect(skuA.description).toBe('SKU A')
+    expect(acme.skuRows.some(s => s.skuCode === 'B')).toBe(false) // delivered order didn't create a SKU row
+  })
+
+  it('includes customers shipped with no open order (pending negative); unions orders ∪ dispatches', () => {
+    const dispatches = [{ deleted: false, bundleEntries: [
+      { customer: 'Ghost', skuCode: 'A', weight: 5 },
+    ] }]
+    const rows = distributorSalesRows([], dispatches, invByCode)
+    const ghost = rows.find(r => r.customer === 'Ghost')
+    expect(ghost.validOrders).toBe(0)
+    expect(ghost.dispatched).toBe(5)
+    expect(ghost.pending).toBe(-5)
+    expect(ghost.inventory).toBe(0)          // no open-ordered SKUs → 0
+    expect(ghost.free).toBe(0)
+  })
+
+  it('buckets blank customer names under "—"', () => {
+    const orders = [{ customer: '', mmId: 'A', quantity: 3, orderStatus: 'Confirmed' }]
+    const dispatches = [{ deleted: false, bundleEntries: [{ customer: '   ', skuCode: 'A', weight: 1 }] }]
+    const dash = distributorSalesRows(orders, dispatches, invByCode).find(r => r.customer === '—')
+    expect(dash).toBeTruthy()
+    expect(dash.id).toBe('—')
+    expect(dash.validOrders).toBe(3)
+    expect(dash.dispatched).toBe(1)
+    expect(dash.pending).toBe(2)
+  })
+
+  it('sorts distributors by pending desc and ignores deleted orders/dispatches', () => {
+    const orders = [
+      { customer: 'Low', mmId: 'A', quantity: 2, orderStatus: 'Confirmed' },
+      { customer: 'High', mmId: 'A', quantity: 20, orderStatus: 'Confirmed' },
+      { customer: 'Del', mmId: 'A', quantity: 99, orderStatus: 'Confirmed', deleted: true }, // ignored
+    ]
+    const dispatches = [{ deleted: true, bundleEntries: [{ customer: 'High', skuCode: 'A', weight: 100 }] }] // ignored
+    const rows = distributorSalesRows(orders, dispatches, invByCode)
+    expect(rows.map(r => r.customer)).toEqual(['High', 'Low'])
+    expect(rows.find(r => r.customer === 'Del')).toBeFalsy()
+    expect(rows.find(r => r.customer === 'High').dispatched).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
Replaces the **Fulfilment** view with a new **Sales Dashboard** that presents a distributor-wise sales matrix with period filtering, drill-down SKU breakdown, and live inventory snapshots. The old customer-wise outstanding view is absorbed into the new distributor sales table, and the backlog + demand-vs-supply sections are reorganized as supporting views.

## Key Changes

- **New `distributorSalesRows()` function** (`src/lib/calc.js`):
  - Joins Orders (demand) and Dispatches (invoiced shipments) by distributor name
  - Calculates per-distributor: `validOrders` (open-status qty), `dispatched` (shipped weight), `pending` (difference)
  - Includes nested per-SKU breakdown for drill-down analysis
  - Unions customers from both orders and dispatches (so over-shipped customers appear with negative pending)
  - Inventory/free are live snapshots from `skuDemandSupply`, not period-scoped
  - Sorted by pending descending; includes test suite with 4 test cases

- **Renamed & restructured component** (`src/App.jsx`):
  - `Fulfilment` → `SalesDashboard`
  - Added period filtering (All Time, monthly, custom date range)
  - Added distributor filter (All Distributors or single)
  - Added KPI cards: Valid Orders, Dispatched/Invoiced, Pending to Invoice, Free Stock (live)
  - Main table shows distributor-wise sales with fill-rate calculation
  - Click a distributor to drill into its SKU-wise breakdown
  - Backlog and Demand vs Supply moved to secondary sections below
  - CSV export for distributor sales data

- **Updated imports & exports**:
  - Removed `customerFulfilment` from imports (function still exists but unused)
  - Added `distributorSalesRows` to imports and exports
  - Tab label changed from "Fulfilment" to "Sales"

- **UI/UX improvements**:
  - Period label displayed in help text (e.g., "All Time", "2025-01", "2025-01-15 → 2025-02-28")
  - Clarified column semantics: "Valid Orders", "Dispatched/Invoiced", "Pending to Invoice", "Free Stock (live)"
  - Help text explains that flow columns (orders, dispatched, pending) follow the period filter, while inventory/free are always live
  - Overdue backlog rows highlighted in red
  - Distributor drill-down shows SKU-level detail with same metrics

## Implementation Details

- Period filtering is applied to orders and dispatches before calculation; inventory/free remain unfiltered (live global pool)
- Distributor-level inventory/free is the sum of the global pool over that customer's open-ordered SKUs — a **shared pool** that overlaps across customers (not totaled in summary)
- Per-SKU rows carry the exact global inventory/free value from `skuDemandSupply`
- Blank/whitespace customer names are normalized to "—" for consistent bucketing
- Deleted orders and dispatches are filtered out at the source
- Sorting is by pending (descending) at both distributor and SKU levels

https://claude.ai/code/session_01JuGXNA5ArTBMcBQpwKY3jx