### PR TITLE
Add fmtT3 formatter for 3-decimal tonnage display

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import {
 } from 'recharts'
 import { useSupabaseStore } from './lib/db'
 import {
-  fmtT, genHRCoilId, tolerance, periodRange, inDateRange,
+  fmtT, fmtT3, genHRCoilId, tolerance, periodRange, inDateRange,
   weightPerPieceFromSku, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
   isOpenOrderStatus, skuInventoryRows,
@@ -304,9 +304,9 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils }) {
     { label: 'Grade', key: 'coilGrade' },
     { label: 'Thick (mm)', key: 'thickness' },
     { label: 'Width (mm)', key: 'width' },
-    { label: 'Invoice Wt (T)', value: r => fmtT(r.invoiceWeight) },
-    { label: 'Actual Wt (T)', value: r => fmtT(r.actualWeight) },
-    { label: 'Dispatched Wt (T)', render: r => { const s = getCoilStats(r); return s.dispatchedWt > 0 ? <span>{fmtT(s.dispatchedWt)}</span> : <span className="text-slate-400">—</span> } },
+    { label: 'Invoice Wt (T)', value: r => fmtT3(r.invoiceWeight) },
+    { label: 'Actual Wt (T)', value: r => fmtT3(r.actualWeight) },
+    { label: 'Dispatched Wt (T)', render: r => { const s = getCoilStats(r); return s.dispatchedWt > 0 ? <span>{fmtT3(s.dispatchedWt)}</span> : <span className="text-slate-400">—</span> } },
     { label: 'Cost (₹)', value: r => r.costPrice ? `₹${Math.round(r.costPrice).toLocaleString()}` : '—' },
   ]
 
@@ -314,7 +314,7 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils }) {
     const header = ['HR Coil ID', 'Date', 'Input Coil #', 'Grade', 'Thickness (mm)', 'Width (mm)', 'Invoice Wt (T)', 'Actual Wt (T)', 'Dispatched Wt (T)', 'Cost (₹)']
     downloadCSV(`coil-inward-${today()}.csv`, header, coils.filter(c => !c.deleted).map(r => {
       const s = getCoilStats(r)
-      return [r.hrCoilId, r.dateOfInward, r.inputCoilNumber, r.coilGrade, r.thickness, r.width, fmtT(r.invoiceWeight), fmtT(r.actualWeight), fmtT(s.dispatchedWt), r.costPrice ? Math.round(r.costPrice) : '']
+      return [r.hrCoilId, r.dateOfInward, r.inputCoilNumber, r.coilGrade, r.thickness, r.width, fmtT3(r.invoiceWeight), fmtT3(r.actualWeight), fmtT3(s.dispatchedWt), r.costPrice ? Math.round(r.costPrice) : '']
     }))
   }
 
@@ -478,7 +478,7 @@ function Slitting({ coils, babyCoils, setBabyCoils, productions }) {
       return true
     }).map(c => ({
       value: c.hrCoilId,
-      label: `${c.hrCoilId} (W:${c.width}mm, ${fmtT(c.actualWeight)}T)`
+      label: `${c.hrCoilId} (W:${c.width}mm, ${fmtT3(c.actualWeight)}T)`
     }))
   }, [coils, babyCoils, editId, form.hrCoilId])
 
@@ -523,7 +523,7 @@ function Slitting({ coils, babyCoils, setBabyCoils, productions }) {
     { label: 'HR Coil ID', key: 'hrCoilId' },
     { label: 'Thick (mm)', key: 'thickness' },
     { label: 'Width (mm)', key: 'width' },
-    { label: 'Weight (T)', value: r => fmtT(r.weight) },
+    { label: 'Weight (T)', value: r => fmtT3(r.weight) },
     { label: 'Cost (₹)', value: r => r.costPrice ? `₹${Math.round(r.costPrice).toLocaleString()}` : '—' },
     { label: 'Width Check', render: r => {
       const g = parentGroups[r.hrCoilId]
@@ -539,7 +539,7 @@ function Slitting({ coils, babyCoils, setBabyCoils, productions }) {
   const downloadBabyCoilsCSV = () => {
     const header = ['Date', 'Baby Coil ID', 'HR Coil ID', 'Thickness (mm)', 'Width (mm)', 'Weight (T)', 'Cost (₹)', 'PO Number']
     downloadCSV(`slitting-${today()}.csv`, header, filteredBabyCoils.map(r => [
-      r.dateOfConversion, r.babyCoilId, r.hrCoilId, r.thickness, r.width, fmtT(r.weight), r.costPrice ? Math.round(r.costPrice) : '', r.poNumber,
+      r.dateOfConversion, r.babyCoilId, r.hrCoilId, r.thickness, r.width, fmtT3(r.weight), r.costPrice ? Math.round(r.costPrice) : '', r.poNumber,
     ]))
   }
 
@@ -563,7 +563,7 @@ function Slitting({ coils, babyCoils, setBabyCoils, productions }) {
             <Field label="Thickness (mm)" auto><Input value={parentCoil?.thickness ?? ''} disabled /></Field>
             <Field label="Width (mm)"><Input type="number" value={form.width} onChange={v => f('width', v)} /></Field>
             <Field label="Length (mm)"><Input type="number" value={form.length} onChange={v => f('length', v)} placeholder="Optional" /></Field>
-            <Field label="Weight (T)" auto><Input value={fmtT(calcWeight)} disabled /></Field>
+            <Field label="Weight (T)" auto><Input value={fmtT3(calcWeight)} disabled /></Field>
             <Field label="Cost Price (₹)" auto><Input value={calcCostPrice ? `₹${Math.round(calcCostPrice).toLocaleString()}` : '—'} disabled /></Field>
             <Field label="PO Number" auto><Input value={parentCoil?.poNumber ?? ''} disabled /></Field>
           </div>

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -5,6 +5,9 @@
 
 // ── Formatting ──
 export const fmtT = (v) => v != null ? Number(v).toFixed(1) : '—'
+// Full-precision tonnage (3 decimals) — used for raw coil-stage records (Coil Inward, Slitting)
+// where operators need exact entered/derived weights, not the dashboard's 1-decimal rounding.
+export const fmtT3 = (v) => v != null ? Number(v).toFixed(3) : '—'
 export const fmtPct = (v) => v != null ? Number(v).toFixed(1) + '%' : '—'
 export const fmtINR = (v) => v != null && !isNaN(v) ? '₹' + Number(v).toLocaleString('en-IN', { maximumFractionDigits: 0 }) : '—'
 

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  fmtT, fmtPct, fmtINR, genHRCoilId, tolerance, periodRange, inDateRange,
+  fmtT, fmtT3, fmtPct, fmtINR, genHRCoilId, tolerance, periodRange, inDateRange,
   weightPerPieceFromSku, bundleWeightCap, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace,
   isOpenOrderStatus, openOrderQtyBySku, shippedByOrderLine, skuBookingRows,
@@ -14,6 +14,14 @@ describe('format helpers', () => {
     expect(fmtT(7.295)).toBe('7.3')
     expect(fmtT(null)).toBe('—')
     expect(fmtT(undefined)).toBe('—')
+  })
+
+  it('fmtT3 renders 3 decimals, em-dash for null/undefined', () => {
+    expect(fmtT3(1.5)).toBe('1.500')
+    expect(fmtT3(0)).toBe('0.000')
+    expect(fmtT3(7.295)).toBe('7.295')
+    expect(fmtT3(null)).toBe('—')
+    expect(fmtT3(undefined)).toBe('—')
   })
 
   it('fmtPct renders 1 decimal + %, em-dash for null', () => {


### PR DESCRIPTION
## Summary
Introduces a new `fmtT3` formatter function to display tonnage values with 3 decimal places (full precision) instead of the existing `fmtT` which rounds to 1 decimal. This is used in raw coil-stage records (Coil Inward and Slitting) where operators need to see exact entered/derived weights without dashboard-level rounding.

## Changes
- **New formatter function** (`src/lib/calc.js`):
  - Added `fmtT3(v)` that formats numbers to 3 decimal places, returning '—' for null/undefined
  - Includes documentation explaining its use case: raw coil-stage records vs. dashboard summaries

- **Updated Coil Inward component** (`src/App.jsx`):
  - Replaced `fmtT` with `fmtT3` for Invoice Weight, Actual Weight, and Dispatched Weight columns
  - Updated CSV export to use `fmtT3` for weight fields

- **Updated Slitting component** (`src/App.jsx`):
  - Replaced `fmtT` with `fmtT3` in baby coil dropdown labels (weight display)
  - Updated Weight column in baby coils table to use `fmtT3`
  - Updated CSV export to use `fmtT3` for weight fields
  - Updated calculated weight field display to use `fmtT3`

- **Added test coverage** (`src/lib/calc.test.js`):
  - New test suite for `fmtT3` covering normal values, zero, edge cases, and null/undefined handling

## Implementation Details
- `fmtT3` follows the same pattern as existing `fmtT` formatter but uses `.toFixed(3)` instead of `.toFixed(1)`
- Maintains consistency with the existing formatting helper API (returns em-dash for falsy values)
- Preserves `fmtT` for dashboard/summary views where 1-decimal rounding is appropriate

https://claude.ai/code/session_01RjKXEdnpKkk2rhjJVdYXT5