### PR TITLE
Redefine Sales Dashboard "Valid Orders" to exclude only cancelled/rejected

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2195,14 +2195,14 @@ function SalesDashboard({ orders, dispatches, productions, skus }) {
           rows.map(r => [r.customer, fmtT(r.validOrders), fmtT(r.dispatched), fmtT(r.pending), fmtT(r.inventory), fmtT(r.free), r.openOrders]))}>⬇ Sales CSV</Btn>
       </div>
       <p className="text-xs text-slate-400 -mt-3">
-        Distributor-wise demand vs invoiced shipments. <strong>Valid Orders</strong> = open-status order qty;
-        <strong> Dispatched/Invoiced</strong> = shipped weight; <strong>Pending to Invoice</strong> = valid orders − dispatched.
+        Distributor-wise demand vs invoiced shipments. <strong>Valid Orders</strong> = ordered qty (excludes Cancelled/Rejected);
+        <strong> Dispatched/Invoiced</strong> = shipped weight; <strong>Pending to Invoice</strong> = valid orders − dispatched (negative ⇒ over-shipped).
         Flow columns follow the period filter (<strong>{periodLabel}</strong>); <strong>Inventory &amp; Free Stock are live</strong> (current
         global pool, not period-scoped) shown as the shared pool for each distributor's ordered SKUs — not exclusive, not additive. All weights in MT.
       </p>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <Card title="Valid Orders" value={`${fmtT(tot(rows, 'validOrders'))} T`} sub="Open-status order qty" color="indigo" />
+        <Card title="Valid Orders" value={`${fmtT(tot(rows, 'validOrders'))} T`} sub="Ordered qty (excl. cancelled/rejected)" color="indigo" />
         <Card title="Dispatched / Invoiced" value={`${fmtT(tot(rows, 'dispatched'))} T`} sub={`Fill rate ${fillRate.toFixed(0)}%`} color="emerald" />
         <Card title="Pending to Invoice" value={<>{redIfNeg(tot(rows, 'pending'))} T</>} sub="Valid orders − dispatched" color="amber" />
         <Card title="Free Stock (live)" value={<>{redIfNeg(globalFree)} T</>} sub="Global inventory − booked" color="cyan" />

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -373,12 +373,14 @@ export function skuDemandSupply(productions, dispatches, orders, skus) {
 // Dispatch upload (invoiced shipments) by Distributor Name, with a nested per-SKU breakdown for
 // drill-down. Customers are unioned from BOTH orders and dispatches, so a customer shipped
 // against a now-closed order still appears (pending goes negative). All weights in MT:
-//   validOrders = Σ quantity of open-status order lines (isOpenOrderStatus)
+//   validOrders = Σ quantity of order lines that are NOT cancelled/rejected (Delivered + blank
+//                 status included — total committed demand, matching skuInventoryRows.totalOrders)
+//   openOrders  = count of order lines still open (isOpenOrderStatus) — stays strict
 //   dispatched  = Σ dispatch bundleEntries weight
 //   pending     = validOrders − dispatched   (simple subtraction; negative ⇒ over-shipped)
 // inventory/free are looked up from invByCode (a skuCode → skuDemandSupply row map the caller
 // builds from UNFILTERED data, so they stay live snapshots). Distributor-level inventory/free is
-// the Σ of the global pool over that customer's open-ordered SKUs — a SHARED pool that overlaps
+// the Σ of the global pool over that customer's valid-ordered SKUs — a SHARED pool that overlaps
 // across customers, so callers must NOT total those two columns. Per-SKU rows carry the exact
 // global value. Sorted by pending desc at both levels; rows carry `id` for DataTable/drill-down. ──
 export function distributorSalesRows(orders, dispatches, invByCode = {}) {
@@ -389,11 +391,11 @@ export function distributorSalesRows(orders, dispatches, invByCode = {}) {
 
   ;(orders || []).filter(o => !o.deleted).forEach(o => {
     const c = cust(key(o.customer))
-    if (!isOpenOrderStatus(o.orderStatus)) return
+    if (/cancel|reject/i.test(o.orderStatus || '')) return  // valid demand = everything except cancelled/rejected
     const code = String(o.mmId || '').trim()
     const q = Number(o.quantity || 0)
     c.validOrders += q
-    c.openOrders += 1
+    if (isOpenOrderStatus(o.orderStatus)) c.openOrders += 1  // "Open Orders" stays strictly open
     if (code) { const s = sku(c, code); s.validOrders += q; if (!s.description) s.description = o.description || '' }
   })
   ;(dispatches || []).filter(d => !d.deleted).flatMap(d => d.bundleEntries || []).forEach(be => {

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -553,10 +553,11 @@ describe('distributorSalesRows', () => {
     B: { skuCode: 'B', description: 'SKU B', inventory: 4, free: -2 },
   }
 
-  it('per-distributor validOrders (open only) / dispatched / pending, with nested per-SKU rows + live inventory/free', () => {
+  it('per-distributor validOrders (excl. cancelled/rejected) / dispatched / pending, with nested per-SKU rows + live inventory/free', () => {
     const orders = [
       { customer: 'Acme', mmId: 'A', quantity: 10, orderStatus: 'Confirmed', description: 'SKU A' },
-      { customer: 'Acme', mmId: 'B', quantity: 5, orderStatus: 'Delivered' },   // closed → excluded from valid
+      { customer: 'Acme', mmId: 'B', quantity: 5, orderStatus: 'Delivered', description: 'SKU B' }, // delivered → still valid demand
+      { customer: 'Acme', mmId: 'A', quantity: 9, orderStatus: 'Cancelled' }, // cancelled → excluded
       { customer: 'Bolt', mmId: 'A', quantity: 4, orderStatus: 'Confirmed' },
     ]
     const dispatches = [{ deleted: false, bundleEntries: [
@@ -565,12 +566,12 @@ describe('distributorSalesRows', () => {
     const rows = distributorSalesRows(orders, dispatches, invByCode)
     const acme = rows.find(r => r.customer === 'Acme')
     expect(acme.id).toBe('Acme')
-    expect(acme.validOrders).toBe(10)        // delivered B excluded
+    expect(acme.validOrders).toBe(15)        // 10 (A) + 5 (delivered B); cancelled A excluded
     expect(acme.dispatched).toBe(6)
-    expect(acme.pending).toBe(4)             // 10 − 6
-    expect(acme.openOrders).toBe(1)
-    expect(acme.inventory).toBe(7)           // Σ over open-ordered SKUs (only A)
-    expect(acme.free).toBe(3)
+    expect(acme.pending).toBe(9)             // 15 − 6
+    expect(acme.openOrders).toBe(1)          // only the Confirmed line is open
+    expect(acme.inventory).toBe(11)          // Σ over valid-ordered SKUs (A:7 + B:4)
+    expect(acme.free).toBe(1)                // A:3 + B:-2
     const skuA = acme.skuRows.find(s => s.skuCode === 'A')
     expect(skuA.id).toBe('A')
     expect(skuA.validOrders).toBe(10)
@@ -579,7 +580,10 @@ describe('distributorSalesRows', () => {
     expect(skuA.inventory).toBe(7)           // exact global per-SKU value
     expect(skuA.free).toBe(3)
     expect(skuA.description).toBe('SKU A')
-    expect(acme.skuRows.some(s => s.skuCode === 'B')).toBe(false) // delivered order didn't create a SKU row
+    const skuB = acme.skuRows.find(s => s.skuCode === 'B')
+    expect(skuB).toBeTruthy()                // delivered order now creates a SKU row
+    expect(skuB.validOrders).toBe(5)
+    expect(skuB.pending).toBe(5)             // 5 − 0 dispatched
   })
 
   it('includes customers shipped with no open order (pending negative); unions orders ∪ dispatches', () => {


### PR DESCRIPTION
## Summary
On the Sales Dashboard, **Pending to Invoice** (`Valid Orders − Dispatched/Invoiced`) showed large, confusing **negative** values. Root cause: **Valid Orders** counted only *open-status* orders (excluding Delivered/Cancelled/Rejected/blank), while **Dispatched/Invoiced** counts *all* shipments. So once an order was fully **Delivered**, it dropped out of demand but its invoice remained → Pending went sharply negative even though the SKU was simply complete.

This PR redefines **Valid Orders = all order lines except Cancelled/Rejected** (Delivered + blank-status now count), matching how `skuInventoryRows` already computes `totalOrders`. After the change, `Pending = total committed demand − invoiced`, so the spurious large negatives disappear; only genuine over-shipment (steel weight variance, e.g. ordered 22.0 / invoiced 22.0 → −0.0) stays slightly negative — which is correct.

## Changes
- **`src/lib/calc.js`** — `distributorSalesRows`: demand filter changed from `isOpenOrderStatus` to "exclude only cancelled/rejected". The **Open Orders** counter stays gated on `isOpenOrderStatus` (Delivered no longer counts as open). Doc comment updated.
- **`src/App.jsx`** — labels only: help text and the *Valid Orders* KPI card now read "ordered qty (excludes Cancelled/Rejected)"; the *Pending to Invoice* note clarifies that negative ⇒ over-shipped.
- **`src/lib/calc.test.js`** — `distributorSalesRows` contract updated to the new definition (Delivered now included; Open Orders stays strict).

## Scope guard
The shared `isOpenOrderStatus` helper is **untouched**, so **Order Backlog** (`orderBacklog`) and **FG Booking** (`skuBookingRows`) — which correctly net per `orderLineId` on open-only status — are unaffected.

## Verification
- `npx vitest run src/lib/calc.test.js` → **62/62 pass**; Backlog / FG Booking / Inventory suites unchanged (proves scope isolation).
- Real-data check on the two uploaded ERP files: **36 SKUs** flip from negative to ≥ 0; **11** stay slightly negative (genuine over-shipment / weight variance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwNiTStTSE7VPSNbrL8aBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwNiTStTSE7VPSNbrL8aBQ)_