### PR TITLE
Exclude Delivered orders from Pending to Dispatch KPIs

### DIFF
--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -237,6 +237,14 @@ export const isOpenOrderStatus = (status) => {
   return s !== '' && !['delivered', 'cancelled', 'canceled', 'rejected'].includes(s)
 }
 
+// ── A line's Confirmed / Non-confirmed stop counting toward "Pending to Dispatch" once the
+// order is Delivered (closed) — a delivered order can still carry a non-confirmed remainder
+// (ordered qty never released) that must NOT show as pending. Only 'Delivered' is treated as
+// closed here (deliberately narrower than isOpenOrderStatus): Cancelled/Rejected are already
+// netted to ~0 inside nonConfirmed, and blank stays counted. ──
+export const isDeliveredStatus = (status) =>
+  String(status || '').trim().toLowerCase() === 'delivered'
+
 // ── Open ordered quantity (MT) per SKU, keyed by mmId (== SKU master skuCode). Sums the
 // Quantity of non-deleted, open-status order lines. ──
 export function openOrderQtyBySku(orders) {
@@ -480,9 +488,9 @@ export function skuBookingRows(productions, dispatches, orders, skus) {
 //                        whatever order they belong to.
 //   invoicedVsOrders = Σ min(ordered, invoiced-against-that-line) over these order lines
 //                      → how much of THESE orders has actually been invoiced (period-proof, per line).
-//   pendingDispatch  = Σ (confirmed + nonConfirmed) over that SKU's orders — the SAME "Pending to
-//                      Dispatch" as the Dashboard / Sales cards (salesKpis); NO order-status filter
-//                      (cancellations are already netted inside nonConfirmed). Blank-mmId orders are
+//   pendingDispatch  = Σ (confirmed + nonConfirmed) over that SKU's NON-delivered orders — the SAME
+//                      "Pending to Dispatch" as the Dashboard / Sales cards (salesKpis); Delivered lines
+//                      excluded (cancellations are already netted inside nonConfirmed). Blank-mmId orders are
 //                      bucketed under a "(Unmapped)" row so this total ties out to the Dashboard card.
 //   reserved         = Σ max(0, releaseQty − invoicedQty) over open order lines (reservedBySku, all-time)
 //   inventory        = produced − invoiced                            (producedPool.availableWeight, all-time)
@@ -503,16 +511,18 @@ export function skuInventoryRows(productions, dispatches, orders, skus, inRange 
       invoicedBySku[code] = (invoicedBySku[code] || 0) + Number(be.weight || 0)
     })
   // Order-driven accumulations (period-scoped by order date).
-  // Pending to Dispatch = Σ(confirmed + nonConfirmed) per SKU — identical to the Dashboard / Sales
-  // "Pending to Dispatch" (salesKpis), so this column reconciles with that card. No order-status
-  // filter (cancellations are already netted inside nonConfirmed); blank-mmId orders bucket under
-  // UNMAPPED so the total still ties out. totalOrders / invoicedVsOrders keep the per-line,
-  // non-cancelled accounting used by the rest of the table.
+  // Pending to Dispatch = Σ(confirmed + nonConfirmed) per SKU over NON-delivered orders —
+  // identical to the Dashboard / Sales "Pending to Dispatch" (salesKpis), so this column
+  // reconciles with that card. Delivered lines are excluded (a closed order is no longer
+  // pending); cancellations are already netted inside nonConfirmed; blank-mmId orders bucket
+  // under UNMAPPED so the total still ties out. totalOrders / invoicedVsOrders keep the per-line,
+  // non-cancelled accounting (delivered demand still counts as committed) used by the rest of the table.
   const UNMAPPED = '(Unmapped)'
   const orderedBySku = {}, invoicedVsOrdersBySku = {}, pendingBySku = {}, descByCode = {}
   ;(orders || []).filter(o => !o.deleted && pass(o.orderDate)).forEach(o => {
     const code = String(o.mmId || '').trim() || UNMAPPED
-    pendingBySku[code] = (pendingBySku[code] || 0) + salesNum(o.confirmed) + salesNum(o.nonConfirmed)
+    if (!isDeliveredStatus(o.orderStatus))
+      pendingBySku[code] = (pendingBySku[code] || 0) + salesNum(o.confirmed) + salesNum(o.nonConfirmed)
     if (code === UNMAPPED) return
     if (!descByCode[code]) descByCode[code] = o.description || ''
     if (/cancel|reject/i.test(o.orderStatus || '')) return
@@ -757,9 +767,10 @@ export function distributorSalesRows(orders, dispatches, invByCode = {}, allDisp
 // "Release − Invoiced Qty" and `nonConfirmed` = "Ordered − Release Qty" − "total cancelled qty")
 // and Invoice → `dispatches` (the single invoice source of truth). So the sales KPIs read
 // Confirmed / Non-confirmed off the ORDER book — a carried-forward snapshot, NOT month-scoped —
-// and invoiced tonnage off DISPATCHES:
-//   Confirmed           = Σ orders.confirmed
-//   Non-confirmed       = Σ orders.nonConfirmed
+// counting only NON-delivered lines (a Delivered order is closed, so its leftover confirmed /
+// non-confirmed no longer counts as pending), and invoiced tonnage off DISPATCHES:
+//   Confirmed           = Σ orders.confirmed       (excluding Delivered lines)
+//   Non-confirmed       = Σ orders.nonConfirmed    (excluding Delivered lines)
 //   Pending to Dispatch = Confirmed + Non-confirmed
 //   MTD Invoice         = Σ dispatch bundleEntries.weight in `month` (YYYY-MM; '' ⇒ all months)
 //   Total Orders        = MTD Invoice + Confirmed + Non-confirmed
@@ -769,10 +780,11 @@ const salesNum = (v) => { const n = Number(v); return isFinite(n) ? n : 0 }
 
 // Aggregate KPI totals for the sales cards. Used by BOTH the Sales dashboard and the factory
 // Dashboard so the two screens can never diverge. `month` ('' = all months) scopes the invoiced
-// tonnage only; Confirmed / Non-confirmed are the live order-book snapshot.
+// tonnage only; Confirmed / Non-confirmed are the live order-book snapshot of NON-delivered
+// orders — Delivered lines are excluded (a closed order is no longer pending to dispatch).
 export function salesKpis(orders, dispatches, month = '') {
   let confirmed = 0, nonConfirmed = 0
-  ;(orders || []).filter(o => !o.deleted).forEach(o => {
+  ;(orders || []).filter(o => !o.deleted && !isDeliveredStatus(o.orderStatus)).forEach(o => {
     confirmed += salesNum(o.confirmed)
     nonConfirmed += salesNum(o.nonConfirmed)
   })
@@ -802,7 +814,7 @@ export function salesByDistributor(orders, dispatches, month = '') {
     return r
   }
   const skuOf = (r, code) => (r._sku[code] = r._sku[code] || { id: code, skuCode: code, confirmed: 0, nonConfirmed: 0, mtdInvoice: 0 })
-  ;(orders || []).filter(o => !o.deleted).forEach(o => {
+  ;(orders || []).filter(o => !o.deleted && !isDeliveredStatus(o.orderStatus)).forEach(o => {
     const { key, name } = resolveDistributorIdentity(o, idx, false)
     const r = row(key, name)
     const c = salesNum(o.confirmed), nc = salesNum(o.nonConfirmed)
@@ -836,7 +848,7 @@ export function salesByDistributor(orders, dispatches, month = '') {
 export function salesByMonth(orders, dispatches) {
   const map = {}
   const row = (m) => (map[m] = map[m] || { month: m, confirmed: 0, nonConfirmed: 0, invoiced: 0 })
-  ;(orders || []).filter(o => !o.deleted).forEach(o => {
+  ;(orders || []).filter(o => !o.deleted && !isDeliveredStatus(o.orderStatus)).forEach(o => {
     const m = salesMonthKey(o.orderDate); if (!m) return
     const r = row(m)
     r.confirmed += salesNum(o.confirmed)

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -3,7 +3,7 @@ import {
   fmtT, fmtT3, fmtPct, fmtINR, genHRCoilId, tolerance, periodRange, inDateRange,
   weightPerPieceFromSku, bundleWeightCap, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, dispatchCoilTrace, THICKNESS_TOL_MM,
-  isOpenOrderStatus, openOrderQtyBySku, shippedByOrderLine, orderLineInvoiced, skuBookingRows,
+  isOpenOrderStatus, isDeliveredStatus, openOrderQtyBySku, shippedByOrderLine, orderLineInvoiced, skuBookingRows,
   customerFulfilment, orderBacklog, skuDemandSupply, skuInventoryRows, distributorSalesRows,
   reservedBySku, skuSizeLabel, canonicalSkuKey, requiredStripWidth, WIDTH_TOL_MM,
   distributorCode, normDistributorName, distributorOrderIndex, resolveDistributorIdentity,
@@ -474,6 +474,23 @@ describe('isOpenOrderStatus', () => {
   })
 })
 
+describe('isDeliveredStatus', () => {
+  it('is true only for a Delivered status (case/space-insensitive)', () => {
+    expect(isDeliveredStatus('Delivered')).toBe(true)
+    expect(isDeliveredStatus(' delivered ')).toBe(true)
+    expect(isDeliveredStatus('DELIVERED')).toBe(true)
+  })
+  it('is false for every non-delivered status, including blank (Delivered-only scope)', () => {
+    expect(isDeliveredStatus('Confirmed')).toBe(false)
+    expect(isDeliveredStatus('Delivery in progress')).toBe(false)  // NOT yet delivered → still counts
+    expect(isDeliveredStatus('Cancelled')).toBe(false)             // netted in nonConfirmed, still counts
+    expect(isDeliveredStatus('Rejected')).toBe(false)
+    expect(isDeliveredStatus('')).toBe(false)
+    expect(isDeliveredStatus(null)).toBe(false)
+    expect(isDeliveredStatus(undefined)).toBe(false)
+  })
+})
+
 describe('openOrderQtyBySku', () => {
   it('sums Quantity of open, non-deleted lines per mmId', () => {
     const orders = [
@@ -787,11 +804,11 @@ describe('skuInventoryRows', () => {
     expect(a.free).toBeCloseTo(5)               // inventory 7 − reserved 2
   })
 
-  it('pending to dispatch sums Confirmed + Non-confirmed regardless of order status', () => {
+  it('pending to dispatch excludes Delivered lines (a closed order is no longer pending)', () => {
     const dispatches = [{ deleted: false, bundleEntries: [{ skuCode: 'A', weight: 10 }] }]
     const orders = [{ mmId: 'A', quantity: 6, releaseQty: 6, invoicedQty: 6, orderStatus: 'Delivered', confirmed: 1.5, nonConfirmed: 0.5 }]
     const [a] = skuInventoryRows(productions, dispatches, orders, skus)
-    expect(a.pendingDispatch).toBeCloseTo(2)    // 1.5 + 0.5, counted even though the line is Delivered (no status filter)
+    expect(a.pendingDispatch).toBeCloseTo(0)    // 1.5 + 0.5 NOT counted — the line is Delivered (closed)
     expect(a.reserved).toBe(0)                  // only a delivered line → excluded
     expect(a.inventory).toBeCloseTo(2)          // 12 − 10
     expect(a.free).toBeCloseTo(2)               // inventory − reserved 0
@@ -1102,5 +1119,25 @@ describe('salesKpis / salesByDistributor / salesByMonth (Confirmed / Non-confirm
     expect(jul.totalOrders).toBeCloseTo(35) // 11 + 18 + 6
     expect(jun.confirmed).toBe(5)           // o2
     expect(jun.invoiced).toBeCloseTo(7)     // d3
+  })
+
+  it('excludes Delivered lines from Confirmed / Non-confirmed (Delivered-only; Cancelled still counts)', () => {
+    const withDelivered = [
+      { id: 'k1', deleted: false, orderDate: '2026-07-02', customer: 'Alpha Steel', distributorCode: 'A1', mmId: 'SKU-1', orderStatus: 'Confirmed', confirmed: 10, nonConfirmed: 4 },
+      { id: 'k2', deleted: false, orderDate: '2026-07-03', customer: 'Alpha Steel', distributorCode: 'A1', mmId: 'SKU-1', orderStatus: 'Delivered', confirmed: 1.5, nonConfirmed: 3 },   // closed → excluded
+      { id: 'k3', deleted: false, orderDate: '2026-07-04', customer: 'Alpha Steel', distributorCode: 'A1', mmId: 'SKU-1', orderStatus: 'Cancelled', confirmed: 0, nonConfirmed: 0.5 }, // not delivered → still counted
+    ]
+    const k = salesKpis(withDelivered, [])
+    expect(k.confirmed).toBe(10)        // 10 only; delivered 1.5 dropped
+    expect(k.nonConfirmed).toBe(4.5)    // 4 + cancelled 0.5; delivered 3 dropped
+    expect(k.pending).toBe(14.5)        // 4.5 MT of delivered demand excluded
+
+    const [dist] = salesByDistributor(withDelivered, [])
+    expect(dist.confirmed).toBe(10)
+    expect(dist.nonConfirmed).toBe(4.5)
+
+    const jul = salesByMonth(withDelivered, []).find(r => r.month === '2026-07')
+    expect(jul.confirmed).toBe(10)
+    expect(jul.nonConfirmed).toBe(4.5)
   })
 })


### PR DESCRIPTION
## Summary
Delivered orders are now excluded from "Pending to Dispatch" calculations across all sales KPIs and inventory rows. A delivered order is considered closed and its remaining confirmed/non-confirmed quantities should no longer count as pending.

## Changes
- **New helper function `isDeliveredStatus()`**: Checks if an order status is exactly "Delivered" (case/space-insensitive). Deliberately narrower than `isOpenOrderStatus()` to treat only Delivered as closed, while Cancelled/Rejected remain counted (already netted in `nonConfirmed`).

- **Updated `skuInventoryRows()`**: Filter out Delivered lines when accumulating `pendingBySku`. Delivered demand still counts toward `totalOrders` and `invoicedVsOrders` (committed demand), but no longer inflates the pending-to-dispatch metric.

- **Updated `salesKpis()`**: Filter orders to exclude Delivered status before summing `confirmed` and `nonConfirmed`.

- **Updated `salesByDistributor()`**: Apply the same Delivered filter when aggregating per-distributor KPIs.

- **Updated `salesByMonth()`**: Apply the same Delivered filter when aggregating per-month KPIs.

- **Documentation**: Clarified comments throughout to explain that Delivered lines are excluded (a closed order is no longer pending), while Cancelled/Rejected remain counted (already netted), and blank-mmId orders still bucket under "(Unmapped)".

## Implementation Details
- The filter `!isDeliveredStatus(o.orderStatus)` is applied consistently at the order-level before accumulation, ensuring the same logic applies across Dashboard, Sales cards, and inventory tables.
- Delivered lines still contribute to `totalOrders` and `invoicedVsOrders` (they represent committed demand), but are excluded only from the pending-to-dispatch sum.
- Test coverage added: `isDeliveredStatus()` unit tests and an integration test verifying that Delivered lines are excluded while Cancelled lines (not yet delivered) remain counted.

https://claude.ai/code/session_01FMzTC5QjK4dGshNCoQJ8CJ