### PR TITLE
Resolve SKU-wise Inventory Description from all orders (not just in-period)

### DIFF
--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -519,12 +519,17 @@ export function skuInventoryRows(productions, dispatches, orders, skus, inRange 
   // non-cancelled accounting (delivered demand still counts as committed) used by the rest of the table.
   const UNMAPPED = '(Unmapped)'
   const orderedBySku = {}, invoicedVsOrdersBySku = {}, pendingBySku = {}, descByCode = {}
+  // Description is resolved from ALL orders (period-independent), so a row kept visible by all-time
+  // Production/Reserved still shows its tube name instead of falling back to the raw SKU code.
+  ;(orders || []).filter(o => !o.deleted).forEach(o => {
+    const code = String(o.mmId || '').trim()
+    if (code && !descByCode[code] && o.description) descByCode[code] = o.description
+  })
   ;(orders || []).filter(o => !o.deleted && pass(o.orderDate)).forEach(o => {
     const code = String(o.mmId || '').trim() || UNMAPPED
     if (!isDeliveredStatus(o.orderStatus))
       pendingBySku[code] = (pendingBySku[code] || 0) + salesNum(o.confirmed) + salesNum(o.nonConfirmed)
     if (code === UNMAPPED) return
-    if (!descByCode[code]) descByCode[code] = o.description || ''
     if (/cancel|reject/i.test(o.orderStatus || '')) return
     const qty = Number(o.quantity || 0)
     const inv = orderLineInvoiced(o, shipped)

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -865,6 +865,16 @@ describe('skuInventoryRows', () => {
     expect(rows.find(r => r.skuCode === 'A').pendingDispatch).toBeCloseTo(6)          // (2+3) + (0+1)
     expect(rows.find(r => r.skuCode === '(Unmapped)').pendingDispatch).toBeCloseTo(4) // 4 + 0
   })
+
+  it('resolves the description from all orders even when the period filter excludes them', () => {
+    const orders = [{ mmId: 'A', releaseQty: 5, invoicedQty: 0, orderStatus: 'Confirmed',
+      orderDate: '2026-05-01', description: 'MS RHS 100x50x2', confirmed: 5, nonConfirmed: 0 }]
+    const inRange = (d) => d >= '2026-06-01' && d <= '2026-06-30' // excludes the May order
+    const [a] = skuInventoryRows(productions, [], orders, [], inRange) // empty SKU master
+    expect(a.description).toBe('MS RHS 100x50x2') // from the order, despite being out of period
+    expect(a.pendingDispatch).toBe(0)             // out of period → not counted
+    expect(a.reserved).toBe(5)                    // all-time (5 − 0)
+  })
 })
 
 describe('orderLineInvoiced', () => {


### PR DESCRIPTION
## Problem

In the **SKU-wise Inventory** table, the **Description** column sometimes showed the raw SKU code duplicated in place of the tube name (e.g. `1140-13075-10074984` appearing in *both* the Code and Description columns).

Description is resolved as `SKU-master description → the order's own description → the raw code`. The order-supplied description was built **only inside the period-scoped order loop**, while a row can still be visible because **Production and Reserved are all-time**. So when the active period filter excluded a SKU's orders (Pending to Dispatch = 0 for that row), the description had no source and fell back to the code.

## Fix

Build `descByCode` in a period-independent pre-pass over **all** non-deleted orders, so a row surfaced by all-time Production/Reserved still shows its tube name. The in-loop assignment is removed; the SKU-master lookup still wins first, and the `(Unmapped)` bucket keeps its fixed label.

Single-function change in `skuInventoryRows` (`src/lib/calc.js`). The pending / Delivered-exclusion logic (`isDeliveredStatus`, from #60) is left untouched.

## Testing

- Added a calc test: an out-of-period order still supplies its Description (`pendingDispatch` stays 0, `reserved` is the all-time value).
- `npx vitest run` → **126 tests passing**.
- `npm run build` → clean.

Branch is rebased on the latest `main` (already includes #59 and #60), so it merges with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCzgqAzbvLVnpfrpYwFkQQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCzgqAzbvLVnpfrpYwFkQQ)_