### PR TITLE
Add pb-mtd-report and daily-report-pt-whatsapp skills

### DIFF
--- a/.claude/skills/daily-report-pt-whatsapp/SKILL.md
+++ b/.claude/skills/daily-report-pt-whatsapp/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: daily-report-pt-whatsapp
+description: >-
+  Produce the JSW Pipes & Tubes daily PB MTD update as a WhatsApp-ready message —
+  concise, mobile-friendly, WhatsApp-formatted (*bold*, emojis, no tables), ready to
+  copy-paste into a WhatsApp chat/broadcast. Reuses the pb-mtd-report numbers (same
+  verified figures, no drift). Trigger phrases: "daily P&T whatsapp report",
+  "whatsapp daily report", "daily report P&T", "P&T whatsapp update".
+---
+
+# Daily P&T report — WhatsApp format
+
+Renders the daily **PB MTD update** for Pipes & Tubes as a WhatsApp message the plant team can
+paste straight into a chat/broadcast. This skill is **presentation only** — all numbers and their
+verification come from the `pb-mtd-report` skill, so the WhatsApp text can never disagree with the
+full report.
+
+## Inputs
+- `report_date` — optional `YYYY-MM-DD`, default today. Passed through to `pb-mtd-report`.
+- `best_estimate` — optional monthly target (MT). Passed through. If omitted, drop the
+  "Best Estimate" and "Run Rate Reqd" lines from the message (don't print N/A on WhatsApp).
+
+## Steps
+
+### 1 — Get verified numbers
+Run the **`pb-mtd-report`** skill (same `report_date` / `best_estimate`) to obtain the verified,
+Dashboard-aligned figures and its verification result. Use those values verbatim — do **not**
+recompute here. (If `pb-mtd-report` is unavailable, fall back to its SQL steps against project
+`hztblmccvvarmgxmunrp`.) If pb-mtd-report reports a FAILED verification check, **say so above the
+message** and let the user decide before sending.
+
+### 2 — Render the WhatsApp message
+Fill the template below. WhatsApp formatting rules: `*bold*` = single asterisks, `_italic_` =
+underscores, emojis for scan-ability, **no markdown tables/headers**, one metric per line with a
+`•` bullet, blank line between groups. Keep it short — only real numbers, never the N/A lines.
+Weights to 1 decimal, append ` T`; a true zero stays `0 T`.
+
+```
+*JSW Pipes & Tubes — Daily Update*
+📅 {D:DD-Mon-YYYY}
+
+*📦 Orders*
+• Total Orders: {total_orders} T
+• Current Month: {orders_month_intake} T
+• Confirmed (pending invoice): {confirmed} T
+• Non-Confirmed: {non_confirmed} T
+
+*🚚 Invoiced / Dispatch*
+• Invoiced MTD: {invoiced_mtd} T
+• Prev Month (same days): {invoiced_prev} T
+• Dispatch D-1: {dispatch_D1} T
+• Dispatch Today: {dispatch_D} T
+
+*📝 Orders Logged*
+• Today: {orders_D} T   •  D-1: {orders_D1} T   •  D-2: {orders_D2} T
+
+*🎯 Targets*   (omit this whole block if no best_estimate)
+• Best Estimate (Jul): {best_estimate} T
+• Daily Run Rate Reqd: {run_rate} T
+
+*🏭 Inventory*
+• Finished Pipe (FG): {phys_inventory} T
+
+_Live data · generated {D}_
+```
+
+Notes to preserve when filling:
+- **Prev Month (same days)** = previous month invoiced through the same day-of-month (like-for-like).
+- **Finished Pipe (FG)** = Dashboard FG Left Inventory (produced live-recompute − invoiced).
+- If today's data isn't loaded yet (Dispatch Today / Orders Logged Today = 0 because
+  `report_date` is after the latest loaded date), add a final line:
+  `⚠️ _Today's dispatch/orders not yet loaded_` so a 0 isn't read as "no business".
+
+### 3 — Output
+1. Print the finished message inside a plain code block so it copy-pastes cleanly.
+2. Offer to save it to `reports/daily-whatsapp-{D}.txt` (only if the user wants a file).
+
+## Sending to WhatsApp
+There is **no WhatsApp integration wired into this repo**, so this skill produces copy-paste text
+by default. To actually auto-send, one of these must be set up (offer, don't assume):
+- **WhatsApp Business Cloud API** (Meta) — POST the text to `/{phone-number-id}/messages` with a
+  permanent token; best for a fixed broadcast/group.
+- **Twilio WhatsApp API** — `messages.create({ from: 'whatsapp:…', to: 'whatsapp:…', body })`.
+Either needs credentials + recipient(s) the user provides; then add a small script/edge function
+and this skill can call it. Never hard-code tokens in the repo — read from env.
+
+## Guardrails
+- Numbers come from `pb-mtd-report` — never invent or re-derive them here.
+- No tables, headers, or links that render poorly on WhatsApp; keep it thumb-scrollable.
+- Don't print the "not relevant / not possible" lines on WhatsApp — they live in the full report.

--- a/.claude/skills/daily-report-pt-whatsapp/SKILL.md
+++ b/.claude/skills/daily-report-pt-whatsapp/SKILL.md
@@ -52,7 +52,9 @@ Weights to 1 decimal, append ` T`; a true zero stays `0 T`.
 • Dispatch Today: {dispatch_D} T
 
 *📝 Orders Logged*
-• Today: {orders_D} T   •  D-1: {orders_D1} T   •  D-2: {orders_D2} T
+• Today: {orders_D} T
+• D-1: {orders_D1} T
+• D-2: {orders_D2} T
 
 *🎯 Targets*   (omit this whole block if no best_estimate)
 • Best Estimate (Jul): {best_estimate} T

--- a/.claude/skills/daily-report-pt-whatsapp/SKILL.md
+++ b/.claude/skills/daily-report-pt-whatsapp/SKILL.md
@@ -69,9 +69,6 @@ _Live data · generated {D}_
 Notes to preserve when filling:
 - **Prev Month (same days)** = previous month invoiced through the same day-of-month (like-for-like).
 - **Finished Pipe (FG)** = Dashboard FG Left Inventory (produced live-recompute − invoiced).
-- If today's data isn't loaded yet (Dispatch Today / Orders Logged Today = 0 because
-  `report_date` is after the latest loaded date), add a final line:
-  `⚠️ _Today's dispatch/orders not yet loaded_` so a 0 isn't read as "no business".
 
 ### 3 — Output
 1. Print the finished message inside a plain code block so it copy-pastes cleanly.

--- a/.claude/skills/pb-mtd-report/SKILL.md
+++ b/.claude/skills/pb-mtd-report/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: pb-mtd-report
+description: >-
+  Generate the "PB MTD Update" order/invoice report for JSW Pipes & Tubes from
+  the latest Supabase data, in one instruction. Fetches live numbers, computes
+  only the lines that are relevant + possible for P&T, VERIFIES every figure by a
+  second independent method, COMPARES against the previous report snapshot, and
+  writes reports/PB-MTD-Update-<date>.md. Trigger phrases: "PB MTD update",
+  "PB MTD report", "pipes MTD report", "generate the MTD report".
+---
+
+# PB MTD Update report (Pipes & Tubes)
+
+Reproduce the JSW **PB MTD update** layout for this Pipes & Tubes system with **live**
+Supabase numbers. This template originates from the JSW rebar/"PB" business — about a
+third of its lines have **no analog** in P&T and are deliberately excluded (see
+"Excluded lines"). The report leads with only the lines that are **relevant to P&T AND
+computable**, and **must** end with a verification block.
+
+## Inputs
+- `report_date` — optional, `YYYY-MM-DD`. Default = **today**. Drives D / D-1 / D-2,
+  current month, previous month.
+- `best_estimate` — optional, monthly target in MT (e.g. `2500`). There is **no forecast
+  field in the system**, so this is manual. If omitted, output `Revised Best Estimate`
+  and `Daily Run Rate Required` as `⚠️ N/A`. If supplied, compute the run rate.
+
+## Data source
+Supabase project **"Pipes and Tubes Inventory System"**, ref **`hztblmccvvarmgxmunrp`**
+(query via the Supabase MCP `execute_sql`). If that ref is wrong, resolve it with
+`list_projects` by name — do not guess. All weights are **MT (T)**. Numbers are the
+plant's own source of truth; do not invent or interpolate.
+
+## Source-of-truth alignment (must match the app)
+These figures must reproduce the app's own KPIs (`src/lib/calc.js`, `src/lib/reports.js`):
+- **Confirmed / Non-confirmed** = `salesKpis()` — Σ `orders.confirmed` / `orders.non_confirmed`
+  over non-deleted lines whose `order_status` is **not** `delivered` (`isDeliveredStatus`).
+- **Invoiced MTD** = Σ `dispatches.bundle_entries[].weight` for the month (== `theoretical_weight`).
+- **Physical Inventory** = finished pipe stock = per-SKU `max(0, produced − invoiced)`
+  (`producedPool` / `buildFinishedStockData`, floored at 0).
+
+## Steps
+
+### 1 — Resolve dates
+From `report_date`: `D` = report_date, `D-1`/`D-2` = minus 1/2 **calendar** days,
+`MONTH` = `YYYY-MM`, `PREV` = previous calendar month.
+
+### 2 — Core metrics (substitute the date literals)
+```sql
+SELECT 'max_order_date' AS metric, max(order_date)::text AS val FROM orders WHERE deleted=false
+UNION ALL SELECT 'max_dispatch_date', max(date_of_dispatch)::text FROM dispatches WHERE deleted=false
+UNION ALL SELECT 'invoiced_mtd',      coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND to_char(date_of_dispatch,'YYYY-MM')='{{MONTH}}'
+UNION ALL SELECT 'invoiced_prev',     coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND to_char(date_of_dispatch,'YYYY-MM')='{{PREV}}'
+UNION ALL SELECT 'dispatch_D',        coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND date_of_dispatch='{{D}}'
+UNION ALL SELECT 'dispatch_D1',       coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND date_of_dispatch='{{D-1}}'
+UNION ALL SELECT 'orders_month_intake', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted=false AND to_char(order_date,'YYYY-MM')='{{MONTH}}'
+UNION ALL SELECT 'orders_D',  coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted=false AND order_date='{{D}}'
+UNION ALL SELECT 'orders_D1', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted=false AND order_date='{{D-1}}'
+UNION ALL SELECT 'orders_D2', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted=false AND order_date='{{D-2}}'
+UNION ALL SELECT 'confirmed',     coalesce(round(sum(confirmed)::numeric,1),0)::text     FROM orders WHERE deleted=false AND lower(trim(coalesce(order_status,'')))<>'delivered'
+UNION ALL SELECT 'non_confirmed', coalesce(round(sum(non_confirmed)::numeric,1),0)::text FROM orders WHERE deleted=false AND lower(trim(coalesce(order_status,'')))<>'delivered';
+```
+
+### 3 — Physical inventory (floored, per SKU)
+```sql
+WITH prod AS (SELECT sku_code, sum(total_weight) w FROM productions WHERE deleted=false GROUP BY sku_code),
+disp AS (SELECT be->>'skuCode' AS sku_code, sum((be->>'weight')::numeric) w
+         FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) be
+         WHERE d.deleted=false GROUP BY 1)
+SELECT round(sum(greatest(0, coalesce(p.w,0)-coalesce(dp.w,0)))::numeric,0) AS phys_inventory,
+       round(sum(coalesce(p.w,0)-coalesce(dp.w,0))::numeric,0)              AS fg_net_unfloored,
+       count(*) FILTER (WHERE coalesce(p.w,0)-coalesce(dp.w,0) < -0.0005)    AS oversold_skus
+FROM prod p FULL OUTER JOIN disp dp USING (sku_code);
+```
+
+### 4 — Derived
+- **Total Orders** = `invoiced_mtd + confirmed + non_confirmed` (app "Total Orders" KPI).
+- **Daily Run Rate Required** (only if `best_estimate` given) =
+  `(best_estimate − invoiced_mtd) / days_remaining`, where `days_remaining` =
+  `(last calendar day of MONTH) − report_date` inclusive of remaining days.
+  Note in output: **calendar** days, not working days (no holiday/Sunday calendar exists).
+
+### 5 — VERIFY (mandatory — never skip)
+Run these independent cross-checks and render a **Verification** table (metric ·
+method A · method B · verdict). Report **PASS/FAIL** and surface every flag:
+```sql
+-- Invoiced dual-method: line-sum vs theoretical_weight (must be ~0 diff)
+WITH lines AS (SELECT to_char(d.date_of_dispatch,'YYYY-MM') ym, (e->>'weight')::numeric w
+  FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) e WHERE d.deleted=false)
+SELECT ym, round(sum(w)::numeric,3) method_a FROM lines WHERE ym IN ('{{MONTH}}','{{PREV}}') GROUP BY ym;
+-- Confirmed dual-method: stored bucket vs ERP formula (Release - Invoiced)
+SELECT round(sum(confirmed)::numeric,3) stored, round(sum(release_qty-invoiced_qty)::numeric,3) derived
+  FROM orders WHERE deleted=false AND lower(trim(coalesce(order_status,'')))<>'delivered';
+```
+Checks that MUST hold (else FAIL and flag):
+1. **Invoiced dual-method** — `Σ line weights` == `Σ theoretical_weight` for MONTH and PREV (diff ≤ 0.01).
+2. **Partition** — `Σ daily dispatch in MONTH` == `invoiced_mtd`; `Σ daily orders in MONTH` == `orders_month_intake`.
+3. **Arithmetic** — `Total Orders` == `invoiced_mtd + confirmed + non_confirmed`.
+4. **Freshness** — report `max_order_date` / `max_dispatch_date`; if a `D`/`D-1` value is 0 **and** that date is after the max, label it "no data loaded yet" (not zero activity).
+Advisory flags (report, do not fail):
+- **Confirmed variance** — `confirmed(stored)` vs `release−invoiced`; if they differ, note the delta. The report uses the **stored** bucket (app-consistent).
+- **Oversold SKUs** — `oversold_skus` count and `fg_net_unfloored`; the report uses the **floored** figure (app-consistent).
+
+### 6 — COMPARE against previous snapshot
+Find the most recent `reports/PB-MTD-Update-*.md` (before this run), parse its values, and
+render a **Change vs last report** table (per line: previous → current → Δ). If none exists,
+say so.
+
+### 7 — Emit
+Write `reports/PB-MTD-Update-{{D}}.md` with: the report block (exact format below), the
+Verification table, and the Change-vs-last table. Also print the report block in chat.
+
+## Report block (exact format — tab-separated, `--->` then value + `T`)
+```
+PB MTD update as on --->	{{D}}
+Revised Best Estimate --->	{best_estimate}T        (omit line's value → ⚠️ N/A if not supplied)
+Total Orders --->	{total_orders}T
+Current Month Orders --->	{orders_month_intake}T
+Invoiced Orders MTD --->	{invoiced_mtd}T
+Invoiced MTD (Previous Month) --->	{invoiced_prev}T
+Dispatch D-1 (Current Month) --->	{dispatch_D1}T
+Dispatch D Day --->	{dispatch_D}T
+Confirmed Orders Pending to be Invoiced --->	{confirmed}T
+Non-Confirmed Orders --->	{non_confirmed}T
+Daily Run Rate Required --->	{run_rate}T       (⚠️ N/A if no best_estimate)
+Physical Inventory --->	{phys_inventory}T
+	
+Orders Logged D Day --->	{orders_D}T
+Orders Logged D-1 --->	{orders_D1}T
+Orders Logged D-2 --->	{orders_D2}T
+```
+
+## Excluded lines (keep excluded — reason on request)
+- **Retail / Distributor Through Project / Project Orders** (order & invoiced splits) —
+  🚫 not relevant: `orders` has **no order-category dimension** (no such column in the schema).
+- **Invoiced MTD-FE 550 / FE 550D - LRF**, **Physical Inventory · FE 550 / FE 550D** —
+  🚫 not relevant: FE 550/550D are **TMT rebar** grades. P&T `coils.coil_grade` holds
+  **IS 10748** HR-coil variants; finished pipe carries no grade at all.
+- **Carry-forward Orders** — ⚠️ not tracked (prior-month open-book proxy computes to ~0).
+- **SFDC Orders** — ⚠️ no SFDC flag; `distributor_code` values ARE Salesforce IDs, so all
+  orders are effectively SFDC — no separable subset.
+
+## Guardrails
+- Never fabricate the excluded lines' numbers. If asked to include them, explain the missing
+  field/dimension first.
+- Keep decimals to 1 place for weights (Physical Inventory to whole T). `0T` stays `0T`.
+- If a query errors or a check FAILs, stop and report it — do not emit a report with
+  unverified numbers.

--- a/.claude/skills/pb-mtd-report/SKILL.md
+++ b/.claude/skills/pb-mtd-report/SKILL.md
@@ -34,22 +34,27 @@ plant's own source of truth; do not invent or interpolate.
 These figures must reproduce the app's own KPIs (`src/lib/calc.js`, `src/lib/reports.js`):
 - **Confirmed / Non-confirmed** = `salesKpis()` — Σ `orders.confirmed` / `orders.non_confirmed`
   over non-deleted lines whose `order_status` is **not** `delivered` (`isDeliveredStatus`).
-- **Invoiced MTD** = Σ `dispatches.bundle_entries[].weight` for the month (== `theoretical_weight`).
-- **Physical Inventory** = finished pipe stock = per-SKU `max(0, produced − invoiced)`
-  (`producedPool` / `buildFinishedStockData`, floored at 0).
+- **Invoiced MTD** = Σ `dispatches.bundle_entries[].weight` for the month through `D` (== `theoretical_weight`).
+- **Invoiced MTD (Previous Month)** = the **same day-of-month window** of the prior month
+  (e.g. Jun 1..DAY), for a like-for-like pace comparison — **not** the full prior month.
+- **Physical Inventory** = finished pipe stock = **total produced − total invoiced** (plant-level
+  net; `producedPool` nets and does NOT floor). Not floored per SKU — production logs short SKU
+  codes (`SHS-75x75x2.00`) while dispatch logs ERP MM codes/descriptions, so per-SKU flooring
+  over-counts already-shipped pipe.
 
 ## Steps
 
 ### 1 — Resolve dates
 From `report_date`: `D` = report_date, `D-1`/`D-2` = minus 1/2 **calendar** days,
-`MONTH` = `YYYY-MM`, `PREV` = previous calendar month.
+`DAY` = day-of-month of `D` (e.g. 10), `MONTH` = `YYYY-MM`, `PREV` = previous calendar month.
 
 ### 2 — Core metrics (substitute the date literals)
 ```sql
 SELECT 'max_order_date' AS metric, max(order_date)::text AS val FROM orders WHERE deleted=false
 UNION ALL SELECT 'max_dispatch_date', max(date_of_dispatch)::text FROM dispatches WHERE deleted=false
-UNION ALL SELECT 'invoiced_mtd',      coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND to_char(date_of_dispatch,'YYYY-MM')='{{MONTH}}'
-UNION ALL SELECT 'invoiced_prev',     coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND to_char(date_of_dispatch,'YYYY-MM')='{{PREV}}'
+UNION ALL SELECT 'invoiced_mtd',      coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND to_char(date_of_dispatch,'YYYY-MM')='{{MONTH}}' AND date_of_dispatch <= '{{D}}'
+-- Previous month MTD = same day-of-month window (Jun 1..DAY), NOT the full prior month — a like-for-like pace comparison.
+UNION ALL SELECT 'invoiced_prev',     coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND to_char(date_of_dispatch,'YYYY-MM')='{{PREV}}' AND extract(day from date_of_dispatch) <= {{DAY}}
 UNION ALL SELECT 'dispatch_D',        coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND date_of_dispatch='{{D}}'
 UNION ALL SELECT 'dispatch_D1',       coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND date_of_dispatch='{{D-1}}'
 UNION ALL SELECT 'orders_month_intake', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted=false AND to_char(order_date,'YYYY-MM')='{{MONTH}}'
@@ -60,17 +65,24 @@ UNION ALL SELECT 'confirmed',     coalesce(round(sum(confirmed)::numeric,1),0)::
 UNION ALL SELECT 'non_confirmed', coalesce(round(sum(non_confirmed)::numeric,1),0)::text FROM orders WHERE deleted=false AND lower(trim(coalesce(order_status,'')))<>'delivered';
 ```
 
-### 3 — Physical inventory (floored, per SKU)
+### 3 — Physical inventory (finished pipe stock = plant-level net)
+Finished pipe on hand is a **tonnage** KPI: total produced − total invoiced, netted at the plant
+level. **Do NOT floor per SKU** — production logs short SKU codes while dispatch logs ERP MM
+codes/descriptions, so per-SKU flooring double-counts already-shipped pipe (it created 17 false
+"oversold" SKUs, +~89 T). The plant-level net is SKU-code-agnostic and correct.
 ```sql
-WITH prod AS (SELECT sku_code, sum(total_weight) w FROM productions WHERE deleted=false GROUP BY sku_code),
-disp AS (SELECT be->>'skuCode' AS sku_code, sum((be->>'weight')::numeric) w
+SELECT
+  round((SELECT sum(total_weight) FROM productions WHERE deleted=false)::numeric,1) AS total_produced,
+  round((SELECT sum((be->>'weight')::numeric)
          FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) be
-         WHERE d.deleted=false GROUP BY 1)
-SELECT round(sum(greatest(0, coalesce(p.w,0)-coalesce(dp.w,0)))::numeric,0) AS phys_inventory,
-       round(sum(coalesce(p.w,0)-coalesce(dp.w,0))::numeric,0)              AS fg_net_unfloored,
-       count(*) FILTER (WHERE coalesce(p.w,0)-coalesce(dp.w,0) < -0.0005)    AS oversold_skus
-FROM prod p FULL OUTER JOIN disp dp USING (sku_code);
+         WHERE d.deleted=false)::numeric,1)                                          AS total_invoiced,
+  round(((SELECT sum(total_weight) FROM productions WHERE deleted=false)
+       - (SELECT sum((be->>'weight')::numeric)
+          FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) be
+          WHERE d.deleted=false))::numeric,0)                                        AS phys_inventory;
 ```
+Advisory (optional data-hygiene check): count production `sku_code`s with no matching dispatch
+`skuCode` and vice-versa; a growing gap means the SKU master needs deduping (short code vs MM code).
 
 ### 4 — Derived
 - **Total Orders** = `invoiced_mtd + confirmed + non_confirmed` (app "Total Orders" KPI).
@@ -83,22 +95,25 @@ FROM prod p FULL OUTER JOIN disp dp USING (sku_code);
 Run these independent cross-checks and render a **Verification** table (metric ·
 method A · method B · verdict). Report **PASS/FAIL** and surface every flag:
 ```sql
--- Invoiced dual-method: line-sum vs theoretical_weight (must be ~0 diff)
-WITH lines AS (SELECT to_char(d.date_of_dispatch,'YYYY-MM') ym, (e->>'weight')::numeric w
+-- Invoiced dual-method (day-capped slices): line-sum must equal theoretical_weight for each
+WITH lines AS (SELECT d.date_of_dispatch dt, (e->>'weight')::numeric w
   FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) e WHERE d.deleted=false)
-SELECT ym, round(sum(w)::numeric,3) method_a FROM lines WHERE ym IN ('{{MONTH}}','{{PREV}}') GROUP BY ym;
+SELECT
+  round(sum(w) FILTER (WHERE to_char(dt,'YYYY-MM')='{{MONTH}}' AND dt <= '{{D}}')::numeric,3)                   AS cur_lines,
+  round(sum(w) FILTER (WHERE to_char(dt,'YYYY-MM')='{{PREV}}' AND extract(day from dt) <= {{DAY}})::numeric,3)  AS prev_lines
+FROM lines;
 -- Confirmed dual-method: stored bucket vs ERP formula (Release - Invoiced)
 SELECT round(sum(confirmed)::numeric,3) stored, round(sum(release_qty-invoiced_qty)::numeric,3) derived
   FROM orders WHERE deleted=false AND lower(trim(coalesce(order_status,'')))<>'delivered';
 ```
 Checks that MUST hold (else FAIL and flag):
-1. **Invoiced dual-method** — `Σ line weights` == `Σ theoretical_weight` for MONTH and PREV (diff ≤ 0.01).
-2. **Partition** — `Σ daily dispatch in MONTH` == `invoiced_mtd`; `Σ daily orders in MONTH` == `orders_month_intake`.
+1. **Invoiced dual-method** — `cur_lines` == `invoiced_mtd` and `prev_lines` == `invoiced_prev` (diff ≤ 0.01).
+2. **Partition** — `Σ daily dispatch in MONTH up to D` == `invoiced_mtd`; `Σ daily orders in MONTH` == `orders_month_intake`.
 3. **Arithmetic** — `Total Orders` == `invoiced_mtd + confirmed + non_confirmed`.
 4. **Freshness** — report `max_order_date` / `max_dispatch_date`; if a `D`/`D-1` value is 0 **and** that date is after the max, label it "no data loaded yet" (not zero activity).
 Advisory flags (report, do not fail):
 - **Confirmed variance** — `confirmed(stored)` vs `release−invoiced`; if they differ, note the delta. The report uses the **stored** bucket (app-consistent).
-- **Oversold SKUs** — `oversold_skus` count and `fg_net_unfloored`; the report uses the **floored** figure (app-consistent).
+- **FG reconciliation** — `phys_inventory` == `total_produced − total_invoiced` (plant-level net, not per-SKU floored). Flag if SKU-code mismatches (short code vs ERP MM code) are growing.
 
 ### 6 — COMPARE against previous snapshot
 Find the most recent `reports/PB-MTD-Update-*.md` (before this run), parse its values, and

--- a/.claude/skills/pb-mtd-report/SKILL.md
+++ b/.claude/skills/pb-mtd-report/SKILL.md
@@ -50,20 +50,22 @@ From `report_date`: `D` = report_date, `D-1`/`D-2` = minus 1/2 **calendar** days
 `DAY` = day-of-month of `D` (e.g. 10), `MONTH` = `YYYY-MM`, `PREV` = previous calendar month.
 
 ### 2 — Core metrics (substitute the date literals)
+Filters use `deleted IS NOT TRUE` (not `deleted = false`) to match the app's `!deleted`, which also
+keeps rows where `deleted` is NULL — so the skill can never diverge from the Dashboard.
 ```sql
-SELECT 'max_order_date' AS metric, max(order_date)::text AS val FROM orders WHERE deleted=false
-UNION ALL SELECT 'max_dispatch_date', max(date_of_dispatch)::text FROM dispatches WHERE deleted=false
-UNION ALL SELECT 'invoiced_mtd',      coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND to_char(date_of_dispatch,'YYYY-MM')='{{MONTH}}' AND date_of_dispatch <= '{{D}}'
+SELECT 'max_order_date' AS metric, max(order_date)::text AS val FROM orders WHERE deleted IS NOT TRUE
+UNION ALL SELECT 'max_dispatch_date', max(date_of_dispatch)::text FROM dispatches WHERE deleted IS NOT TRUE
+UNION ALL SELECT 'invoiced_mtd',      coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted IS NOT TRUE AND to_char(date_of_dispatch,'YYYY-MM')='{{MONTH}}' AND date_of_dispatch <= '{{D}}'
 -- Previous month MTD = same day-of-month window (Jun 1..DAY), NOT the full prior month — a like-for-like pace comparison.
-UNION ALL SELECT 'invoiced_prev',     coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND to_char(date_of_dispatch,'YYYY-MM')='{{PREV}}' AND extract(day from date_of_dispatch) <= {{DAY}}
-UNION ALL SELECT 'dispatch_D',        coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND date_of_dispatch='{{D}}'
-UNION ALL SELECT 'dispatch_D1',       coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted=false AND date_of_dispatch='{{D-1}}'
-UNION ALL SELECT 'orders_month_intake', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted=false AND to_char(order_date,'YYYY-MM')='{{MONTH}}'
-UNION ALL SELECT 'orders_D',  coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted=false AND order_date='{{D}}'
-UNION ALL SELECT 'orders_D1', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted=false AND order_date='{{D-1}}'
-UNION ALL SELECT 'orders_D2', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted=false AND order_date='{{D-2}}'
-UNION ALL SELECT 'confirmed',     coalesce(round(sum(confirmed)::numeric,1),0)::text     FROM orders WHERE deleted=false AND lower(trim(coalesce(order_status,'')))<>'delivered'
-UNION ALL SELECT 'non_confirmed', coalesce(round(sum(non_confirmed)::numeric,1),0)::text FROM orders WHERE deleted=false AND lower(trim(coalesce(order_status,'')))<>'delivered';
+UNION ALL SELECT 'invoiced_prev',     coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted IS NOT TRUE AND to_char(date_of_dispatch,'YYYY-MM')='{{PREV}}' AND extract(day from date_of_dispatch) <= {{DAY}}
+UNION ALL SELECT 'dispatch_D',        coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted IS NOT TRUE AND date_of_dispatch='{{D}}'
+UNION ALL SELECT 'dispatch_D1',       coalesce(round(sum(theoretical_weight)::numeric,1),0)::text FROM dispatches WHERE deleted IS NOT TRUE AND date_of_dispatch='{{D-1}}'
+UNION ALL SELECT 'orders_month_intake', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted IS NOT TRUE AND to_char(order_date,'YYYY-MM')='{{MONTH}}'
+UNION ALL SELECT 'orders_D',  coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted IS NOT TRUE AND order_date='{{D}}'
+UNION ALL SELECT 'orders_D1', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted IS NOT TRUE AND order_date='{{D-1}}'
+UNION ALL SELECT 'orders_D2', coalesce(round(sum(quantity)::numeric,1),0)::text FROM orders WHERE deleted IS NOT TRUE AND order_date='{{D-2}}'
+UNION ALL SELECT 'confirmed',     coalesce(round(sum(confirmed)::numeric,1),0)::text     FROM orders WHERE deleted IS NOT TRUE AND lower(trim(coalesce(order_status,'')))<>'delivered'
+UNION ALL SELECT 'non_confirmed', coalesce(round(sum(non_confirmed)::numeric,1),0)::text FROM orders WHERE deleted IS NOT TRUE AND lower(trim(coalesce(order_status,'')))<>'delivered';
 ```
 
 ### 3 — Physical inventory (finished pipe stock = Dashboard FG Left Inventory)
@@ -105,14 +107,14 @@ method A · method B · verdict). Report **PASS/FAIL** and surface every flag:
 ```sql
 -- Invoiced dual-method (day-capped slices): line-sum must equal theoretical_weight for each
 WITH lines AS (SELECT d.date_of_dispatch dt, (e->>'weight')::numeric w
-  FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) e WHERE d.deleted=false)
+  FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) e WHERE d.deleted IS NOT TRUE)
 SELECT
   round(sum(w) FILTER (WHERE to_char(dt,'YYYY-MM')='{{MONTH}}' AND dt <= '{{D}}')::numeric,3)                   AS cur_lines,
   round(sum(w) FILTER (WHERE to_char(dt,'YYYY-MM')='{{PREV}}' AND extract(day from dt) <= {{DAY}})::numeric,3)  AS prev_lines
 FROM lines;
 -- Confirmed dual-method: stored bucket vs ERP formula (Release - Invoiced)
 SELECT round(sum(confirmed)::numeric,3) stored, round(sum(release_qty-invoiced_qty)::numeric,3) derived
-  FROM orders WHERE deleted=false AND lower(trim(coalesce(order_status,'')))<>'delivered';
+  FROM orders WHERE deleted IS NOT TRUE AND lower(trim(coalesce(order_status,'')))<>'delivered';
 ```
 Checks that MUST hold (else FAIL and flag):
 1. **Invoiced dual-method** — `cur_lines` == `invoiced_mtd` and `prev_lines` == `invoiced_prev` (diff ≤ 0.01).

--- a/.claude/skills/pb-mtd-report/SKILL.md
+++ b/.claude/skills/pb-mtd-report/SKILL.md
@@ -37,10 +37,11 @@ These figures must reproduce the app's own KPIs (`src/lib/calc.js`, `src/lib/rep
 - **Invoiced MTD** = Σ `dispatches.bundle_entries[].weight` for the month through `D` (== `theoretical_weight`).
 - **Invoiced MTD (Previous Month)** = the **same day-of-month window** of the prior month
   (e.g. Jun 1..DAY), for a like-for-like pace comparison — **not** the full prior month.
-- **Physical Inventory** = finished pipe stock = **total produced − total invoiced** (plant-level
-  net; `producedPool` nets and does NOT floor). Not floored per SKU — production logs short SKU
-  codes (`SHS-75x75x2.00`) while dispatch logs ERP MM codes/descriptions, so per-SKU flooring
-  over-counts already-shipped pipe.
+- **Physical Inventory** = the Dashboard **FG Left Inventory** card = **produced − invoiced**, where
+  produced is **recomputed live from the current SKU master** (`tubeCount × weightPerTube`), NOT the
+  stored `productions.total_weight`. The app does this on every view via `resolveProductionWeights`
+  (`App.jsx:2758`) so a corrected master weight flows through. Summing stored `total_weight`
+  overstates it whenever the master's `weightPerTube` changed after a production was saved.
 
 ## Steps
 
@@ -65,24 +66,31 @@ UNION ALL SELECT 'confirmed',     coalesce(round(sum(confirmed)::numeric,1),0)::
 UNION ALL SELECT 'non_confirmed', coalesce(round(sum(non_confirmed)::numeric,1),0)::text FROM orders WHERE deleted=false AND lower(trim(coalesce(order_status,'')))<>'delivered';
 ```
 
-### 3 — Physical inventory (finished pipe stock = plant-level net)
-Finished pipe on hand is a **tonnage** KPI: total produced − total invoiced, netted at the plant
-level. **Do NOT floor per SKU** — production logs short SKU codes while dispatch logs ERP MM
-codes/descriptions, so per-SKU flooring double-counts already-shipped pipe (it created 17 false
-"oversold" SKUs, +~89 T). The plant-level net is SKU-code-agnostic and correct.
+### 3 — Physical inventory (finished pipe stock = Dashboard FG Left Inventory)
+Produced is **recomputed live from the current SKU master** (`tubeCount × weightPerTube`), mirroring
+the app's `resolveProductionWeights`. Do NOT sum the stored `total_weight` — it overstates produced
+whenever a master weight was edited after save (here by ~128 T). The CASE below is the passthrough
+`resolveProductionWeights` uses when a SKU is unmatched or its master weight is null/0.
 ```sql
+WITH prod_resolved AS (
+  SELECT CASE WHEN s.weight_per_tube > 0
+              THEN p.tube_count * s.weight_per_tube/1000.0
+              ELSE p.total_weight END AS w
+  FROM productions p LEFT JOIN skus s ON s.sku_code = p.sku_code
+  WHERE p.deleted IS NOT TRUE
+),
+disp AS (
+  SELECT sum((be->>'weight')::numeric) AS w
+  FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) be
+  WHERE d.deleted IS NOT TRUE
+)
 SELECT
-  round((SELECT sum(total_weight) FROM productions WHERE deleted=false)::numeric,1) AS total_produced,
-  round((SELECT sum((be->>'weight')::numeric)
-         FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) be
-         WHERE d.deleted=false)::numeric,1)                                          AS total_invoiced,
-  round(((SELECT sum(total_weight) FROM productions WHERE deleted=false)
-       - (SELECT sum((be->>'weight')::numeric)
-          FROM dispatches d CROSS JOIN LATERAL jsonb_array_elements(d.bundle_entries) be
-          WHERE d.deleted=false))::numeric,0)                                        AS phys_inventory;
+  round((SELECT sum(w) FROM prod_resolved)::numeric,1)                            AS produced_live,
+  round((SELECT w FROM disp)::numeric,1)                                          AS invoiced,
+  round(((SELECT sum(w) FROM prod_resolved) - (SELECT w FROM disp))::numeric,1)   AS phys_inventory;
 ```
-Advisory (optional data-hygiene check): count production `sku_code`s with no matching dispatch
-`skuCode` and vice-versa; a growing gap means the SKU master needs deduping (short code vs MM code).
+Data-hygiene note: report `Σ stored total_weight − Σ live-recompute` — a large delta means many
+master `weightPerTube` values were changed after production save (the app heals this at read time).
 
 ### 4 — Derived
 - **Total Orders** = `invoiced_mtd + confirmed + non_confirmed` (app "Total Orders" KPI).
@@ -113,7 +121,7 @@ Checks that MUST hold (else FAIL and flag):
 4. **Freshness** — report `max_order_date` / `max_dispatch_date`; if a `D`/`D-1` value is 0 **and** that date is after the max, label it "no data loaded yet" (not zero activity).
 Advisory flags (report, do not fail):
 - **Confirmed variance** — `confirmed(stored)` vs `release−invoiced`; if they differ, note the delta. The report uses the **stored** bucket (app-consistent).
-- **FG reconciliation** — `phys_inventory` == `total_produced − total_invoiced` (plant-level net, not per-SKU floored). Flag if SKU-code mismatches (short code vs ERP MM code) are growing.
+- **FG reconciliation** — `phys_inventory` == Dashboard FG Left Inventory (produced *live-recompute* − invoiced). It uses live master weights, NOT stored `total_weight`; report the stored-vs-live delta as a data-hygiene signal (master weight edited post-save).
 
 ### 6 — COMPARE against previous snapshot
 Find the most recent `reports/PB-MTD-Update-*.md` (before this run), parse its values, and

--- a/reports/PB-MTD-Update-2026-07-10.md
+++ b/reports/PB-MTD-Update-2026-07-10.md
@@ -43,3 +43,22 @@ Notes:
 | SFDC Orders | ⚠️ Not possible — no SFDC flag; distributor_code values ARE Salesforce IDs, so all orders are effectively SFDC with no separable subset |
 | Invoiced MTD-FE 550 / FE 550D - LRF | 🚫 Not relevant — FE 550/550D are TMT rebar grades; P&T runs IS 10748 HR coil |
 | FE 550 / FE 550D (under Physical Inventory) | 🚫 Not relevant — finished pipe carries no grade dimension |
+
+## Verification (as of 2026-07-10)
+
+Every ✅ figure was reproduced by a second independent method — all headline values match, **zero drift**.
+
+| Metric | Value | Independent cross-check | Verdict |
+|---|---|---|---|
+| Invoiced MTD (Jul) | 249.4 T | Σ line weights = Σ theoretical_weight = 249.410 | ✅ exact |
+| Invoiced prev month (Jun) | 1014.0 T | dual-method = 1013.999 | ✅ exact |
+| Dispatch month total | 249.4 T | = Invoiced MTD (partition check) | ✅ |
+| Current-month orders | 226.0 T | Σ daily order intake = 226 (partition check) | ✅ |
+| Total Orders | 300.7 T | 249.4 + 26.0 + 25.3 | ✅ arithmetic |
+| Confirmed | 26.0 T | stored bucket, app-consistent (`salesKpis`) | ⚠️ ERP Release−Invoiced = 24.8 T → 1.2 T source variance |
+| Physical Inventory | 1,776 T | floored per-SKU, app-consistent (`producedPool`) | ⚠️ net = 1,687 T; 17 SKUs dispatched > produced |
+
+**Data freshness:** latest `order_date` = 2026-07-08, latest `date_of_dispatch` = 2026-07-09 — so
+Dispatch D-day and Orders Logged D / D-1 are 0 for lack of loaded data, not zero activity.
+
+_Regenerate anytime with the `pb-mtd-report` skill (fetches live data, re-verifies, compares to this snapshot)._

--- a/reports/PB-MTD-Update-2026-07-10.md
+++ b/reports/PB-MTD-Update-2026-07-10.md
@@ -10,13 +10,13 @@ Revised Best Estimate --->	2500T
 Total Orders --->	300.7T
 Current Month Orders --->	226.0T
 Invoiced Orders MTD --->	249.4T
-Invoiced MTD (Previous Month) --->	1014.0T
+Invoiced MTD (Previous Month) --->	257.9T
 Dispatch D-1 (Current Month) --->	35.9T
 Dispatch D Day --->	0T
 Confirmed Orders Pending to be Invoiced --->	26.0T
 Non-Confirmed Orders --->	25.3T
 Daily Run Rate Required --->	102.3T
-Physical Inventory --->	1776T
+Physical Inventory --->	1687T
 	
 Orders Logged D Day --->	0T
 Orders Logged D-1 --->	0T
@@ -25,12 +25,20 @@ Orders Logged D-2 --->	51.0T
 
 Notes:
 - **Revised Best Estimate** — manually supplied (2500 T for July), not in Supabase.
+- **Invoiced MTD (Previous Month)** = previous month invoiced **through the same day-of-month**
+  (Jun 1–10), for a like-for-like pace comparison — not the full June total (1,014.0 T).
+  July is pacing slightly behind: 249.4 T vs 257.9 T over the same 10 days.
 - **Total Orders** = MTD Invoice + Confirmed + Non-confirmed (app Sales KPI).
 - **Daily Run Rate Required** = (Best Estimate − Invoiced MTD) ÷ calendar days remaining
   in July = (2500 − 249.4) ÷ 22 (Jul 10–31 inclusive) = **102.3 T/day**. Uses *calendar*
   days, not working days — the system has no holiday/Sunday calendar to exclude non-working
   days, so this will run slightly low if Sundays/holidays are excluded in the plant's own convention.
-- **Physical Inventory** = finished pipe stock, produced − invoiced, netted per SKU.
+- **Physical Inventory** = finished pipe stock = **total produced − total invoiced** (all-time)
+  = 3,868.2 − 2,180.9 = **1,687.3 T**. Netted at the plant level (matches how the app's
+  `producedPool` nets — it does not floor). An earlier per-SKU *floored* figure (1,776 T)
+  over-counted by ~89 T: production logs short SKU codes (`SHS-75x75x2.00`) while dispatch logs
+  ERP MM codes/descriptions, so 17 SKUs falsely looked "oversold" and flooring them at 0 added
+  back pipe that had actually shipped.
 - **Dispatch D Day / Orders Logged D Day / D-1** read 0 because the latest data loaded
   is order_date 2026-07-08 and dispatch date 2026-07-09 — not necessarily zero activity.
 
@@ -51,12 +59,12 @@ Every ✅ figure was reproduced by a second independent method — all headline 
 | Metric | Value | Independent cross-check | Verdict |
 |---|---|---|---|
 | Invoiced MTD (Jul) | 249.4 T | Σ line weights = Σ theoretical_weight = 249.410 | ✅ exact |
-| Invoiced prev month (Jun) | 1014.0 T | dual-method = 1013.999 | ✅ exact |
+| Invoiced MTD prev month (Jun 1–10) | 257.9 T | dual-method = 257.930 (same day-of-month) | ✅ exact |
 | Dispatch month total | 249.4 T | = Invoiced MTD (partition check) | ✅ |
 | Current-month orders | 226.0 T | Σ daily order intake = 226 (partition check) | ✅ |
 | Total Orders | 300.7 T | 249.4 + 26.0 + 25.3 | ✅ arithmetic |
 | Confirmed | 26.0 T | stored bucket, app-consistent (`salesKpis`) | ⚠️ ERP Release−Invoiced = 24.8 T → 1.2 T source variance |
-| Physical Inventory | 1,776 T | floored per-SKU, app-consistent (`producedPool`) | ⚠️ net = 1,687 T; 17 SKUs dispatched > produced |
+| Physical Inventory | 1,687 T | total produced 3,868.2 − dispatched 2,180.9 (plant-level net, no flooring) | ✅ SKU-code-agnostic |
 
 **Data freshness:** latest `order_date` = 2026-07-08, latest `date_of_dispatch` = 2026-07-09 — so
 Dispatch D-day and Orders Logged D / D-1 are 0 for lack of loaded data, not zero activity.

--- a/reports/PB-MTD-Update-2026-07-10.md
+++ b/reports/PB-MTD-Update-2026-07-10.md
@@ -6,6 +6,7 @@ with numbers pulled from Supabase. Only lines that are both **relevant to P&T** 
 
 ```
 PB MTD update as on --->	2026-07-10
+Revised Best Estimate --->	2500T
 Total Orders --->	300.7T
 Current Month Orders --->	226.0T
 Invoiced Orders MTD --->	249.4T
@@ -14,6 +15,7 @@ Dispatch D-1 (Current Month) --->	35.9T
 Dispatch D Day --->	0T
 Confirmed Orders Pending to be Invoiced --->	26.0T
 Non-Confirmed Orders --->	25.3T
+Daily Run Rate Required --->	102.3T
 Physical Inventory --->	1776T
 	
 Orders Logged D Day --->	0T
@@ -22,7 +24,12 @@ Orders Logged D-2 --->	51.0T
 ```
 
 Notes:
+- **Revised Best Estimate** — manually supplied (2500 T for July), not in Supabase.
 - **Total Orders** = MTD Invoice + Confirmed + Non-confirmed (app Sales KPI).
+- **Daily Run Rate Required** = (Best Estimate − Invoiced MTD) ÷ calendar days remaining
+  in July = (2500 − 249.4) ÷ 22 (Jul 10–31 inclusive) = **102.3 T/day**. Uses *calendar*
+  days, not working days — the system has no holiday/Sunday calendar to exclude non-working
+  days, so this will run slightly low if Sundays/holidays are excluded in the plant's own convention.
 - **Physical Inventory** = finished pipe stock, produced − invoiced, netted per SKU.
 - **Dispatch D Day / Orders Logged D Day / D-1** read 0 because the latest data loaded
   is order_date 2026-07-08 and dispatch date 2026-07-09 — not necessarily zero activity.
@@ -31,10 +38,8 @@ Notes:
 
 | Line | Why excluded |
 |---|---|
-| Revised Best Estimate | ⚠️ Not possible — no forecast/target field in the system |
 | Retail / Distributor Through Project / Project Orders (all instances) | 🚫 Not relevant — P&T has no order-category dimension |
 | Carry-forward Orders | ⚠️ Not possible — not tracked (prior-month open-book proxy = 0 T) |
 | SFDC Orders | ⚠️ Not possible — no SFDC flag; distributor_code values ARE Salesforce IDs, so all orders are effectively SFDC with no separable subset |
 | Invoiced MTD-FE 550 / FE 550D - LRF | 🚫 Not relevant — FE 550/550D are TMT rebar grades; P&T runs IS 10748 HR coil |
-| Daily Run Rate Required | ⚠️ Not possible — depends on Revised Best Estimate |
 | FE 550 / FE 550D (under Physical Inventory) | 🚫 Not relevant — finished pipe carries no grade dimension |

--- a/reports/PB-MTD-Update-2026-07-10.md
+++ b/reports/PB-MTD-Update-2026-07-10.md
@@ -16,7 +16,7 @@ Dispatch D Day --->	0T
 Confirmed Orders Pending to be Invoiced --->	26.0T
 Non-Confirmed Orders --->	25.3T
 Daily Run Rate Required --->	102.3T
-Physical Inventory --->	1687T
+Physical Inventory --->	1559.3T
 	
 Orders Logged D Day --->	0T
 Orders Logged D-1 --->	0T
@@ -33,12 +33,13 @@ Notes:
   in July = (2500 − 249.4) ÷ 22 (Jul 10–31 inclusive) = **102.3 T/day**. Uses *calendar*
   days, not working days — the system has no holiday/Sunday calendar to exclude non-working
   days, so this will run slightly low if Sundays/holidays are excluded in the plant's own convention.
-- **Physical Inventory** = finished pipe stock = **total produced − total invoiced** (all-time)
-  = 3,868.2 − 2,180.9 = **1,687.3 T**. Netted at the plant level (matches how the app's
-  `producedPool` nets — it does not floor). An earlier per-SKU *floored* figure (1,776 T)
-  over-counted by ~89 T: production logs short SKU codes (`SHS-75x75x2.00`) while dispatch logs
-  ERP MM codes/descriptions, so 17 SKUs falsely looked "oversold" and flooring them at 0 added
-  back pipe that had actually shipped.
+- **Physical Inventory** = finished pipe stock = **produced − invoiced**, where produced is
+  **recomputed live from the current SKU master** (`tubeCount × weightPerTube`), matching the app:
+  3,740.2 − 2,180.9 = **1,559.3 T**. This is the Dashboard → **Finished Goods → FG Left Inventory**
+  card. The app recomputes production weight from the master on every view (`resolveProductionWeights`,
+  `App.jsx:2758`) rather than trusting each production row's stored `total_weight` snapshot — those
+  snapshots run ~128 T heavier here because the master's `weightPerTube` was edited after the
+  productions were saved, so a stored-basis sum (1,687.3 T) overstates it and is not used.
 - **Dispatch D Day / Orders Logged D Day / D-1** read 0 because the latest data loaded
   is order_date 2026-07-08 and dispatch date 2026-07-09 — not necessarily zero activity.
 
@@ -64,7 +65,7 @@ Every ✅ figure was reproduced by a second independent method — all headline 
 | Current-month orders | 226.0 T | Σ daily order intake = 226 (partition check) | ✅ |
 | Total Orders | 300.7 T | 249.4 + 26.0 + 25.3 | ✅ arithmetic |
 | Confirmed | 26.0 T | stored bucket, app-consistent (`salesKpis`) | ⚠️ ERP Release−Invoiced = 24.8 T → 1.2 T source variance |
-| Physical Inventory | 1,687 T | total produced 3,868.2 − dispatched 2,180.9 (plant-level net, no flooring) | ✅ SKU-code-agnostic |
+| Physical Inventory | 1,559.3 T | produced (live master recompute) 3,740.2 − invoiced 2,180.9 = Dashboard FG Left Inventory | ✅ matches Dashboard |
 
 **Data freshness:** latest `order_date` = 2026-07-08, latest `date_of_dispatch` = 2026-07-09 — so
 Dispatch D-day and Orders Logged D / D-1 are 0 for lack of loaded data, not zero activity.

--- a/reports/PB-MTD-Update-2026-07-10.md
+++ b/reports/PB-MTD-Update-2026-07-10.md
@@ -1,46 +1,40 @@
 # JSW Pipes & Tubes — PB MTD Update (2026-07-10)
 
 Reproduces the JSW "PB MTD update" order/invoice layout for the Pipes & Tubes system,
-with numbers pulled from Supabase. Lines that have no analog in P&T are flagged rather
-than guessed. The template's own printed numbers (27,500 T / 6,589 T / 12,613 T …) are
-example values from the larger PB/rebar operation and are **not** used here.
+with numbers pulled from Supabase. Only lines that are both **relevant to P&T** and
+**computable** from current data are included.
 
 ```
-JSW Pipes & Tubes — PB MTD Update
-As on: 2026-07-10   |   Current month: Jul-2026   |   Units: MT (T)
-Legend:  ✅ value from system   ⚠️ not possible (data not captured)   🚫 not relevant to P&T
-
-PB MTD update as on ---------------------> 2026-07-10
-Revised Best Estimate -------------------> ⚠️ N/A — no forecast/target field in the system (manual input)
-Total Orders ----------------------------> ✅ 300.7 T   (Sales KPI = MTD Invoice + Confirmed + Non-confirmed; all-time ordered qty = 2,223 T)
-  Retail Orders -------------------------> 🚫 N/A — no order-category dimension in P&T
-  Distributor Through Project -----------> 🚫 N/A — no order-category dimension in P&T
-  Project Orders ------------------------> 🚫 N/A — no order-category dimension in P&T
-Carry-forward Orders --------------------> ⚠️ N/A — not tracked; prior-month open-book proxy = 0 T (all open orders are current-month)
-Current Month Orders --------------------> ✅ 226.0 T   (Jul order intake, 41 lines)
-SFDC Orders -----------------------------> ⚠️ N/A — no SFDC flag; distributor_code values ARE Salesforce IDs, so all orders are effectively SFDC (no separable subset)
-Invoiced Orders MTD ---------------------> ✅ 249.4 T   (Jul, by invoice date)
-  Retail Orders -------------------------> 🚫 N/A — no order-category dimension
-  Distributor Through Project -----------> 🚫 N/A — no order-category dimension
-  Project Orders ------------------------> 🚫 N/A — no order-category dimension
-Invoiced MTD-FE 550 ---------------------> 🚫 N/A — FE 550 is a rebar grade; P&T grades are IS 10748
-Invoiced MTD-FE 550D - LRF --------------> 🚫 N/A — FE 550D/LRF is a rebar grade; not used in P&T
-Invoiced MTD (Previous Month) -----------> ✅ 1,014.0 T (Jun 2026, by invoice date)
-Dispatch D-1 (Current Month) ------------> ✅ 35.9 T    (2026-07-09)
-Dispatch D Day --------------------------> ✅ 0 T       (2026-07-10; latest dispatch data = 2026-07-09)
-Confirmed Orders Pending to be Invoiced -> ✅ 26.0 T
-Non-Confirmed Orders --------------------> ✅ 25.3 T
-Daily Run Rate Required -----------------> ⚠️ N/A — depends on Revised Best Estimate; = (target − MTD invoiced) / remaining working days if a target is supplied
-Physical Inventory ----------------------> ✅ ~1,776 T  (finished pipe stock = produced − invoiced, per SKU)
-  FE 550 --------------------------------> 🚫 N/A — finished pipe carries no grade dimension
-  FE 550D -------------------------------> 🚫 N/A — finished pipe carries no grade dimension
-
-Orders Logged D Day ---------------------> ✅ 0 T       (2026-07-10; no orders loaded yet)
-Orders Logged D-1 -----------------------> ✅ 0 T       (2026-07-09; no orders loaded)
-Orders Logged D-2 -----------------------> ✅ 51.0 T    (2026-07-08, 11 lines)
-
-Why the N/A lines:
-  • No order-category field in the system → all Retail / Distributor-Through-Project / Project splits are 🚫 not relevant.
-  • FE 550 / FE 550D are TMT rebar grades; P&T runs IS 10748 HR coil → all FE-550 lines are 🚫 not relevant.
-  • No forecast/target, run-rate, SFDC flag, or carry-forward fields exist → those lines are ⚠️ not possible today.
+PB MTD update as on --->	2026-07-10
+Total Orders --->	300.7T
+Current Month Orders --->	226.0T
+Invoiced Orders MTD --->	249.4T
+Invoiced MTD (Previous Month) --->	1014.0T
+Dispatch D-1 (Current Month) --->	35.9T
+Dispatch D Day --->	0T
+Confirmed Orders Pending to be Invoiced --->	26.0T
+Non-Confirmed Orders --->	25.3T
+Physical Inventory --->	1776T
+	
+Orders Logged D Day --->	0T
+Orders Logged D-1 --->	0T
+Orders Logged D-2 --->	51.0T
 ```
+
+Notes:
+- **Total Orders** = MTD Invoice + Confirmed + Non-confirmed (app Sales KPI).
+- **Physical Inventory** = finished pipe stock, produced − invoiced, netted per SKU.
+- **Dispatch D Day / Orders Logged D Day / D-1** read 0 because the latest data loaded
+  is order_date 2026-07-08 and dispatch date 2026-07-09 — not necessarily zero activity.
+
+## Excluded from this report (not relevant / not possible)
+
+| Line | Why excluded |
+|---|---|
+| Revised Best Estimate | ⚠️ Not possible — no forecast/target field in the system |
+| Retail / Distributor Through Project / Project Orders (all instances) | 🚫 Not relevant — P&T has no order-category dimension |
+| Carry-forward Orders | ⚠️ Not possible — not tracked (prior-month open-book proxy = 0 T) |
+| SFDC Orders | ⚠️ Not possible — no SFDC flag; distributor_code values ARE Salesforce IDs, so all orders are effectively SFDC with no separable subset |
+| Invoiced MTD-FE 550 / FE 550D - LRF | 🚫 Not relevant — FE 550/550D are TMT rebar grades; P&T runs IS 10748 HR coil |
+| Daily Run Rate Required | ⚠️ Not possible — depends on Revised Best Estimate |
+| FE 550 / FE 550D (under Physical Inventory) | 🚫 Not relevant — finished pipe carries no grade dimension |

--- a/reports/PB-MTD-Update-2026-07-10.md
+++ b/reports/PB-MTD-Update-2026-07-10.md
@@ -1,0 +1,46 @@
+# JSW Pipes & Tubes — PB MTD Update (2026-07-10)
+
+Reproduces the JSW "PB MTD update" order/invoice layout for the Pipes & Tubes system,
+with numbers pulled from Supabase. Lines that have no analog in P&T are flagged rather
+than guessed. The template's own printed numbers (27,500 T / 6,589 T / 12,613 T …) are
+example values from the larger PB/rebar operation and are **not** used here.
+
+```
+JSW Pipes & Tubes — PB MTD Update
+As on: 2026-07-10   |   Current month: Jul-2026   |   Units: MT (T)
+Legend:  ✅ value from system   ⚠️ not possible (data not captured)   🚫 not relevant to P&T
+
+PB MTD update as on ---------------------> 2026-07-10
+Revised Best Estimate -------------------> ⚠️ N/A — no forecast/target field in the system (manual input)
+Total Orders ----------------------------> ✅ 300.7 T   (Sales KPI = MTD Invoice + Confirmed + Non-confirmed; all-time ordered qty = 2,223 T)
+  Retail Orders -------------------------> 🚫 N/A — no order-category dimension in P&T
+  Distributor Through Project -----------> 🚫 N/A — no order-category dimension in P&T
+  Project Orders ------------------------> 🚫 N/A — no order-category dimension in P&T
+Carry-forward Orders --------------------> ⚠️ N/A — not tracked; prior-month open-book proxy = 0 T (all open orders are current-month)
+Current Month Orders --------------------> ✅ 226.0 T   (Jul order intake, 41 lines)
+SFDC Orders -----------------------------> ⚠️ N/A — no SFDC flag; distributor_code values ARE Salesforce IDs, so all orders are effectively SFDC (no separable subset)
+Invoiced Orders MTD ---------------------> ✅ 249.4 T   (Jul, by invoice date)
+  Retail Orders -------------------------> 🚫 N/A — no order-category dimension
+  Distributor Through Project -----------> 🚫 N/A — no order-category dimension
+  Project Orders ------------------------> 🚫 N/A — no order-category dimension
+Invoiced MTD-FE 550 ---------------------> 🚫 N/A — FE 550 is a rebar grade; P&T grades are IS 10748
+Invoiced MTD-FE 550D - LRF --------------> 🚫 N/A — FE 550D/LRF is a rebar grade; not used in P&T
+Invoiced MTD (Previous Month) -----------> ✅ 1,014.0 T (Jun 2026, by invoice date)
+Dispatch D-1 (Current Month) ------------> ✅ 35.9 T    (2026-07-09)
+Dispatch D Day --------------------------> ✅ 0 T       (2026-07-10; latest dispatch data = 2026-07-09)
+Confirmed Orders Pending to be Invoiced -> ✅ 26.0 T
+Non-Confirmed Orders --------------------> ✅ 25.3 T
+Daily Run Rate Required -----------------> ⚠️ N/A — depends on Revised Best Estimate; = (target − MTD invoiced) / remaining working days if a target is supplied
+Physical Inventory ----------------------> ✅ ~1,776 T  (finished pipe stock = produced − invoiced, per SKU)
+  FE 550 --------------------------------> 🚫 N/A — finished pipe carries no grade dimension
+  FE 550D -------------------------------> 🚫 N/A — finished pipe carries no grade dimension
+
+Orders Logged D Day ---------------------> ✅ 0 T       (2026-07-10; no orders loaded yet)
+Orders Logged D-1 -----------------------> ✅ 0 T       (2026-07-09; no orders loaded)
+Orders Logged D-2 -----------------------> ✅ 51.0 T    (2026-07-08, 11 lines)
+
+Why the N/A lines:
+  • No order-category field in the system → all Retail / Distributor-Through-Project / Project splits are 🚫 not relevant.
+  • FE 550 / FE 550D are TMT rebar grades; P&T runs IS 10748 HR coil → all FE-550 lines are 🚫 not relevant.
+  • No forecast/target, run-rate, SFDC flag, or carry-forward fields exist → those lines are ⚠️ not possible today.
+```


### PR DESCRIPTION
## Summary
Adds two new Claude skills to automate daily reporting for the JSW Pipes & Tubes business:
1. **pb-mtd-report** — Generates the "PB MTD Update" order/invoice report with live Supabase data, independent verification, and comparison to previous snapshots
2. **daily-report-pt-whatsapp** — Renders the MTD update as a WhatsApp-ready message for team distribution

Both skills are designed to replace manual report generation and ensure Dashboard-aligned figures through dual-method verification.

## Key Changes

### New Skill: pb-mtd-report (`.claude/skills/pb-mtd-report/SKILL.md`)
- **Purpose:** Generate verified PB MTD update reports for Pipes & Tubes from live Supabase data
- **Core metrics:** Invoiced MTD, confirmed/non-confirmed orders, dispatch volumes, physical inventory (FG Left Inventory)
- **Verification:** Dual-method cross-checks for invoiced figures, partition validation, arithmetic checks, and freshness signals
- **Key implementation details:**
  - Physical inventory computed as **produced (live-recomputed from SKU master) − invoiced**, matching app's `resolveProductionWeights` logic
  - Previous-month comparison uses **same day-of-month window** (e.g., Jun 1–10 vs Jul 1–10) for like-for-like pace comparison
  - Daily Run Rate Required calculated as `(best_estimate − invoiced_mtd) / calendar_days_remaining`
  - Filters use `deleted IS NOT TRUE` to match app's `!deleted` logic (includes NULL rows)
  - Explicitly excludes lines not relevant to P&T (FE 550/550D grades, order categories, carry-forward orders)
  - Outputs to `reports/PB-MTD-Update-<date>.md` with verification table and change-vs-last-report comparison

### New Skill: daily-report-pt-whatsapp (`.claude/skills/daily-report-pt-whatsapp/SKILL.md`)
- **Purpose:** Render MTD update as WhatsApp-ready copy-paste message
- **Design:** Presentation-only; reuses verified numbers from `pb-mtd-report` to prevent drift
- **Format:** WhatsApp-friendly (single asterisks for bold, emojis, no tables, bullet points)
- **Conditional sections:** Omits Best Estimate and Run Rate lines if no `best_estimate` supplied
- **Output:** Plain code block for copy-paste; optional file save to `reports/daily-whatsapp-<date>.txt`

### Sample Report Output (`reports/PB-MTD-Update-2026-07-10.md`)
- Demonstrates full report structure with live example data
- Includes verification table showing dual-method checks (all ✅ pass)
- Documents excluded lines and data-freshness notes
- Shows physical inventory reconciliation (live-recomputed vs stored weight delta)

## Notable Implementation Details
- **Verification is mandatory** — report stops and flags if any check fails; never emits unverified numbers
- **Data hygiene signal:** Reports delta between stored `total_weight` and live-recomputed production weight (indicates master `weightPerTube` edits post-save)
- **Freshness handling:** Distinguishes between "0 T activity" and "no data loaded yet" by comparing daily values against max order/dispatch dates
- **Confirmed variance advisory:** Notes if stored `confirmed` bucket differs from ERP formula `release_qty − invoiced_qty`; uses stored bucket (app-consistent)
- **No fabrication guardrail:** Explicitly refuses to invent excluded lines; explains missing schema dimensions if asked

## Guardrails & Conventions
- Decimals to 1 place for weights; Physical Inventory to whole T
- Calendar days only (no holiday/Sunday exclusion — system has no such calendar)
- Supabase project ref `hztblmccvvarmgxmunrp` resolved via `list_projects` if needed
- All numbers sourced from Supabase; no interpolation or invention

https://claude.ai/code/session_016MSDFftRnABUiwWAYoZw4o