### PR TITLE
Bridge ERP codes absent from master via order description

### DIFF
--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -321,7 +321,7 @@ export function reservedBySku(orders, keyOf = (c) => c) {
   ;(orders || []).filter(o => !o.deleted && isOpenOrderStatus(o.orderStatus)).forEach(o => {
     const code = String(o.mmId || '').trim()
     if (!code) return
-    const k = keyOf(code)
+    const k = keyOf(code, o.description)   // bridge an ERP code the master lacks via its description
     out[k] = (out[k] || 0) + Math.max(0, Number(o.releaseQty || 0) - Number(o.invoicedQty || 0))
   })
   return out
@@ -381,12 +381,27 @@ export function canonicalSkuKey(skuOrDesc) {
 // strings (ERP code vs description vs "1.6"/"1.60") into ONE identity, and bridges the two id
 // systems (productions/dispatches use `skuCode`; orders use `mmId` == skuCode). Keys are computed
 // ONLY from full master OBJECTS — satisfying canonicalSkuKey's invariant (needs productType + size +
-// thickness + an IS-token description) — so object-form and description-form always agree. A code
-// that matches NO master row keys as ITSELF (unchanged from raw-string behavior — never wrongly
-// merged). Read-time + non-destructive: nothing is stored; callers pass the live `skus`. ──
+// thickness + an IS-token description) — so object-form and description-form always agree.
+// The returned resolver is `(code, desc?) => key`:
+//   • a code IN the master resolves to that master row's canonical key (byCode wins first, so
+//     production/dispatch/tests keep exact-code netting and are never affected by the desc arg);
+//   • a code ABSENT from the master falls back to canonicalising the SUPPLIED `desc`, but ONLY when
+//     that yields a structured physical key (contains '|'). This is what lets an order/invoice line
+//     whose ERP code the SKU catalog doesn't carry yet still collapse onto the same identity as
+//     production, instead of stranding on its raw code and showing 0 production — the SKU-master gap
+//     that split one tube into a produced row PLUS a phantom "negative-free" order row. An
+//     unparsable desc (canonicalSkuKey returns a normalised-desc fallback, no '|') is NOT used as a
+//     bridge, so two unrelated lines can never accidentally merge;
+//   • otherwise the code keys as ITSELF (raw-string behavior — never wrongly merged).
+// Read-time + non-destructive: nothing is stored; callers pass the live `skus`. ──
 export function skuKeyResolver(skus) {
   const byCode = new Map((skus || []).map(s => [s.skuCode, canonicalSkuKey(s)]))
-  return (code) => byCode.get(code) || String(code || '')
+  return (code, desc = '') => {
+    const hit = byCode.get(code)
+    if (hit) return hit
+    if (desc) { const k = canonicalSkuKey(desc); if (k.includes('|')) return k }
+    return String(code || '')
+  }
 }
 
 // ── Shipped (invoiced) weight per order line, from dispatch entries' orderLineId
@@ -593,11 +608,11 @@ export function skuInventoryRows(productions, dispatches, orders, skus, inRange 
   // Production/Reserved still shows its tube name instead of falling back to the raw SKU code.
   ;(orders || []).filter(o => !o.deleted).forEach(o => {
     const code = String(o.mmId || '').trim()
-    if (code && o.description) { const k = keyOf(code); if (!descByKey[k]) descByKey[k] = o.description }
+    if (code && o.description) { const k = keyOf(code, o.description); if (!descByKey[k]) descByKey[k] = o.description }
   })
   ;(orders || []).filter(o => !o.deleted && pass(o.orderDate)).forEach(o => {
     const raw = String(o.mmId || '').trim()
-    const k = raw ? keyOf(raw) : UNMAPPED
+    const k = raw ? keyOf(raw, o.description) : UNMAPPED
     if (!isDeliveredStatus(o.orderStatus))
       pendingBySku[k] = (pendingBySku[k] || 0) + salesNum(o.confirmed) + salesNum(o.nonConfirmed)
     if (k === UNMAPPED) return
@@ -892,8 +907,8 @@ export function salesByDistributor(orders, dispatches, month = '', skus = []) {
     if (name && (!r.customer || r.customer === '—')) r.customer = name
     return r
   }
-  const skuOf = (r, code) => {
-    const k = keyOf(code)
+  const skuOf = (r, code, desc = '') => {
+    const k = keyOf(code, desc)   // orders pass their description so an ERP code the master lacks still merges
     return r._sku[k] = r._sku[k] || { id: k, skuCode: skuByKey.get(k)?.skuCode || code, confirmed: 0, nonConfirmed: 0, mtdInvoice: 0 }
   }
   ;(orders || []).filter(o => !o.deleted && !isDeliveredStatus(o.orderStatus)).forEach(o => {
@@ -902,7 +917,7 @@ export function salesByDistributor(orders, dispatches, month = '', skus = []) {
     const c = salesNum(o.confirmed), nc = salesNum(o.nonConfirmed)
     r.confirmed += c; r.nonConfirmed += nc
     const code = String(o.mmId || '').trim()
-    if (code) { const s = skuOf(r, code); s.confirmed += c; s.nonConfirmed += nc }
+    if (code) { const s = skuOf(r, code, o.description); s.confirmed += c; s.nonConfirmed += nc }
   })
   ;(dispatches || []).filter(d => !d.deleted).forEach(d => {
     if (month && salesMonthKey(d.dateOfDispatch) !== month) return

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -460,6 +460,28 @@ describe('skuKeyResolver + canonical-identity netting (Pillar 1)', () => {
     expect(rows[0].reserved).toBeCloseTo(2)                  // order's reserved MT lands on the same row
     expect(rows[0].free).toBeCloseTo(3)                      // 5 − 2
   })
+  it('bridges an order whose ERP code is ABSENT from the master onto production via its description', () => {
+    const keyOf = skuKeyResolver(skus)
+    // 'ghost-erp' is in NO master row, but its description is the same physical pipe as RHS-100x50x1.60:
+    expect(keyOf('ghost-erp', 'MS RHS One Helix IS 4923 YSt 210 Black 100x50x1.6x6000'))
+      .toBe(keyOf('RHS-100x50x1.60'))
+    // an absent code with an UNPARSABLE description still keys as ITSELF (never wrongly merged):
+    expect(keyOf('ghost-erp', 'freight charge')).toBe('ghost-erp')
+    // …and a code that IS in the master ignores the desc arg entirely (exact-code netting unchanged):
+    expect(keyOf('ERP-100', 'anything at all')).toBe(keyOf('ERP-100'))
+  })
+  it('skuInventoryRows: an order coded with an ERP number the master lacks lands on the produced row (not a phantom −free split)', () => {
+    const productions = [{ deleted: false, skuCode: 'RHS-100x50x1.60', tubeCount: 100, totalWeight: 5, dateOfProduction: '2026-06-01' }]
+    // mmId is an ERP code that does NOT exist in `skus`; only its description identifies the pipe:
+    const orders = [{ deleted: false, mmId: '1140-13075-99999999', orderStatus: 'Confirmed', quantity: 2,
+      releaseQty: 2, invoicedQty: 0, confirmed: 2, nonConfirmed: 0, orderDate: '2026-06-01',
+      description: 'MS RHS One Helix IS 4923 YSt 210 Black 100x50x1.60x6000' }]
+    const rows = skuInventoryRows(productions, [], orders, skus)
+    expect(rows).toHaveLength(1)                             // one physical pipe → one row, not two
+    expect(rows[0].production).toBeCloseTo(5)                // production shows (was 0 before the fix)
+    expect(rows[0].reserved).toBeCloseTo(2)
+    expect(rows[0].free).toBeCloseTo(3)                      // 5 − 2, positive (was −2, stranded)
+  })
 })
 
 describe('dispatchCoilTrace', () => {


### PR DESCRIPTION
## Summary
Extends the SKU key resolver to fall back to parsing an order's description when its ERP code (`mmId`) is not found in the master catalog. This prevents orders with unmapped ERP codes from creating phantom "negative-free" inventory rows and allows them to correctly net against production.

## Changes

- **`skuKeyResolver(skus)`** now returns a resolver function `(code, desc?) => key` that:
  - Returns the canonical key if the code exists in the master (exact-code netting unchanged)
  - Falls back to parsing the supplied description via `canonicalSkuKey()` if the code is absent AND the description yields a structured physical key (contains `|`)
  - Returns the raw code string otherwise (never wrongly merges unparsable descriptions)

- **`reservedBySku()`**, **`skuInventoryRows()`**, and **`salesByDistributor()`** now pass `o.description` to the key resolver, enabling the bridge for orders with absent ERP codes

- **Test coverage** added:
  - `skuKeyResolver` correctly bridges an absent code via its description to the same identity as production
  - Unparsable descriptions are not used as bridges (prevents accidental merges)
  - Codes in the master ignore the description argument (exact-code netting preserved)
  - End-to-end: an order with an absent ERP code but matching description now lands on the produced row instead of creating a phantom split

## Implementation Details
The resolver checks `byCode.get(code)` first (production/dispatch/tests unaffected). Only when absent does it attempt to canonicalise the description. The `|` check ensures only structured keys (containing product type, size, thickness, and IS-token) are used as bridges; normalised-description fallbacks are rejected, preventing unrelated lines from accidentally merging.

https://claude.ai/code/session_01WGBEdbanmTyrW6yqGzZak6