### PR TITLE
Add PB MTD Dashboard report with KPI cards and SKU ageing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2723,15 +2723,17 @@ function SyncErrorBanner() {
 // ── Reports — one-click formatted .xlsx stock reports (lazy-loads exceljs via ./lib/reports).
 // Finished = on-hand pipes (produced − dispatched) by ROUND/SHS/RHS; Raw = unslit HR coils +
 // free baby-coil strip. Buttons disable while generating; failures surface inline. ──
-function Reports({ skus, productions, dispatches, coils, babyCoils }) {
-  const [busy, setBusy] = useState(null)   // 'finished' | 'raw' | null
+function Reports({ skus, productions, dispatches, coils, babyCoils, orders }) {
+  const [busy, setBusy] = useState(null)   // 'finished' | 'raw' | 'dashboard' | null
   const [err, setErr] = useState(null)
+  const [bestEstimate, setBestEstimate] = useState('')  // manual monthly target (MT); '' ⇒ % of BE / run rate = N/A
   const run = async (which) => {
     setErr(null); setBusy(which)
     try {
       const R = await import('./lib/reports')
       if (which === 'finished') await R.generateFinishedStockReport(skus, productions, dispatches)
-      else await R.generateRawMaterialReport(coils, babyCoils, productions)
+      else if (which === 'raw') await R.generateRawMaterialReport(coils, babyCoils, productions)
+      else await R.generateMtdDashboardReport(orders, dispatches, productions, skus, { bestEstimate: bestEstimate === '' ? null : Number(bestEstimate) })
     } catch (e) {
       setErr(String(e?.message || e))
     } finally {
@@ -2740,6 +2742,22 @@ function Reports({ skus, productions, dispatches, coils, babyCoils }) {
   }
   return (
     <div className="space-y-6">
+      <Section title="PB MTD Dashboard (Excel)">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="w-44">
+            <Field label="Best Estimate (MT)" helper="Monthly target — optional. Blank ⇒ % of BE & Run Rate show N/A.">
+              <Input type="number" value={bestEstimate} onChange={setBestEstimate} placeholder="e.g. 2500" />
+            </Field>
+          </div>
+          <Btn variant="primary" disabled={busy === 'dashboard'} onClick={() => run('dashboard')}>
+            {busy === 'dashboard' ? 'Generating…' : '⬇ PB MTD Dashboard (.xlsx)'}
+          </Btn>
+        </div>
+        <div className="mt-4 text-xs text-slate-500 dark:text-slate-400 space-y-1">
+          <p><span className="font-medium text-slate-600 dark:text-slate-300">PB MTD Dashboard</span> — the monthly order/invoice/inventory dashboard (as on today): headline KPIs, Order Status Summary, Order Pipeline — MTD, and Inventory &amp; Production, plus a second sheet of the Top 5 SKUs by on-hand inventory with FIFO ageing. Numbers reconcile with the Sales &amp; Dashboard KPIs.</p>
+        </div>
+      </Section>
+
       <Section title="Stock Reports (Excel)">
         <div className="flex flex-wrap gap-3">
           <Btn variant="success" disabled={busy === 'finished'} onClick={() => run('finished')}>
@@ -2749,12 +2767,13 @@ function Reports({ skus, productions, dispatches, coils, babyCoils }) {
             {busy === 'raw' ? 'Generating…' : '⬇ Raw Material Stock (.xlsx)'}
           </Btn>
         </div>
-        {err && <p className="mt-3 text-sm text-red-600 dark:text-red-400">Report failed: {err}</p>}
         <div className="mt-4 text-xs text-slate-500 dark:text-slate-400 space-y-1">
           <p><span className="font-medium text-slate-600 dark:text-slate-300">Finished Pipe Stock</span> — on-hand pipes (produced − dispatched) grouped ROUND / SHS / RHS, with per-section and grand totals.</p>
           <p><span className="font-medium text-slate-600 dark:text-slate-300">Raw Material Stock</span> — whole unslit HR coils plus free baby-coil strip, grouped by width × thickness.</p>
         </div>
       </Section>
+
+      {err && <p className="text-sm text-red-600 dark:text-red-400">Report failed: {err}</p>}
     </div>
   )
 }
@@ -2856,7 +2875,7 @@ function InventoryApp({ onLogout }) {
         {tab === 'skuMaster' && <SKUMaster skus={skus} setSkus={setSkus} productions={productions} />}
         {tab === 'orders' && <Orders orders={orders} setOrders={setOrders} dispatches={dispatches} setDispatches={setDispatches} productions={resolvedProductions} skus={skus} setSkus={setSkus} />}
         {tab === 'sales' && <SalesDashboard orders={orders} dispatches={dispatches} skus={skus} />}
-        {tab === 'reports' && <Reports skus={skus} productions={resolvedProductions} dispatches={dispatches} coils={coils} babyCoils={babyCoils} />}
+        {tab === 'reports' && <Reports skus={skus} productions={resolvedProductions} dispatches={dispatches} coils={coils} babyCoils={babyCoils} orders={orders} />}
       </main>
 
       {/* Footer */}

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -271,7 +271,9 @@ export function producedPool(productions, dispatches, excludeDispatchId = null, 
 // average (and oldest) age. Draining is by WEIGHT so the surviving weight equals producedPool's
 // availableWeight — i.e. it ties exactly to the "Inventory (T)" column. `keyOf` should be the same
 // skuKeyResolver used by the caller so ageing joins to the same rows. `asOf` is 'YYYY-MM-DD'.
-// Returns { [key]: { onhandWeight, avgAgeDays, oldestAgeDays } } (only keys with positive stock). ──
+// Returns { [key]: { onhandWeight, avgAgeDays, oldestAgeDays, buckets:{d0_30,d31_60,d61_90,d90plus} } }
+// (only keys with positive stock). `buckets` split the surviving weight by age band (Σ buckets ==
+// onhandWeight); the field is additive — earlier callers that read only the scalar ages ignore it. ──
 export function skuAgeing(productions, dispatches, keyOf = (c) => c, asOf = new Date().toISOString().slice(0, 10)) {
   const dayOf = (iso) => Math.floor(Date.parse(String(iso)) / 86400000)
   const asOfDay = dayOf(asOf)
@@ -291,6 +293,7 @@ export function skuAgeing(productions, dispatches, keyOf = (c) => c, asOf = new 
   for (const k of Object.keys(layersByKey)) {
     const layers = layersByKey[k].sort((a, b) => String(a.date).localeCompare(String(b.date)))
     let drain = dispByKey[k] || 0, onhand = 0, ageWt = 0, oldest = null
+    const bkt = { d0_30: 0, d31_60: 0, d61_90: 0, d90plus: 0 }  // surviving weight by age band
     for (const L of layers) {
       let surv = L.weight
       if (drain > 0) { const take = Math.min(drain, L.weight); surv -= take; drain -= take }   // FIFO: oldest shipped first
@@ -299,8 +302,12 @@ export function skuAgeing(productions, dispatches, keyOf = (c) => c, asOf = new 
       const age = Number.isFinite(d) ? asOfDay - d : 0
       onhand += surv; ageWt += surv * age
       if (oldest == null || age > oldest) oldest = age
+      if (age <= 30) bkt.d0_30 += surv
+      else if (age <= 60) bkt.d31_60 += surv
+      else if (age <= 90) bkt.d61_90 += surv
+      else bkt.d90plus += surv
     }
-    if (onhand > 1e-9) out[k] = { onhandWeight: onhand, avgAgeDays: ageWt / onhand, oldestAgeDays: oldest }
+    if (onhand > 1e-9) out[k] = { onhandWeight: onhand, avgAgeDays: ageWt / onhand, oldestAgeDays: oldest, buckets: bkt }
   }
   return out
 }

--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -11,7 +11,7 @@
 // (a styled-write library — the app's `xlsx` is read-only for our purposes) and trigger
 // the download. Mirrors the Blob+anchor pattern of downloadCSV in App.jsx.
 // ═══════════════════════════════════════════════════════════════
-import { producedPool, coilConsumption, skuSizeLabel, skuKeyResolver } from './calc'
+import { producedPool, coilConsumption, skuSizeLabel, skuKeyResolver, skuAgeing, salesKpis } from './calc'
 
 const EPS = 0.0005 // MT — treat anything below as zero (rounding noise)
 
@@ -132,6 +132,100 @@ export function buildRawMaterialData(coils, babyCoils, productions) {
     hrCoil: { groups: hrCoil, total: hrTotal },
     strip: { groups: strip, total: stripTotal },
     grand: hrTotal + stripTotal,
+  }
+}
+
+// ── Report C data: PB MTD Dashboard. Reproduces the app's Sales/Dashboard KPIs (salesKpis) +
+// FIFO stock ageing (skuAgeing) for the monthly management report, mirroring the `pb-mtd-report`
+// skill so the two never diverge. Only P&T-possible lines are computed — segments, plants,
+// FE550/FE550D grades, order categories, SFDC, carry-forward, opening/closing balances and DSI
+// have no analog in this system and are deliberately absent.
+//   `date` = report day D (default today), drives MTD / prev-month-same-days / D / D-1 / D-2.
+//   `productions` MUST be live-weight-resolved by the caller (resolveProductionWeights) so produced
+//     tonnage matches the app's FG Left Inventory (a stored total_weight overstates once a master
+//     weightPerTube is edited post-save).
+//   `bestEstimate` = manual monthly target MT (no forecast field exists); null ⇒ Invoice % of BE and
+//     Daily Run Rate render N/A.
+// Pure + DOM-free (no exceljs) so it's unit-testable. ──
+const dashMonthKey = (d) => String(d || '').slice(0, 7)
+const dashDay = (d) => Number(String(d || '').slice(8, 10))
+const dashShift = (iso, days) => { const d = new Date(iso + 'T00:00:00Z'); d.setUTCDate(d.getUTCDate() + days); return d.toISOString().slice(0, 10) }
+const dashPrevMonth = (iso) => { const d = new Date(iso + 'T00:00:00Z'); d.setUTCDate(1); d.setUTCMonth(d.getUTCMonth() - 1); return d.toISOString().slice(0, 7) }
+const dashDaysRemaining = (iso) => { const d = new Date(iso + 'T00:00:00Z'); const day = d.getUTCDate(); d.setUTCMonth(d.getUTCMonth() + 1, 0); return d.getUTCDate() - day + 1 } // report day → month end, inclusive
+
+export function buildMtdDashboardData(orders, dispatches, productions, skus, { date = today(), bestEstimate = null } = {}) {
+  const D = date, D1 = dashShift(D, -1), D2 = dashShift(D, -2)
+  const MONTH = dashMonthKey(D), PREV = dashPrevMonth(D), DAY = dashDay(D)
+  const beNum = Number(bestEstimate)
+  const BE = (bestEstimate == null || bestEstimate === '' || !Number.isFinite(beNum) || beNum <= 0) ? null : beNum
+  const num = (v) => { const n = Number(v); return Number.isFinite(n) ? n : 0 }
+
+  // Invoiced tonnage from dispatches (Σ bundleEntries weight over non-deleted rows matching a predicate).
+  const dispLines = (dispatches || []).filter(d => !d.deleted)
+  const sumDisp = (pred) => dispLines.reduce((t, d) =>
+    pred(d) ? t + (d.bundleEntries || []).reduce((s, be) => s + num(be.weight), 0) : t, 0)
+  const invoicedMtd = sumDisp(d => dashMonthKey(d.dateOfDispatch) === MONTH && d.dateOfDispatch <= D) // MTD capped at ≤ D
+  const invoicedPrev = sumDisp(d => dashMonthKey(d.dateOfDispatch) === PREV && dashDay(d.dateOfDispatch) <= DAY) // prev month, same day-of-month window
+  const dispatchD = sumDisp(d => d.dateOfDispatch === D)
+  const dispatchD1 = sumDisp(d => d.dateOfDispatch === D1)
+  const invoicedAll = sumDisp(() => true)
+
+  // Order-book snapshot (Confirmed / Non-confirmed are all-time non-delivered; salesKpis is the app's own KPI).
+  const kpi = salesKpis(orders, dispatches, MONTH)
+  const confirmed = kpi.confirmed, nonConfirmed = kpi.nonConfirmed
+  const pending = confirmed + nonConfirmed
+  const totalOrders = invoicedMtd + confirmed + nonConfirmed
+  const invoicedPctPipeline = totalOrders > 0 ? (invoicedMtd / totalOrders) * 100 : null
+
+  // Orders intake (Σ quantity).
+  const ordLines = (orders || []).filter(o => !o.deleted)
+  const sumOrd = (pred) => ordLines.reduce((t, o) => pred(o) ? t + num(o.quantity) : t, 0)
+  const ordersMonthIntake = sumOrd(o => dashMonthKey(o.orderDate) === MONTH)
+  const ordersD = sumOrd(o => o.orderDate === D)
+  const ordersD1 = sumOrd(o => o.orderDate === D1)
+  const ordersD2 = sumOrd(o => o.orderDate === D2)
+
+  // Production + physical inventory (productions already live-resolved by caller).
+  const prodLines = (productions || []).filter(p => !p.deleted)
+  const producedLive = prodLines.reduce((t, p) => t + num(p.totalWeight), 0)
+  const freshProductionMtd = prodLines.reduce((t, p) => dashMonthKey(p.dateOfProduction) === MONTH ? t + num(p.totalWeight) : t, 0)
+  const physicalInventory = producedLive - invoicedAll
+
+  // Targets (only when a Best Estimate is supplied).
+  const invoicePctOfBe = BE != null ? (invoicedMtd / BE) * 100 : null
+  const remaining = dashDaysRemaining(D)
+  const dailyRunRate = BE != null && remaining > 0 ? Math.max(0, BE - invoicedMtd) / remaining : null
+
+  // FIFO ageing per canonical SKU (buckets + weighted-avg age), joined for the top-5 detail sheet.
+  const keyOf = skuKeyResolver(skus)
+  const ageing = skuAgeing(productions, dispatches, keyOf, D)
+  const skuByKey = new Map((skus || []).map(s => [keyOf(s.skuCode), s]))
+  const zeroBkt = () => ({ d0_30: 0, d31_60: 0, d61_90: 0, d90plus: 0 })
+  const addBkt = (acc, b) => { acc.d0_30 += b.d0_30; acc.d31_60 += b.d31_60; acc.d61_90 += b.d61_90; acc.d90plus += b.d90plus }
+  const allBuckets = zeroBkt()
+  let onhandTot = 0, ageWtTot = 0
+  const ageingRows = Object.entries(ageing).map(([k, v]) => {
+    onhandTot += v.onhandWeight; ageWtTot += v.onhandWeight * v.avgAgeDays; addBkt(allBuckets, v.buckets)
+    const sku = skuByKey.get(k)
+    const size = skuSizeLabel(sku)
+    const label = size ? (sku?.thickness ? `${size} x ${sku.thickness}` : size) : (sku?.description || k)
+    return { key: k, label, onhandMt: v.onhandWeight, buckets: v.buckets, oldestAgeDays: v.oldestAgeDays, avgAgeDays: v.avgAgeDays }
+  })
+  const invAgeingDaysAvg = onhandTot > 0 ? ageWtTot / onhandTot : null
+
+  // Top 5 SKUs by on-hand inventory (MT), descending — with their combined subtotal.
+  const top5 = ageingRows.slice().sort((a, b) => b.onhandMt - a.onhandMt).slice(0, 5)
+  const t5 = top5.reduce((acc, r) => { acc.onhandMt += r.onhandMt; addBkt(acc.buckets, r.buckets); acc.ageWt += r.onhandMt * r.avgAgeDays; return acc },
+    { onhandMt: 0, buckets: zeroBkt(), ageWt: 0 })
+  const top5Total = { onhandMt: t5.onhandMt, buckets: t5.buckets, avgAgeDays: t5.onhandMt > 0 ? t5.ageWt / t5.onhandMt : null }
+
+  return {
+    date: D, month: MONTH, prevMonth: PREV, day: DAY, daysRemaining: remaining, bestEstimate: BE,
+    kpis: { bestEstimate: BE, orderPipeline: totalOrders, invoicedMtd, invoicedPctPipeline, pending, physicalInventory, invAgeingDaysAvg },
+    orderStatus: { bestEstimate: BE, ordersReceived: totalOrders, invoicedMtd, confirmed, nonConfirmed, invoicePctOfBe },
+    orderPipelineMtd: { totalOrders, ordersMonthIntake, invoicedMtd, invoicedPrev, dispatchD1, dispatchD, confirmed, nonConfirmed, dailyRunRate, ordersD, ordersD1, ordersD2 },
+    inventoryProduction: { freshProductionMtd, physicalInventory, invAgeingDaysAvg, buckets: allBuckets },
+    skuAgeingTop5: { rows: top5, total: top5Total },
   }
 }
 
@@ -322,4 +416,162 @@ export async function generateRawMaterialReport(coils, babyCoils, productions, o
   gt.eachCell(c => { c.fill = fill(COLOR.grand); c.border = ALL_BORDERS })
 
   await downloadWorkbook(wb, `raw-material-${date}.xlsx`)
+}
+
+// ── Report C — PB MTD Dashboard (2 sheets) ──
+// Sheet 1 "Dashboard": a 6-card KPI band + three colour-banded tables (Order Status Summary,
+// Order Pipeline — MTD, Inventory & Production). Sheet 2: Top-5 SKUs by on-hand inventory (MT)
+// with FIFO age buckets. Numbers come from buildMtdDashboardData (which mirrors pb-mtd-report),
+// so pass live-weight-resolved productions. `opts.bestEstimate` (MT) is the manual monthly target.
+const DASH = {
+  be: 'FFBF8F00', pipeline: 'FF2E75B6', invoiced: 'FF548235', pending: 'FFC55A11',
+  physinv: 'FF7030A0', ageing: 'FF1F7A72',
+  bandStatus: 'FF2E75B6', bandPipeline: 'FF548235', bandInv: 'FFC55A11',
+}
+const naMt = (v) => (v == null ? 'N/A' : Number(v))                       // MT cell: number → numFmt, null → "N/A"
+const naPct = (v) => (v == null ? 'N/A' : `${Number(v).toFixed(1)}%`)      // percentage cell as text
+
+export async function generateMtdDashboardReport(orders, dispatches, productions, skus, opts = {}) {
+  const date = opts.date || today()
+  const company = opts.companyName || 'JSW One Pipes & Tubes'
+  const data = buildMtdDashboardData(orders, dispatches, productions, skus, { date, bestEstimate: opts.bestEstimate ?? null })
+  const ExcelJS = await loadExcelJS()
+  const wb = new ExcelJS.Workbook()
+  const cL = (n) => String.fromCharCode(64 + n)
+
+  // ── Sheet 1 — Dashboard (12-column grid: 6 KPI cards × 2 cols; left table cols 1–6, right 7–12) ──
+  const ws = wb.addWorksheet('Dashboard', {
+    views: [{ state: 'frozen', ySplit: 2 }],
+    pageSetup: { orientation: 'landscape', fitToPage: true, fitToWidth: 1, fitToHeight: 0, margins: { left: 0.3, right: 0.3, top: 0.4, bottom: 0.4, header: 0.2, footer: 0.2 } },
+  })
+  const N = 12
+  ws.columns = Array.from({ length: N }, () => ({ width: 11 }))
+  const monthLabel = new Date(date + 'T00:00:00Z')
+    .toLocaleString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' }).toUpperCase()
+  writeTitle(ws, N, `${company} — PB MTD DASHBOARD — ${monthLabel}`, date)
+
+  const setBorders = (r, c1, c2) => { for (let c = c1; c <= c2; c++) ws.getCell(r, c).border = ALL_BORDERS }
+
+  // KPI band — headers (row 4), values (row 5), captions (row 6).
+  const k = data.kpis
+  const cards = [
+    { h: 'BEST ESTIMATE (MT)', v: naMt(k.bestEstimate), s: 'manual target', c: DASH.be },
+    { h: 'ORDER PIPELINE (MT)', v: naMt(k.orderPipeline), s: 'Invoiced + Conf + Non-Conf', c: DASH.pipeline },
+    { h: 'INVOICED MTD (MT)', v: naMt(k.invoicedMtd), s: k.invoicedPctPipeline == null ? '' : `${k.invoicedPctPipeline.toFixed(1)}% of pipeline`, c: DASH.invoiced },
+    { h: 'PENDING TO SERVE (MT)', v: naMt(k.pending), s: 'Conf + Non-Conf', c: DASH.pending },
+    { h: 'PHYSICAL INVENTORY (MT)', v: naMt(k.physicalInventory), s: 'produced − invoiced', c: DASH.physinv },
+    { h: 'INV. AGEING (DAYS AVG)', v: naMt(k.invAgeingDaysAvg), s: 'FIFO, tonnage-wtd', c: DASH.ageing },
+  ]
+  const HR = 4, VR = 5, SR = 6
+  ws.getRow(HR).height = 30; ws.getRow(VR).height = 22
+  cards.forEach((card, i) => {
+    const c1 = i * 2 + 1, c2 = c1 + 1
+    ws.mergeCells(`${cL(c1)}${HR}:${cL(c2)}${HR}`)
+    const h = ws.getCell(HR, c1)
+    h.value = card.h; h.font = { bold: true, size: 9, color: { argb: 'FFFFFFFF' } }
+    h.fill = fill(card.c); h.alignment = { horizontal: 'center', vertical: 'middle', wrapText: true }
+    ws.mergeCells(`${cL(c1)}${VR}:${cL(c2)}${VR}`)
+    const v = ws.getCell(VR, c1)
+    v.value = card.v; v.font = { bold: true, size: 15 }
+    if (typeof card.v === 'number') v.numFmt = '#,##0.0'
+    v.alignment = { horizontal: 'center', vertical: 'middle' }
+    ws.mergeCells(`${cL(c1)}${SR}:${cL(c2)}${SR}`)
+    const s = ws.getCell(SR, c1)
+    s.value = card.s; s.font = { size: 8, color: { argb: 'FF6B7280' } }
+    s.alignment = { horizontal: 'center' }
+    setBorders(HR, c1, c2); setBorders(VR, c1, c2); setBorders(SR, c1, c2)
+  })
+
+  // A colour-banded label|value table. label spans lc1..lc2, value spans vc1..vc2; band spans the lot.
+  const table = (startRow, lc1, lc2, vc1, vc2, title, argb, headerLabel, rows) => {
+    ws.mergeCells(`${cL(lc1)}${startRow}:${cL(vc2)}${startRow}`)
+    const band = ws.getCell(startRow, lc1)
+    band.value = title; band.font = { bold: true, color: { argb: 'FFFFFFFF' } }
+    band.fill = fill(argb); band.alignment = { horizontal: 'left', vertical: 'middle' }
+    const hrow = startRow + 1
+    ws.mergeCells(`${cL(lc1)}${hrow}:${cL(lc2)}${hrow}`)
+    ws.mergeCells(`${cL(vc1)}${hrow}:${cL(vc2)}${hrow}`)
+    const hl = ws.getCell(hrow, lc1); hl.value = headerLabel; hl.font = { bold: true }; hl.fill = fill(COLOR.head); hl.alignment = { horizontal: 'left' }
+    const hv = ws.getCell(hrow, vc1); hv.value = 'MT'; hv.font = { bold: true }; hv.fill = fill(COLOR.head); hv.alignment = { horizontal: 'right' }
+    setBorders(hrow, lc1, vc2)
+    let r = hrow + 1
+    rows.forEach(row => {
+      ws.mergeCells(`${cL(lc1)}${r}:${cL(lc2)}${r}`)
+      ws.mergeCells(`${cL(vc1)}${r}:${cL(vc2)}${r}`)
+      const lcell = ws.getCell(r, lc1); lcell.value = (row.indent ? '     ' : '') + row.label; lcell.alignment = { horizontal: 'left' }
+      const vcell = ws.getCell(r, vc1); vcell.value = row.value; vcell.alignment = { horizontal: 'right' }
+      if (typeof row.value === 'number') vcell.numFmt = '#,##0.0'
+      if (row.strong) { lcell.font = { bold: true }; vcell.font = { bold: true }; lcell.fill = fill(COLOR.grand); vcell.fill = fill(COLOR.grand) }
+      setBorders(r, lc1, vc2)
+      r++
+    })
+    return r
+  }
+
+  const os = data.orderStatus, op = data.orderPipelineMtd, ip = data.inventoryProduction
+  let leftRow = table(8, 1, 4, 5, 6, 'ORDER STATUS SUMMARY', DASH.bandStatus, 'Metric', [
+    { label: 'Best Estimate (BE)', value: naMt(os.bestEstimate) },
+    { label: 'Orders Received (Total Orders)', value: os.ordersReceived },
+    { label: 'Invoiced MTD', value: os.invoicedMtd },
+    { label: 'Confirmed Pending Invoice', value: os.confirmed },
+    { label: 'Non-Confirmed Orders', value: os.nonConfirmed },
+    { label: 'Invoice % of BE', value: naPct(os.invoicePctOfBe), strong: true },
+  ])
+  leftRow += 1 // spacer between the two stacked left-hand tables
+  table(leftRow, 1, 4, 5, 6, 'INVENTORY & PRODUCTION', DASH.bandInv, 'Metric', [
+    { label: 'Fresh Production MTD', value: ip.freshProductionMtd },
+    { label: 'Physical Inventory', value: ip.physicalInventory },
+    { label: 'Inventory Ageing (Days Avg)', value: naMt(ip.invAgeingDaysAvg) },
+    { label: 'Ageing 0–30 d', value: ip.buckets.d0_30, indent: true },
+    { label: 'Ageing 31–60 d', value: ip.buckets.d31_60, indent: true },
+    { label: 'Ageing 61–90 d', value: ip.buckets.d61_90, indent: true },
+    { label: 'Ageing 90+ d', value: ip.buckets.d90plus, indent: true },
+  ])
+  table(8, 7, 10, 11, 12, 'ORDER PIPELINE — MTD', DASH.bandPipeline, 'Line', [
+    { label: 'Total Orders', value: op.totalOrders },
+    { label: 'Current Month Orders', value: op.ordersMonthIntake },
+    { label: 'Invoiced Orders MTD', value: op.invoicedMtd },
+    { label: 'Invoiced MTD (Prev Month, same days)', value: op.invoicedPrev },
+    { label: 'Dispatch D-1', value: op.dispatchD1 },
+    { label: 'Dispatch D Day', value: op.dispatchD },
+    { label: 'Confirmed Pending Invoice', value: op.confirmed },
+    { label: 'Non-Confirmed Orders', value: op.nonConfirmed },
+    { label: 'Daily Run Rate Required', value: naMt(op.dailyRunRate), strong: true },
+    { label: 'Orders Logged — D Day', value: op.ordersD },
+    { label: 'Orders Logged — D-1', value: op.ordersD1 },
+    { label: 'Orders Logged — D-2', value: op.ordersD2 },
+  ])
+
+  // ── Sheet 2 — Top-5 SKUs by on-hand inventory (MT) + FIFO age buckets ──
+  const ws2 = wb.addWorksheet('SKU Ageing (Top 5)', {
+    views: [{ state: 'frozen', ySplit: 3 }],
+    pageSetup: { orientation: 'landscape', fitToPage: true, fitToWidth: 1, fitToHeight: 0, margins: { left: 0.3, right: 0.3, top: 0.4, bottom: 0.4, header: 0.2, footer: 0.2 } },
+  })
+  ws2.columns = [{ width: 24 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 10 }, { width: 10 }, { width: 11 }, { width: 15 }]
+  writeTitle(ws2, 8, `${company} — TOP 5 SKUs BY ON-HAND INVENTORY (MT)`, date)
+  styleHeaderRow(ws2.addRow(['SKU', 'On-hand MT', '0–30 d', '31–60 d', '61–90 d', '90+ d', 'Oldest (d)', 'Wtd Avg Age (d)']))
+  const t5 = data.skuAgeingTop5
+  if (!t5.rows.length) {
+    const r = ws2.addRow(['No finished stock on hand', '', '', '', '', '', '', '']); r.eachCell(c => { c.border = ALL_BORDERS })
+  }
+  t5.rows.forEach(row => {
+    const r = ws2.addRow([row.label, row.onhandMt, row.buckets.d0_30, row.buckets.d31_60, row.buckets.d61_90, row.buckets.d90plus,
+      row.oldestAgeDays == null ? '' : Math.round(row.oldestAgeDays), row.avgAgeDays == null ? '' : row.avgAgeDays])
+    ;[2, 3, 4, 5, 6].forEach(i => numCell(r, i, '#,##0.0'))
+    numCell(r, 7, '0'); numCell(r, 8, '0.0')
+    r.eachCell(c => { c.border = ALL_BORDERS })
+  })
+  if (t5.rows.length) {
+    const tr = ws2.addRow(['TOTAL (top 5)', t5.total.onhandMt, t5.total.buckets.d0_30, t5.total.buckets.d31_60,
+      t5.total.buckets.d61_90, t5.total.buckets.d90plus, '', t5.total.avgAgeDays == null ? '' : t5.total.avgAgeDays])
+    tr.font = { bold: true }
+    ;[2, 3, 4, 5, 6].forEach(i => numCell(tr, i, '#,##0.0')); numCell(tr, 8, '0.0')
+    tr.eachCell(c => { c.fill = fill(COLOR.sub); c.border = ALL_BORDERS })
+  }
+  const note = ws2.addRow(['Top 5 by on-hand MT. Full-stock ageing totals are on the Dashboard sheet (Inventory & Production).'])
+  ws2.mergeCells(`A${note.number}:H${note.number}`)
+  note.getCell(1).font = { italic: true, size: 9, color: { argb: 'FF6B7280' } }
+
+  await downloadWorkbook(wb, `PB-MTD-Dashboard-${date}.xlsx`)
+  return data
 }

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildFinishedStockData, buildRawMaterialData } from './reports'
+import { buildFinishedStockData, buildRawMaterialData, buildMtdDashboardData } from './reports'
 
 // ── Report A fixture ──
 const skus = [
@@ -98,5 +98,150 @@ describe('buildRawMaterialData', () => {
     expect(hrCoil.groups).toEqual([])
     expect(strip.groups).toEqual([])
     expect(grand).toBe(0)
+  })
+})
+
+// ── Report C fixture — PB MTD Dashboard. D = 2026-07-15 (DAY 15, MONTH 2026-07, PREV 2026-06). ──
+const dSkus = [
+  { skuCode: 'S1', productType: 'SHS', height: 50, breadth: 50, thickness: 2.0, length: 6000, weightPerTube: 10 },
+  { skuCode: 'S2', productType: 'SHS', height: 40, breadth: 40, thickness: 2.5, length: 6000, weightPerTube: 8 },
+]
+const dOrders = [
+  { orderDate: '2026-07-15', quantity: 20, confirmed: 5, nonConfirmed: 3, orderStatus: 'Confirmed' }, // D
+  { orderDate: '2026-07-14', quantity: 10, confirmed: 2, nonConfirmed: 1, orderStatus: '' },          // D-1
+  { orderDate: '2026-07-13', quantity: 8,  confirmed: 0, nonConfirmed: 4, orderStatus: '' },          // D-2
+  { orderDate: '2026-07-02', quantity: 12, confirmed: 1, nonConfirmed: 2, orderStatus: '' },          // earlier this month
+  { orderDate: '2026-06-20', quantity: 30, confirmed: 9, nonConfirmed: 9, orderStatus: 'Delivered' }, // prev month + delivered → excluded from conf/non-conf & intake
+  { orderDate: '2026-07-05', quantity: 5,  confirmed: 4, nonConfirmed: 0, orderStatus: 'Delivered' }, // delivered → excluded from conf/non-conf, still counts in month intake
+]
+const dDispatches = [
+  { dateOfDispatch: '2026-07-15', bundleEntries: [{ skuCode: 'S1', weight: 12 }] }, // D
+  { dateOfDispatch: '2026-07-14', bundleEntries: [{ skuCode: 'S1', weight: 8 }] },  // D-1
+  { dateOfDispatch: '2026-07-03', bundleEntries: [{ skuCode: 'S2', weight: 10 }] }, // this month
+  { dateOfDispatch: '2026-06-10', bundleEntries: [{ skuCode: 'S1', weight: 7 }] },  // prev month, day 10 ≤ 15 → prev window
+  { dateOfDispatch: '2026-06-20', bundleEntries: [{ skuCode: 'S1', weight: 5 }] },  // prev month, day 20 > 15 → NOT in prev window
+]
+const dProductions = [ // already live-weight-resolved (totalWeight is authoritative)
+  { skuCode: 'S1', dateOfProduction: '2026-07-10', tubeCount: 100, totalWeight: 40 },
+  { skuCode: 'S1', dateOfProduction: '2026-05-01', tubeCount: 50,  totalWeight: 20 },
+  { skuCode: 'S2', dateOfProduction: '2026-07-12', tubeCount: 60,  totalWeight: 25 },
+  { skuCode: 'S2', dateOfProduction: '2026-06-01', tubeCount: 30,  totalWeight: 15 },
+]
+
+describe('buildMtdDashboardData', () => {
+  const D = '2026-07-15'
+  it('derives dates: month / prev-month / day / calendar days remaining (inclusive)', () => {
+    const r = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
+    expect(r.month).toBe('2026-07')
+    expect(r.prevMonth).toBe('2026-06')
+    expect(r.day).toBe(15)
+    expect(r.daysRemaining).toBe(17) // Jul 15..31 inclusive
+  })
+
+  it('computes order/invoice KPIs (confirmed & non-confirmed exclude Delivered lines)', () => {
+    const { kpis, orderStatus } = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
+    expect(orderStatus.confirmed).toBe(8)       // 5+2+0+1 (two Delivered lines excluded)
+    expect(orderStatus.nonConfirmed).toBe(10)   // 3+1+4+2
+    expect(kpis.pending).toBe(18)
+    expect(kpis.invoicedMtd).toBe(30)           // July ≤ D: 12+8+10
+    expect(kpis.orderPipeline).toBe(48)         // 30 + 8 + 10
+    expect(kpis.invoicedPctPipeline).toBeCloseTo(62.5, 4)
+  })
+
+  it('computes the Order Pipeline — MTD lines (prev-month same-days, D / D-1, orders logged)', () => {
+    const { orderPipelineMtd } = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
+    expect(orderPipelineMtd.totalOrders).toBe(48)
+    expect(orderPipelineMtd.ordersMonthIntake).toBe(55)  // 20+10+8+12+5 (July, incl. Delivered qty; June excluded)
+    expect(orderPipelineMtd.invoicedPrev).toBe(7)        // June day ≤ 15 only (06-20 excluded)
+    expect(orderPipelineMtd.dispatchD).toBe(12)
+    expect(orderPipelineMtd.dispatchD1).toBe(8)
+    expect(orderPipelineMtd.ordersD).toBe(20)
+    expect(orderPipelineMtd.ordersD1).toBe(10)
+    expect(orderPipelineMtd.ordersD2).toBe(8)
+  })
+
+  it('computes production + physical inventory from live weights', () => {
+    const { inventoryProduction } = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
+    expect(inventoryProduction.freshProductionMtd).toBe(65) // July: 40 + 25
+    expect(inventoryProduction.physicalInventory).toBe(58)  // produced 100 − invoiced-all 42
+  })
+
+  it('FIFO ageing: buckets tie to on-hand, weighted-avg age, and Σ buckets == physical inventory (no over-dispatch)', () => {
+    const { inventoryProduction, kpis } = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
+    const b = inventoryProduction.buckets
+    expect(b.d0_30).toBeCloseTo(53, 6)   // S1 28 @5d + S2 25 @3d
+    expect(b.d31_60).toBeCloseTo(5, 6)   // S2 5 @44d
+    expect(b.d61_90).toBeCloseTo(0, 6)
+    expect(b.d90plus).toBeCloseTo(0, 6)
+    expect(b.d0_30 + b.d31_60 + b.d61_90 + b.d90plus).toBeCloseTo(58, 6)
+    expect(kpis.invAgeingDaysAvg).toBeCloseTo(7.5, 4) // (28*5 + 30*9.8333)/58
+  })
+
+  it('top-5 SKU ageing: sorted by on-hand MT desc, labelled size × thickness, with subtotal', () => {
+    const { skuAgeingTop5 } = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
+    expect(skuAgeingTop5.rows).toHaveLength(2)
+    expect(skuAgeingTop5.rows[0].onhandMt).toBeCloseTo(30, 6) // S2 first (bigger)
+    expect(skuAgeingTop5.rows[0].label).toBe('40x40 x 2.5')
+    expect(skuAgeingTop5.rows[1].onhandMt).toBeCloseTo(28, 6) // S1
+    expect(skuAgeingTop5.rows[1].label).toBe('50x50 x 2')
+    expect(skuAgeingTop5.total.onhandMt).toBeCloseTo(58, 6)
+    expect(skuAgeingTop5.total.avgAgeDays).toBeCloseTo(7.5, 4)
+  })
+
+  it('Best Estimate blank ⇒ Invoice % of BE and Daily Run Rate are null (render N/A)', () => {
+    const r = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
+    expect(r.orderStatus.invoicePctOfBe).toBeNull()
+    expect(r.orderPipelineMtd.dailyRunRate).toBeNull()
+  })
+
+  it('Best Estimate supplied ⇒ Invoice % of BE and Daily Run Rate computed', () => {
+    const r = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D, bestEstimate: 2500 })
+    expect(r.orderStatus.invoicePctOfBe).toBeCloseTo(1.2, 4)      // 30 / 2500
+    expect(r.orderPipelineMtd.dailyRunRate).toBeCloseTo(145.2941, 3) // (2500 − 30) / 17
+  })
+
+  it('handles empty inputs without throwing', () => {
+    const r = buildMtdDashboardData([], [], [], [], { date: D })
+    expect(r.kpis.physicalInventory).toBe(0)
+    expect(r.kpis.invAgeingDaysAvg).toBeNull()
+    expect(r.skuAgeingTop5.rows).toEqual([])
+  })
+})
+
+describe('generateMtdDashboardReport (render smoke test)', () => {
+  it('renders a valid 2-sheet workbook with the expected colour bands and cell values', async () => {
+    const { generateMtdDashboardReport } = await import('./reports')
+    // Capture the workbook bytes by stubbing the browser download path (downloadWorkbook uses Blob/URL/document).
+    let buf = null
+    const origDoc = globalThis.document, origURL = globalThis.URL, origBlob = globalThis.Blob
+    globalThis.Blob = class { constructor(parts) { this._buf = parts[0] } }
+    globalThis.URL = { createObjectURL: (b) => { buf = b._buf; return 'blob:x' }, revokeObjectURL() {} }
+    globalThis.document = { createElement: () => ({ click() {}, style: {} }), body: { appendChild() {}, removeChild() {} } }
+    try {
+      await generateMtdDashboardReport(dOrders, dDispatches, dProductions, dSkus, { date: '2026-07-15', bestEstimate: 2500 })
+    } finally {
+      globalThis.document = origDoc; globalThis.URL = origURL; globalThis.Blob = origBlob
+    }
+    expect(buf).toBeTruthy()
+
+    const mod = await import('exceljs')
+    const ExcelJS = mod.Workbook ? mod : (mod.default ?? mod)
+    const wb = new ExcelJS.Workbook()
+    await wb.xlsx.load(buf)
+    expect(wb.worksheets.map(w => w.name)).toEqual(['Dashboard', 'SKU Ageing (Top 5)'])
+
+    const ws = wb.getWorksheet('Dashboard')
+    expect(String(ws.getCell('A1').value)).toContain('PB MTD DASHBOARD')
+    expect(ws.getCell('A8').value).toBe('ORDER STATUS SUMMARY')
+    expect(ws.getCell('G8').value).toBe('ORDER PIPELINE — MTD')
+    expect(Number(ws.getCell(5, 9).value)).toBeCloseTo(58, 6)   // Physical Inventory KPI card (card 5 → col 9, value row 5)
+    expect(Number(ws.getCell('E13').value)).toBe(8)             // Order Status → Confirmed Pending Invoice
+    expect(ws.getCell('E15').value).toBe('1.2%')                // Order Status → Invoice % of BE (30/2500)
+    expect(Number(ws.getCell('K18').value)).toBeCloseTo(145.2941, 3) // Order Pipeline → Daily Run Rate Required
+
+    const ws2 = wb.getWorksheet('SKU Ageing (Top 5)')
+    expect(ws2.getCell('A4').value).toBe('40x40 x 2.5')         // top SKU by on-hand MT
+    expect(ws2.getCell('A6').value).toBe('TOTAL (top 5)')
+    expect(Number(ws2.getCell('B6').value)).toBeCloseTo(58, 6)  // top-5 on-hand total
   })
 })


### PR DESCRIPTION
## Summary
Introduces a new **PB MTD Dashboard** Excel report (Report C) that mirrors the app's Sales/Dashboard KPIs and adds FIFO stock ageing analysis. The report is generated on-demand with an optional monthly target (Best Estimate) and exports to a 2-sheet workbook: a dashboard with 6 KPI cards and three colour-banded tables, plus a Top-5 SKUs by on-hand inventory sheet with age-bucket detail.

## Key Changes

### Core Data Builder (`src/lib/reports.js`)
- **`buildMtdDashboardData()`** — Pure, DOM-free function that computes:
  - **Order KPIs**: Invoiced MTD, confirmed/non-confirmed pending, order pipeline, invoice % of Best Estimate
  - **Production & Inventory**: Fresh production MTD, physical inventory (produced − invoiced), FIFO ageing by SKU
  - **Daily Run Rate**: `(BE − invoiced) / days remaining` when Best Estimate is supplied; null otherwise
  - **Age Buckets**: Splits on-hand weight into 0–30d, 31–60d, 61–90d, 90+ day bands (additive, sums to physical inventory)
  - **Top-5 SKUs**: Sorted by on-hand MT descending, with weighted-average age and bucket detail
  - Handles empty inputs gracefully; all date math is ISO-string-based (no timezone surprises)

### Excel Rendering (`src/lib/reports.js`)
- **`generateMtdDashboardReport()`** — Async function that:
  - Renders **Sheet 1 "Dashboard"**: 12-column landscape layout with frozen header
    - 6 KPI cards (2 cols × 3 rows) with colour bands: Best Estimate, Order Pipeline, Invoiced MTD, Pending, Physical Inventory, Inventory Ageing
    - Three colour-banded tables: Order Status Summary, Inventory & Production, Order Pipeline — MTD
    - All tables include indent-formatted sub-rows (e.g., ageing buckets under Inventory & Production)
  - Renders **Sheet 2 "SKU Ageing (Top 5)"**: Tabular detail with SKU label (size × thickness), on-hand MT, age buckets, oldest age, weighted-avg age, and a subtotal row
  - Handles null Best Estimate by rendering "N/A" for dependent metrics (Invoice % of BE, Daily Run Rate)
  - Exports as `PB-MTD-Dashboard-{date}.xlsx`

### Integration (`src/App.jsx`)
- Added **Reports** component prop: `orders` (required for dashboard data)
- New UI section "PB MTD Dashboard (Excel)" with:
  - Input field for optional Best Estimate (MT) with helper text
  - Button to generate the report; disables while generating
  - Inline error display
- Wired `generateMtdDashboardReport()` call with live-weight-resolved productions (caller responsibility)

### Calc Module Enhancement (`src/lib/calc.js`)
- **`skuAgeing()`** now returns `buckets: { d0_30, d31_60, d61_90, d90plus }` in addition to scalar ages
- Buckets are additive and sum to `onhandWeight`; earlier callers that read only scalar ages are unaffected

### Test Coverage (`src/lib/reports.test.js`)
- **`buildMtdDashboardData` unit tests** (9 tests):
  - Date derivation (month, prev-month, day, days remaining)
  - Order/invoice KPIs (confirmed/non-confirmed exclude Delivered lines)
  - Order Pipeline — MTD lines (prev-month same-days window, D/D-1, orders logged)
  - Production + physical inventory from live weights
  - FIFO ageing: bucket distribution, weighted-avg age, sum validation
  - Top-5 SKU sorting and labelling (size × thickness)
  - Best Estimate null handling (N/A rendering)
  - Best Estimate supplied (% of BE and Daily Run

https://claude.ai/code/session_01LeS2JzPqZVwWcmbMMESjgb