### PR TITLE
SKU ageing sheet: list all SKUs over 2 MT (follow-up to #68)

### DIFF
--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -152,6 +152,7 @@ const dashDay = (d) => Number(String(d || '').slice(8, 10))
 const dashShift = (iso, days) => { const d = new Date(iso + 'T00:00:00Z'); d.setUTCDate(d.getUTCDate() + days); return d.toISOString().slice(0, 10) }
 const dashPrevMonth = (iso) => { const d = new Date(iso + 'T00:00:00Z'); d.setUTCDate(1); d.setUTCMonth(d.getUTCMonth() - 1); return d.toISOString().slice(0, 7) }
 const dashDaysRemaining = (iso) => { const d = new Date(iso + 'T00:00:00Z'); const day = d.getUTCDate(); d.setUTCMonth(d.getUTCMonth() + 1, 0); return d.getUTCDate() - day + 1 } // report day → month end, inclusive
+const MIN_ONHAND_MT = 2 // Sheet 2 lists every SKU with more than this much on-hand finished stock (MT)
 
 export function buildMtdDashboardData(orders, dispatches, productions, skus, { date = today(), bestEstimate = null } = {}) {
   const D = date, D1 = dashShift(D, -1), D2 = dashShift(D, -2)
@@ -213,11 +214,11 @@ export function buildMtdDashboardData(orders, dispatches, productions, skus, { d
   })
   const invAgeingDaysAvg = onhandTot > 0 ? ageWtTot / onhandTot : null
 
-  // Top 5 SKUs by on-hand inventory (MT), descending — with their combined subtotal.
-  const top5 = ageingRows.slice().sort((a, b) => b.onhandMt - a.onhandMt).slice(0, 5)
-  const t5 = top5.reduce((acc, r) => { acc.onhandMt += r.onhandMt; addBkt(acc.buckets, r.buckets); acc.ageWt += r.onhandMt * r.avgAgeDays; return acc },
+  // Every SKU with on-hand inventory above MIN_ONHAND_MT, descending — with their combined subtotal.
+  const stockRows = ageingRows.filter(r => r.onhandMt > MIN_ONHAND_MT).sort((a, b) => b.onhandMt - a.onhandMt)
+  const st = stockRows.reduce((acc, r) => { acc.onhandMt += r.onhandMt; addBkt(acc.buckets, r.buckets); acc.ageWt += r.onhandMt * r.avgAgeDays; return acc },
     { onhandMt: 0, buckets: zeroBkt(), ageWt: 0 })
-  const top5Total = { onhandMt: t5.onhandMt, buckets: t5.buckets, avgAgeDays: t5.onhandMt > 0 ? t5.ageWt / t5.onhandMt : null }
+  const stockTotal = { onhandMt: st.onhandMt, buckets: st.buckets, avgAgeDays: st.onhandMt > 0 ? st.ageWt / st.onhandMt : null }
 
   return {
     date: D, month: MONTH, prevMonth: PREV, day: DAY, daysRemaining: remaining, bestEstimate: BE,
@@ -225,7 +226,7 @@ export function buildMtdDashboardData(orders, dispatches, productions, skus, { d
     orderStatus: { bestEstimate: BE, ordersReceived: totalOrders, invoicedMtd, confirmed, nonConfirmed, invoicePctOfBe },
     orderPipelineMtd: { totalOrders, ordersMonthIntake, invoicedMtd, invoicedPrev, dispatchD1, dispatchD, confirmed, nonConfirmed, dailyRunRate, ordersD, ordersD1, ordersD2 },
     inventoryProduction: { freshProductionMtd, physicalInventory, invAgeingDaysAvg, buckets: allBuckets },
-    skuAgeingTop5: { rows: top5, total: top5Total },
+    skuAgeingRows: { rows: stockRows, total: stockTotal },
   }
 }
 
@@ -542,33 +543,33 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
     { label: 'Orders Logged — D-2', value: op.ordersD2 },
   ])
 
-  // ── Sheet 2 — Top-5 SKUs by on-hand inventory (MT) + FIFO age buckets ──
-  const ws2 = wb.addWorksheet('SKU Ageing (Top 5)', {
+  // ── Sheet 2 — every SKU with on-hand inventory > MIN_ONHAND_MT (MT) + FIFO age buckets ──
+  const ws2 = wb.addWorksheet(`SKU Ageing (>${MIN_ONHAND_MT} MT)`, {
     views: [{ state: 'frozen', ySplit: 3 }],
     pageSetup: { orientation: 'landscape', fitToPage: true, fitToWidth: 1, fitToHeight: 0, margins: { left: 0.3, right: 0.3, top: 0.4, bottom: 0.4, header: 0.2, footer: 0.2 } },
   })
   ws2.columns = [{ width: 24 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 10 }, { width: 10 }, { width: 11 }, { width: 15 }]
-  writeTitle(ws2, 8, `${company} — TOP 5 SKUs BY ON-HAND INVENTORY (MT)`, date)
+  writeTitle(ws2, 8, `${company} — SKUs WITH ON-HAND INVENTORY > ${MIN_ONHAND_MT} MT`, date)
   styleHeaderRow(ws2.addRow(['SKU', 'On-hand MT', '0–30 d', '31–60 d', '61–90 d', '90+ d', 'Oldest (d)', 'Wtd Avg Age (d)']))
-  const t5 = data.skuAgeingTop5
-  if (!t5.rows.length) {
-    const r = ws2.addRow(['No finished stock on hand', '', '', '', '', '', '', '']); r.eachCell(c => { c.border = ALL_BORDERS })
+  const stock = data.skuAgeingRows
+  if (!stock.rows.length) {
+    const r = ws2.addRow([`No SKU with more than ${MIN_ONHAND_MT} MT on hand`, '', '', '', '', '', '', '']); r.eachCell(c => { c.border = ALL_BORDERS })
   }
-  t5.rows.forEach(row => {
+  stock.rows.forEach(row => {
     const r = ws2.addRow([row.label, row.onhandMt, row.buckets.d0_30, row.buckets.d31_60, row.buckets.d61_90, row.buckets.d90plus,
       row.oldestAgeDays == null ? '' : Math.round(row.oldestAgeDays), row.avgAgeDays == null ? '' : row.avgAgeDays])
     ;[2, 3, 4, 5, 6].forEach(i => numCell(r, i, '#,##0.0'))
     numCell(r, 7, '0'); numCell(r, 8, '0.0')
     r.eachCell(c => { c.border = ALL_BORDERS })
   })
-  if (t5.rows.length) {
-    const tr = ws2.addRow(['TOTAL (top 5)', t5.total.onhandMt, t5.total.buckets.d0_30, t5.total.buckets.d31_60,
-      t5.total.buckets.d61_90, t5.total.buckets.d90plus, '', t5.total.avgAgeDays == null ? '' : t5.total.avgAgeDays])
+  if (stock.rows.length) {
+    const tr = ws2.addRow([`TOTAL (>${MIN_ONHAND_MT} MT)`, stock.total.onhandMt, stock.total.buckets.d0_30, stock.total.buckets.d31_60,
+      stock.total.buckets.d61_90, stock.total.buckets.d90plus, '', stock.total.avgAgeDays == null ? '' : stock.total.avgAgeDays])
     tr.font = { bold: true }
     ;[2, 3, 4, 5, 6].forEach(i => numCell(tr, i, '#,##0.0')); numCell(tr, 8, '0.0')
     tr.eachCell(c => { c.fill = fill(COLOR.sub); c.border = ALL_BORDERS })
   }
-  const note = ws2.addRow(['Top 5 by on-hand MT. Full-stock ageing totals are on the Dashboard sheet (Inventory & Production).'])
+  const note = ws2.addRow([`All SKUs with more than ${MIN_ONHAND_MT} MT on-hand stock, by tonnage. Full-stock ageing totals are on the Dashboard sheet (Inventory & Production).`])
   ws2.mergeCells(`A${note.number}:H${note.number}`)
   note.getCell(1).font = { italic: true, size: 9, color: { argb: 'FF6B7280' } }
 

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -177,15 +177,32 @@ describe('buildMtdDashboardData', () => {
     expect(kpis.invAgeingDaysAvg).toBeCloseTo(7.5, 4) // (28*5 + 30*9.8333)/58
   })
 
-  it('top-5 SKU ageing: sorted by on-hand MT desc, labelled size × thickness, with subtotal', () => {
-    const { skuAgeingTop5 } = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
-    expect(skuAgeingTop5.rows).toHaveLength(2)
-    expect(skuAgeingTop5.rows[0].onhandMt).toBeCloseTo(30, 6) // S2 first (bigger)
-    expect(skuAgeingTop5.rows[0].label).toBe('40x40 x 2.5')
-    expect(skuAgeingTop5.rows[1].onhandMt).toBeCloseTo(28, 6) // S1
-    expect(skuAgeingTop5.rows[1].label).toBe('50x50 x 2')
-    expect(skuAgeingTop5.total.onhandMt).toBeCloseTo(58, 6)
-    expect(skuAgeingTop5.total.avgAgeDays).toBeCloseTo(7.5, 4)
+  it('SKU ageing (>2 MT): sorted by on-hand MT desc, labelled size × thickness, with subtotal', () => {
+    const { skuAgeingRows } = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
+    expect(skuAgeingRows.rows).toHaveLength(2) // S1 (28) and S2 (30) both exceed 2 MT
+    expect(skuAgeingRows.rows[0].onhandMt).toBeCloseTo(30, 6) // S2 first (bigger)
+    expect(skuAgeingRows.rows[0].label).toBe('40x40 x 2.5')
+    expect(skuAgeingRows.rows[1].onhandMt).toBeCloseTo(28, 6) // S1
+    expect(skuAgeingRows.rows[1].label).toBe('50x50 x 2')
+    expect(skuAgeingRows.total.onhandMt).toBeCloseTo(58, 6)
+    expect(skuAgeingRows.total.avgAgeDays).toBeCloseTo(7.5, 4)
+  })
+
+  it('SKU ageing (>2 MT): excludes SKUs with 2 MT or less on-hand', () => {
+    const skus = [
+      { skuCode: 'BIG', productType: 'SHS', height: 50, breadth: 50, thickness: 2.0, length: 6000, weightPerTube: 10 },
+      { skuCode: 'SMALL', productType: 'SHS', height: 40, breadth: 40, thickness: 2.5, length: 6000, weightPerTube: 8 },
+    ]
+    const productions = [
+      { skuCode: 'BIG', dateOfProduction: '2026-07-10', tubeCount: 10, totalWeight: 10 },   // on-hand 9 (>2 → kept)
+      { skuCode: 'SMALL', dateOfProduction: '2026-07-10', tubeCount: 5, totalWeight: 5 },    // on-hand 1.5 (≤2 → dropped)
+    ]
+    const dispatches = [
+      { dateOfDispatch: '2026-07-12', bundleEntries: [{ skuCode: 'BIG', weight: 1 }, { skuCode: 'SMALL', weight: 3.5 }] },
+    ]
+    const { skuAgeingRows } = buildMtdDashboardData([], dispatches, productions, skus, { date: '2026-07-15' })
+    expect(skuAgeingRows.rows.map(r => r.label)).toEqual(['50x50 x 2']) // only BIG (9 MT); SMALL (1.5 MT) excluded
+    expect(skuAgeingRows.total.onhandMt).toBeCloseTo(9, 6)
   })
 
   it('Best Estimate blank ⇒ Invoice % of BE and Daily Run Rate are null (render N/A)', () => {
@@ -204,7 +221,7 @@ describe('buildMtdDashboardData', () => {
     const r = buildMtdDashboardData([], [], [], [], { date: D })
     expect(r.kpis.physicalInventory).toBe(0)
     expect(r.kpis.invAgeingDaysAvg).toBeNull()
-    expect(r.skuAgeingTop5.rows).toEqual([])
+    expect(r.skuAgeingRows.rows).toEqual([])
   })
 })
 
@@ -228,7 +245,7 @@ describe('generateMtdDashboardReport (render smoke test)', () => {
     const ExcelJS = mod.Workbook ? mod : (mod.default ?? mod)
     const wb = new ExcelJS.Workbook()
     await wb.xlsx.load(buf)
-    expect(wb.worksheets.map(w => w.name)).toEqual(['Dashboard', 'SKU Ageing (Top 5)'])
+    expect(wb.worksheets.map(w => w.name)).toEqual(['Dashboard', 'SKU Ageing (>2 MT)'])
 
     const ws = wb.getWorksheet('Dashboard')
     expect(String(ws.getCell('A1').value)).toContain('PB MTD DASHBOARD')
@@ -239,9 +256,9 @@ describe('generateMtdDashboardReport (render smoke test)', () => {
     expect(ws.getCell('E15').value).toBe('1.2%')                // Order Status → Invoice % of BE (30/2500)
     expect(Number(ws.getCell('K18').value)).toBeCloseTo(145.2941, 3) // Order Pipeline → Daily Run Rate Required
 
-    const ws2 = wb.getWorksheet('SKU Ageing (Top 5)')
-    expect(ws2.getCell('A4').value).toBe('40x40 x 2.5')         // top SKU by on-hand MT
-    expect(ws2.getCell('A6').value).toBe('TOTAL (top 5)')
-    expect(Number(ws2.getCell('B6').value)).toBeCloseTo(58, 6)  // top-5 on-hand total
+    const ws2 = wb.getWorksheet('SKU Ageing (>2 MT)')
+    expect(ws2.getCell('A4').value).toBe('40x40 x 2.5')         // highest-inventory SKU
+    expect(ws2.getCell('A6').value).toBe('TOTAL (>2 MT)')
+    expect(Number(ws2.getCell('B6').value)).toBeCloseTo(58, 6)  // >2 MT on-hand total
   })
 })


### PR DESCRIPTION
## Summary
Follow-up to #68, which shipped the PB MTD Dashboard with a **Top-5** SKU ageing sheet. This changes Sheet 2 of the dashboard workbook to list **every SKU whose on-hand finished stock exceeds 2 MT**, sorted by tonnage descending, instead of a fixed top 5. #68 merged before this refinement landed, so it goes in as its own PR.

## Changes (`src/lib/reports.js`)
- `buildMtdDashboardData` now filters the ageing rows by `onhandMt > MIN_ONHAND_MT` (2 MT) instead of slicing to a fixed count; the returned field is `skuAgeingRows` (was `skuAgeingTop5`), with the subtotal summing the filtered rows.
- The sheet name **"SKU Ageing (>2 MT)"**, the title, and the **"TOTAL (>2 MT)"** row are all driven off the `MIN_ONHAND_MT` constant, so the cutoff is a one-line change if it ever needs adjusting.
- Print-fit (`fitToWidth: 1`, `fitToHeight: 0`) flows a longer list onto additional landscape pages when needed.

Everything else in the dashboard (KPI band, Order Status Summary, Order Pipeline — MTD, Inventory & Production, and the Sheet-1 full-stock ageing buckets) is unchanged.

## Tests (`src/lib/reports.test.js`)
- Updated the ageing assertions to the new `skuAgeingRows` shape and the `>2 MT` sheet/label names in the render smoke test.
- Added a test asserting a SKU with ≤ 2 MT on-hand is excluded from the list.
- `npm test` → **167 passing**; `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeS2JzPqZVwWcmbMMESjgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeS2JzPqZVwWcmbMMESjgb)_