### PR TITLE
Add communication guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,15 @@ You operate as the decision-maker in a modular system. Your job is NOT to do eve
 
 Why? 90% accuracy across 5 steps = 59% total success. Push repeatable work into tested scripts. You focus on decisions.
 
+## How To Answer Me
+- Plain English. Explain unavoidable jargon in brackets, once.
+- Answer first, then the reasoning. Headers and bullets, not walls of text.
+- Examples must use my real files and numbers, never generic ones.
+- Draw a small text diagram when there's branching, ordering, or a comparison — skip it otherwise, and keep it under 12 lines.
+- When I have to decide: what improves, what gets worse, what bites me later, what breaks. Then pick one and say why.
+- Say what you did NOT do, not just what you did.
+- Short is still the goal. Structure, not volume.
+
 ## System Architecture
 **Blueprints (/blueprints)** - Step-by-step instructions in markdown. Goal, inputs, scripts to use, output, edge cases. Check here FIRST.
 


### PR DESCRIPTION
## Summary
Added a new "How To Answer Me" section to CLAUDE.md that documents the expected format and style for responses within the system. This establishes clear conventions for how Claude should communicate with the user when making decisions and providing guidance.

## Key Changes
- **New section: "How To Answer Me"** — Documents 7 communication principles:
  - Plain English with jargon explained in brackets (once per term)
  - Answer-first structure with headers and bullets, not prose walls
  - Real examples using actual project files and numbers
  - Text diagrams for branching/ordering/comparisons (max 12 lines)
  - Decision framing: what improves, what worsens, what breaks later, then recommendation with reasoning
  - Explicit callout of what was NOT done, not just what was
  - Emphasis on structure over volume

## Implementation Details
The section is positioned early in CLAUDE.md (after the Core Principle, before System Architecture) to make it immediately visible as a reference guide. It reinforces the project's philosophy of focused decision-making by clarifying how communication should support that goal — concise, structured, and decision-oriented rather than comprehensive or verbose.

This aligns with the existing "90% accuracy across 5 steps" principle by ensuring responses are optimized for clarity and actionability rather than exhaustiveness.

https://claude.ai/code/session_01PzbFF7pd8XKGRymSnBmr8U