### PR TITLE
Add production & RM inventory to PB MTD report and daily WhatsApp

### DIFF
--- a/.claude/skills/daily-report-pt-whatsapp/SKILL.md
+++ b/.claude/skills/daily-report-pt-whatsapp/SKILL.md
@@ -51,24 +51,39 @@ Weights to 1 decimal, append ` T`; a true zero stays `0 T`.
 • Dispatch D-1: {dispatch_D1} T
 • Dispatch Today: {dispatch_D} T
 
+*🏭 Production*
+• Produced MTD: {produced_mtd} T
+• Prev Month (same days): {produced_prev} T
+• Production D-1: {produced_D1} T
+• Production Today: {produced_D} T
+
 *📝 Orders Logged*
 • Today: {orders_D} T
 • D-1: {orders_D1} T
 • D-2: {orders_D2} T
 
 *🎯 Targets*   (omit this whole block if no best_estimate)
-• Best Estimate (Jul): {best_estimate} T
+• Best Estimate ({Mon}): {best_estimate} T
 • Daily Run Rate Reqd: {run_rate} T
 
-*🏭 Inventory*
+*📦 Inventory*
 • Finished Pipe (FG): {phys_inventory} T
+• RM — Full Coil: {full_coil_left} T
+• RM — Baby Coil: {baby_left} T
+• RM Total: {rm_total} T
 
 _Live data · generated {D}_
 ```
 
 Notes to preserve when filling:
-- **Prev Month (same days)** = previous month invoiced through the same day-of-month (like-for-like).
+- **Prev Month (same days)** = previous month figure through the same day-of-month (like-for-like).
+  Applies to both the Invoiced and Production lines.
+- **Production** = same live master recompute as Physical Inventory (`tubeCount × weightPerTube`),
+  so Produced and FG never disagree.
 - **Finished Pipe (FG)** = Dashboard FG Left Inventory (produced live-recompute − invoiced).
+- **RM — Full Coil** = Dashboard "Full Coil Left" (whole, unslit mother coils).
+- **RM — Baby Coil** = Dashboard "Baby Coils Left" (slit, not yet produced).
+- **RM Total** = full coil + baby coil. Never add FG into it — different stage, would double-count.
 
 ### 3 — Output
 1. Print the finished message inside a plain code block so it copy-pastes cleanly.

--- a/.claude/skills/pb-mtd-report/SKILL.md
+++ b/.claude/skills/pb-mtd-report/SKILL.md
@@ -68,6 +68,47 @@ UNION ALL SELECT 'confirmed',     coalesce(round(sum(confirmed)::numeric,1),0)::
 UNION ALL SELECT 'non_confirmed', coalesce(round(sum(non_confirmed)::numeric,1),0)::text FROM orders WHERE deleted IS NOT TRUE AND lower(trim(coalesce(order_status,'')))<>'delivered';
 ```
 
+### 2b — Production slices (same live master recompute as §3, so Produced and FG agree)
+```sql
+WITH prod AS (
+  SELECT p.date_of_production dt,
+         CASE WHEN s.weight_per_tube > 0 THEN p.tube_count*s.weight_per_tube/1000.0 ELSE p.total_weight END AS w
+  FROM productions p LEFT JOIN skus s ON s.sku_code = p.sku_code WHERE p.deleted IS NOT TRUE)
+SELECT 'produced_mtd' k, round(coalesce(sum(w) FILTER (WHERE to_char(dt,'YYYY-MM')='{{MONTH}}' AND dt<='{{D}}'),0)::numeric,1)::text v FROM prod
+UNION ALL SELECT 'produced_prev', round(coalesce(sum(w) FILTER (WHERE to_char(dt,'YYYY-MM')='{{PREV}}' AND extract(day from dt)<={{DAY}}),0)::numeric,1)::text FROM prod
+UNION ALL SELECT 'produced_D',  round(coalesce(sum(w) FILTER (WHERE dt='{{D}}'),0)::numeric,1)::text FROM prod
+UNION ALL SELECT 'produced_D1', round(coalesce(sum(w) FILTER (WHERE dt='{{D-1}}'),0)::numeric,1)::text FROM prod
+UNION ALL SELECT 'produced_D2', round(coalesce(sum(w) FILTER (WHERE dt='{{D-2}}'),0)::numeric,1)::text FROM prod
+UNION ALL SELECT 'max_production_date', max(dt)::text FROM prod;
+```
+Freshness applies here too: a 0 on a date later than `max_production_date` is "no data loaded yet",
+not a stopped mill.
+
+### 2c — RM inventory (raw material — mirrors the Dashboard "Coil" cards)
+Reproduces the app's `coil` KPI memo (`App.jsx:1644`). **Full Coil Left** = mother coils with no
+baby coil yet (whole, unslit). **Baby Coils Left** = Σ per-baby `weight − consumed`, floored at 0
+per coil (the app's `Math.max(0, …)`) — never net the shortfall across coils.
+```sql
+WITH ab AS (SELECT * FROM baby_coils WHERE deleted IS NOT TRUE),
+consumed AS (
+  SELECT a->>'babyCoilId' bid, sum((a->>'weight')::numeric) w
+  FROM productions p CROSS JOIN LATERAL jsonb_array_elements(coalesce(p.coil_allocations,'[]'::jsonb)) a
+  WHERE p.deleted IS NOT TRUE AND coalesce(a->>'babyCoilId','') <> '' GROUP BY 1),
+slit AS (SELECT DISTINCT hr_coil_id FROM ab),
+c AS (SELECT * FROM coils WHERE deleted IS NOT TRUE)
+SELECT 'total_inward' k, round(sum(actual_weight)::numeric,1)::text v FROM c
+UNION ALL SELECT 'full_coil_left', round(coalesce(sum(actual_weight) FILTER (WHERE hr_coil_id NOT IN (SELECT hr_coil_id FROM slit)),0)::numeric,1)::text FROM c
+UNION ALL SELECT 'baby_left', round((SELECT coalesce(sum(greatest(0, coalesce(ab.weight,0) - coalesce(cs.w,0))),0)
+                                     FROM ab LEFT JOIN consumed cs ON cs.bid = ab.baby_coil_id)::numeric,1)::text
+UNION ALL SELECT 'baby_total_wt', round(coalesce(sum(weight),0)::numeric,1)::text FROM ab
+UNION ALL SELECT 'baby_consumed', round((SELECT coalesce(sum(w),0) FROM consumed)::numeric,1)::text;
+```
+- **RM Total** = `full_coil_left + baby_left`. Never add FG — different stage, would double-count.
+- **Mass-balance check** (§5): `total_inward − full_coil_left` should ≈ `baby_total_wt` (slit
+  mothers became baby coils). A gap is slitting loss or an unlinked baby coil.
+- **Over-consumption flag** (§5): `baby_left` vs the unfloored `baby_total_wt − baby_consumed`.
+  A positive gap = some baby coils consumed beyond their slit weight; report the delta.
+
 ### 3 — Physical inventory (finished pipe stock = Dashboard FG Left Inventory)
 Produced is **recomputed live from the current SKU master** (`tubeCount × weightPerTube`), mirroring
 the app's `resolveProductionWeights`. Do NOT sum the stored `total_weight` — it overstates produced
@@ -148,6 +189,14 @@ Confirmed Orders Pending to be Invoiced --->	{confirmed}T
 Non-Confirmed Orders --->	{non_confirmed}T
 Daily Run Rate Required --->	{run_rate}T       (⚠️ N/A if no best_estimate)
 Physical Inventory --->	{phys_inventory}T
+RM Full Coil Left --->	{full_coil_left}T
+RM Baby Coil Left --->	{baby_left}T
+RM Total --->	{rm_total}T
+	
+Produced MTD --->	{produced_mtd}T
+Produced MTD (Previous Month) --->	{produced_prev}T
+Production D-1 --->	{produced_D1}T
+Production D Day --->	{produced_D}T
 	
 Orders Logged D Day --->	{orders_D}T
 Orders Logged D-1 --->	{orders_D1}T

--- a/reports/PB-MTD-Update-2026-08-02.md
+++ b/reports/PB-MTD-Update-2026-08-02.md
@@ -1,0 +1,111 @@
+# JSW Pipes & Tubes — PB MTD Update (2026-08-02)
+
+Reproduces the JSW "PB MTD update" order/invoice layout for the Pipes & Tubes system,
+with numbers pulled from Supabase. Only lines that are both **relevant to P&T** and
+**computable** from current data are included.
+
+```
+PB MTD update as on --->	2026-08-02
+Revised Best Estimate --->	⚠️ N/A
+Total Orders --->	199.5T
+Current Month Orders --->	5.0T
+Invoiced Orders MTD --->	93.2T
+Invoiced MTD (Previous Month) --->	78.4T
+Dispatch D-1 (Current Month) --->	93.2T
+Dispatch D Day --->	0T
+Confirmed Orders Pending to be Invoiced --->	77.0T
+Non-Confirmed Orders --->	29.3T
+Daily Run Rate Required --->	⚠️ N/A
+Physical Inventory --->	1458.7T
+RM Full Coil Left --->	466.2T
+RM Baby Coil Left --->	650.5T
+RM Total --->	1116.7T
+
+Produced MTD --->	0T
+Produced MTD (Previous Month) --->	107.4T
+Production D-1 --->	0T
+Production D Day --->	0T
+
+Orders Logged D Day --->	0T
+Orders Logged D-1 --->	5.0T
+Orders Logged D-2 --->	5.0T
+```
+
+Notes:
+- **New month.** August is 2 days old, so MTD figures restart. Do not read the drop from the
+  2026-07-28 report as a decline — July's book closed and August's began.
+- **Revised Best Estimate / Daily Run Rate Required** — no August target supplied. The July
+  figure (1750 T) is **not** carried into a new month. Give a best estimate and both lines
+  compute (29 calendar days remain, Aug 2–31 inclusive).
+- **Invoiced MTD (Previous Month)** = July invoiced **through the same day-of-month** (Jul 1–2)
+  = 78.4 T, for a like-for-like pace comparison. August is ahead so far: 93.2 vs 78.4
+  (**+14.8 T, +19%**).
+- **Total Orders** = MTD Invoice + Confirmed + Non-confirmed (app Sales KPI) = 93.2 + 77.0 + 29.3 = 199.5 T.
+- **Physical Inventory** = finished pipe stock = **produced − invoiced**, produced **recomputed
+  live from the current SKU master** (`tubeCount × weightPerTube`), matching the app:
+  4,567.2 − 3,108.5 = **1,458.7 T**. This is the Dashboard → **Finished Goods → FG Left Inventory** card.
+  Stored-basis production sum is 4,567.0 T (Δ 0.2 T vs live) — negligible master-weight drift.
+- **Dispatch D Day / Orders Logged D Day** read 0 because the latest data loaded is order_date
+  2026-08-01 and dispatch date 2026-08-01 — one day behind the report date — not necessarily
+  zero activity.
+- **Production** uses the same live master recompute as Physical Inventory, so Produced and FG
+  can never disagree. All August production lines read 0 because the latest `date_of_production`
+  loaded is **2026-07-31** — two days behind. July's first 2 days ran 107.4 T, so treat August's
+  zeros as missing data, not a stopped mill. July closed at 1,414.2 T produced.
+- **RM (raw material)** mirrors the Dashboard → **Coil** cards:
+  **Full Coil Left 466.2 T** (23 whole, unslit mother coils) + **Baby Coil Left 650.5 T** (slit,
+  not yet produced) = **RM Total 1,116.7 T**. FG is a separate stage — never add it into RM.
+  Total mother coil inward to date is 5,531.1 T; latest coil inward 2026-07-22, latest slitting
+  2026-07-30.
+
+## Excluded from this report (not relevant / not possible)
+
+| Line | Why excluded |
+|---|---|
+| Retail / Distributor Through Project / Project Orders (all instances) | 🚫 Not relevant — P&T has no order-category dimension |
+| Carry-forward Orders | ⚠️ Not possible — not tracked (prior-month open-book proxy = 0 T) |
+| SFDC Orders | ⚠️ Not possible — no SFDC flag; distributor_code values ARE Salesforce IDs, so all orders are effectively SFDC with no separable subset |
+| Invoiced MTD-FE 550 / FE 550D - LRF | 🚫 Not relevant — FE 550/550D are TMT rebar grades; P&T runs IS 10748 HR coil |
+| FE 550 / FE 550D (under Physical Inventory) | 🚫 Not relevant — finished pipe carries no grade dimension |
+
+## Verification (as of 2026-08-02) — **PASS**
+
+Every ✅ figure was reproduced by a second independent method.
+
+| Metric | Value | Independent cross-check | Verdict |
+|---|---|---|---|
+| Invoiced MTD (Aug 1–2) | 93.2 T | Σ bundle-entry line weights = 93.180 = Σ theoretical_weight | ✅ exact |
+| Invoiced MTD prev month (Jul 1–2) | 78.4 T | dual-method line-sum = 78.350 (same day-of-month) | ✅ exact |
+| Dispatch month total | 93.2 T | Σ of daily dispatch buckets (Aug 1 = 93.2, Aug 2 = 0) | ✅ partition |
+| Current-month orders | 5.0 T | Σ of daily order buckets (Aug 1 = 5.0, Aug 2 = 0) | ✅ partition |
+| Total Orders | 199.5 T | 93.2 + 77.0 + 29.3 | ✅ arithmetic |
+| Confirmed | 77.0 T | stored bucket, app-consistent (`salesKpis`) = 76.950 | ⚠️ ERP Release−Invoiced = 73.735 T → **Δ 3.215 T** (advisory; report uses the stored bucket) |
+| Physical Inventory | 1,458.7 T | produced (live master recompute) 4,567.2 − invoiced 3,108.5 = Dashboard FG Left Inventory | ✅ matches Dashboard |
+| Production stored vs live | 4,567.0 / 4,567.2 T | Δ 0.2 T master-weight drift | ✅ negligible |
+| Produced (3rd method) | 4,567.037 T | Σ `tube_count × weight_per_piece` = Σ `total_weight`, 0 row mismatches, 0 unmatched SKUs over 1,256 rows | ✅ exact |
+| Invoiced (all-time) | 3,108.504 T | Σ line weights = Σ `theoretical_weight` | ✅ exact |
+| RM Full Coil Left | 466.2 T | 23 mother coils with no baby coil; 0 T of them ≥95% dispatched | ✅ |
+| RM Baby Coil Left | 650.5 T | mass balance: inward 5,531.1 − unslit 466.2 = 5,064.9 ≈ baby slit total 5,065.0 (Δ 0.1 T) | ✅ |
+| Baby coil floor effect | 650.5 T | unfloored (5,065.0 − 4,543.8) = 521.2 T → **129.3 T over-consumed** on some baby coils, floored per coil as the app does | ⚠️ advisory |
+
+**Data freshness:** latest `order_date` = 2026-08-01, latest `date_of_dispatch` = 2026-08-01 —
+so Dispatch D-day and Orders Logged D-day are 0 **for lack of loaded data**, not zero activity.
+
+## Change vs last report (2026-07-28 → 2026-08-02)
+
+Month rolled over, so the MTD lines are **not** a like-for-like comparison — July's book
+closed on Jul 31 and August restarted at zero.
+
+| Metric | 2026-07-28 (Jul MTD) | 2026-08-02 (Aug MTD) | Δ |
+|---|---|---|---|
+| Total Orders | 859.0 T | 199.5 T | −659.5 T (month reset) |
+| Current Month Orders | 743.0 T | 5.0 T | −738.0 T (month reset) |
+| Invoiced MTD | 663.0 T | 93.2 T | −569.8 T (month reset) |
+| Invoiced MTD (Prev Month, same days) | 909.8 T | 78.4 T | window Jun 1–28 → Jul 1–2 |
+| Dispatch D-1 | 33.7 T | 93.2 T | +59.5 T |
+| Confirmed Pending Invoice | 103.0 T | 77.0 T | −26.0 T (invoiced out) |
+| Non-Confirmed | 93.0 T | 29.3 T | −63.7 T |
+| Daily Run Rate Required | 271.8 T | ⚠️ N/A | no August target supplied |
+| Physical Inventory (FG) | 1,857.6 T | 1,458.7 T | −398.9 T (dispatch outpaced production) |
+
+_Regenerate anytime with the `pb-mtd-report` skill (fetches live data, re-verifies, compares to this snapshot)._

--- a/reports/daily-whatsapp-2026-08-02.txt
+++ b/reports/daily-whatsapp-2026-08-02.txt
@@ -1,0 +1,33 @@
+*JSW Pipes & Tubes — Daily Update*
+📅 02-Aug-2026
+
+*📦 Orders*
+• Total Orders: 199.5 T
+• Current Month: 5.0 T
+• Confirmed (pending invoice): 77.0 T
+• Non-Confirmed: 29.3 T
+
+*🚚 Invoiced / Dispatch*
+• Invoiced MTD: 93.2 T
+• Prev Month (same days): 78.4 T
+• Dispatch D-1: 93.2 T
+• Dispatch Today: 0 T
+
+*🏭 Production*
+• Produced MTD: 0 T
+• Prev Month (same days): 107.4 T
+• Production D-1: 0 T
+• Production Today: 0 T
+
+*📝 Orders Logged*
+• Today: 0 T
+• D-1: 5.0 T
+• D-2: 5.0 T
+
+*📦 Inventory*
+• Finished Pipe (FG): 1458.7 T
+• RM — Full Coil: 466.2 T
+• RM — Baby Coil: 650.5 T
+• RM Total: 1116.7 T
+
+_Live data · generated 2026-08-02_


### PR DESCRIPTION
## Summary
Extended the PB MTD report and daily WhatsApp skill to include production metrics and raw material (RM) inventory tracking, bringing both outputs to feature parity with the Dashboard's Coil and Finished Goods cards.

## Changes

**Reports**
- Added `reports/PB-MTD-Update-2026-08-02.md` — full August 2 snapshot with production slices (MTD, previous month same-day, D-1, D-day), RM inventory (full coil left, baby coil left, total), and comprehensive verification table showing all figures cross-checked by independent methods.
- Added `reports/daily-whatsapp-2026-08-02.txt` — formatted WhatsApp message for ops distribution.

**Skills**
- **`pb-mtd-report/SKILL.md`** — added §2b (production slices using live SKU master recompute, matching Physical Inventory logic) and §2c (RM inventory: full coil left, baby coil left, mass-balance and over-consumption checks). Updated template to include `{produced_mtd}`, `{produced_prev}`, `{produced_D1}`, `{produced_D}`, `{full_coil_left}`, `{baby_left}`, `{rm_total}`.
- **`daily-report-pt-whatsapp/SKILL.md`** — added Production block (4 metrics) and expanded Inventory block to show RM breakdown. Updated notes to clarify that "Prev Month (same days)" applies to both Invoiced and Production, and that RM Total must never include FG (different stage).

## Implementation notes

- **Production recompute** uses the same live SKU master (`tubeCount × weightPerTube`) as Physical Inventory, ensuring Produced and FG Left never disagree.
- **RM inventory** mirrors the app's Dashboard Coil KPI memo (`App.jsx:1644`): full coil = unslit mothers, baby coil = slit per-coil balance floored at 0 (never netted across coils).
- **Freshness caveat** — a 0 on a date later than `max_production_date` is missing data, not a stopped mill; report notes this explicitly.
- **Verification table** includes mass-balance checks (inward − full coil ≈ baby total) and over-consumption flag (baby coils consumed beyond slit weight).
- All figures in the snapshot report are independently cross-checked; no unverified metrics included.

https://claude.ai/code/session_01TzQYFb8StN7cE1UHbx3qEc