### PR TITLE
Store ship-to state on every order and invoice line

### DIFF
--- a/blueprints/import-daily-dispatch.md
+++ b/blueprints/import-daily-dispatch.md
@@ -18,6 +18,7 @@ The **One Helix** invoice `.xlsx` (Zoho-style, one row per invoice line, 13 colu
 | customer | **Customer Name** | stored **per entry** (JSONB), shown in table + reconciliation CSV |
 | childOrderId | **PurchaseOrder** | == the order's Child Order ID → preserves distributor/order linkage |
 | poRef / branch | **CF.Purchase Bill Reference No** / **Branch Name** | stored per entry (reference only) |
+| shipToState | **Ship to GST** (first 2 digits) | no state column on this sheet — decoded via `resolveShipToState` (`calc.js`), `Bill to - GST` as fallback; stored per entry, blank when unresolvable (see `docs/DATA-MODEL.md`) |
 
 The One Helix export fills **MM ID** on every line, so that is matched first; older sheets without
 it still resolve by **Item Name**. There is **no pieces** column → pieces are derived from weight

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -12,11 +12,29 @@ All pipeline data lives in **Supabase Postgres**, accessed via `useSupabaseStore
 | `jsw:dispatches` | `dispatches` | Stage 4 dispatch **and invoice** records — now loaded from the daily "Upload Sales Excel" **Invoice** tab (via `buildDispatchRecords`, called from the Orders component); the Dispatch tab is a read-only records/reconciliation view. `bundle_entries` carry per-entry `invoiceNo`, `coilAllocations` (`{babyCoilId,hrCoilId,…}`), and legacy `traceHrCoilId` |
 | `jsw:skus` | `skus` | SKU master (falls back to `DEFAULT_SKUS` when table is empty) |
 | `jsw:distributorEstimates` | `distributor_estimates` | **Distributor Monthly Estimate** — the typed Best Estimate (planned invoiced MT) for one distributor in one month. `distributor_key` is the app's resolved distributor identity (ERP `distributor_code` when present, otherwise the normalised name — the same key `salesByDistributor` groups by), `month` is `'YYYY-MM'`. **Unique on `(distributor_key, month)`**, which is also the upsert arbiter. Written inline from the Sales tab; the plant Best Estimate is their sum, never typed (see `docs/adr/0001-…`) |
-| `jsw:orders` | `orders` | Customer order book — Orders tab of the daily Sales upload. Per-line `confirmed` (ERP Release − Invoiced), `non_confirmed` (Ordered − Release − Cancelled), and `distributor_code`. **PO Master was removed (July 2026)** — the `purchase_orders` table is left dormant |
+| `jsw:orders` | `orders` | Customer order book — Orders tab of the daily Sales upload. Per-line `confirmed` (ERP Release − Invoiced), `non_confirmed` (Ordered − Release − Cancelled), `distributor_code`, and `ship_to_state` (see below). **PO Master was removed (July 2026)** — the `purchase_orders` table is left dormant |
 
 The change is **additive/backward-compatible**: production `coil_allocations` carry **both** `babyCoilId` (capacity/FIFO) and the mother `hrCoilId` (cost/tracker), and legacy mother-only/`traceHrCoilId` rows still resolve. The `baby_coils` table is **active again** — re-added to `TABLE_MAP`/`HARD_DELETE_TABLES` in `db.js`; the `delete from baby_coils;` wipe was removed from `supabase-setup.sql`.
 
 The `bundles` and `tubes` tables still exist in Postgres but are **legacy** — Bundle Formation was removed and the tube stage stays removed; neither is read/written by the app.
+
+## Ship-to state (region reporting)
+Every order line and every invoice line carries the state it shipped to, so sales can be grouped by
+region. The two sheets of the One Helix workbook supply it differently — resolved by
+`resolveShipToState()` / `gstStateName()` in `src/lib/calc.js` and stored **UPPER-CASE** on both
+sides, so `TAMIL NADU` from an order and from an invoice group under one key:
+
+| Source | Where it's stored | How the state is derived |
+|---|---|---|
+| **Orders** sheet | `orders.ship_to_state` (new column; `alter table … add column if not exists` in `supabase-setup.sql`) | The sheet's own **`Ship to State`** column, populated on every row. Its `Ship to GST` is the literal `0`, so the GSTIN fallback lands on **`Bill to - GST`** |
+| **Invoice** sheet | per-entry `shipToState` **inside `dispatches.bundle_entries`** — `dispatches` has no such column, and a stray top-level key makes Supabase reject the whole upsert | The sheet has **no state column**: state = the first two digits of **`Ship to GST`** (the GST state code — 29 Karnataka, 33 Tamil Nadu, 36 Telangana, …), falling back to `Bill to - GST` |
+
+`GST_STATE_CODES` in `calc.js` holds **every** state/UT code (01–38 plus 97/99), not only those seen
+in today's file, so a first shipment to a new state resolves the day it happens. A line whose state
+cannot be resolved (blank column, `0`, non-numeric or unknown prefix) stores **blank** and is counted
+in the upload banner — it is **never** guessed from a customer name, city or pincode. Both stores are
+replace-all on upload, so one "Upload Sales Excel" run backfills the whole history; there is no
+separate migration of existing rows.
 
 ## Sync & upsert semantics
 Mutations update React state optimistically, then sync to Supabase in the background; failures broadcast a `jsw:syncError` window event **and re-read the table** so state can't keep claiming rows Postgres refused. Upserts arbitrate on `id` except **`skus`, which arbitrates on `sku_code`**, and **`distributor_estimates`, which arbitrates on the composite `distributor_key,month`** (`conflictTargetFor` in `db.js`) — that column is UNIQUE, and Postgres resolves `ON CONFLICT` against only ONE index, so a conflict on a *non-arbiter* unique column is a hard error that fails the whole batch.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import {
   rmRollsFg, capAllocationRows, requiredStripWidth, WIDTH_TOL_MM, isOpenOrderStatus, skuInventoryRows, skuSizeLabel,
   canonicalSkuKey, skuKeyResolver, skuImportResolver, salesKpis, salesByDistributor, salesByMonth,
   shippedByOrderLine, orderLineInvoiced, orderLineStage, distributorCode, dedupeDispatchLines, toISODate,
+  resolveShipToState,
 } from './lib/calc'
 import DEFAULT_SKUS from './data/skus'
 // Seed data imports kept for reference — all arrays are now empty
@@ -1300,6 +1301,13 @@ function mapDispatchRow(row) {
     pieces:         qtyIsPieces ? qty : '',     // absent in the One Helix file → derived from weight
     customer:       String(pick(...DISTRIBUTOR_HEADER_ALIASES)).trim(),
     distributorCode: String(pick('distributorcode')).trim(),
+    // Ship-to state: the Invoice sheet has NO state column, so it is decoded from the ship-to
+    // GSTIN prefix (bill-to as the fallback). '' when unresolvable — counted, never guessed.
+    shipToState:    resolveShipToState({
+      state:     pick('shiptostate'),
+      shipToGst: pick('shiptogst', 'shiptogstin', 'shiptogstno'),
+      billToGst: pick('billto-gst', 'billtogst', 'billtogstin', 'gstin', 'gstno'),
+    }),
     grade:          String(pick('grade')).trim(),
     diameter:       num(pick('diametermm', 'diameter')),
     branchName:     String(pick('branchname', 'branch')).trim(),
@@ -1324,7 +1332,7 @@ function buildDispatchRecords(rows, { skus, productions, existing = [] }) {
   // Keep product lines only: need an item description + qty; drop any Freight line.
   const parsed = rows.map(mapDispatchRow).filter(r =>
     r.skuDescRaw && !/freight/i.test(r.skuDescRaw) && (r.weight || r.pieces))
-  if (!parsed.length) return { newRecords: [], newCatalogSkus: [], stats: { invoiceCount: 0, lineCount: 0, skippedDuplicateLines: [], unknownSkus: [], blankCustomer: 0, noRows: true } }
+  if (!parsed.length) return { newRecords: [], newCatalogSkus: [], stats: { invoiceCount: 0, lineCount: 0, skippedDuplicateLines: [], unknownSkus: [], blankCustomer: 0, blankShipToState: 0, noRows: true } }
 
   // SKU resolution: MM ID (== skuCode) first, then exact description, then canonical identity;
   // falling back to the static catalog (DEFAULT_SKUS) with a collision-safe self-heal. See
@@ -1365,6 +1373,9 @@ function buildDispatchRecords(rows, { skus, productions, existing = [] }) {
       length: r.sku?.length || 6000, width: '', thickness: r.sku?.thickness ?? '',
       grade: r.grade || '', diameter: r.diameter || '', customer: r.customer || '',
       distributorCode: r.distributorCode || '', branchName: r.branchName || '', poRef: r.poRef || '',
+      // Per-ENTRY (inside bundleEntries JSONB) — `dispatches` has no shipToState column and a stray
+      // top-level key makes Supabase reject the whole upsert (see blueprints/import-daily-dispatch.md).
+      shipToState: r.shipToState || '',
       orderLineId: r.orderLineId || '', orderId: r.orderId || '', childOrderId: r.childOrderId || '',
       coilAllocations: allocs, traceHrCoilId: allocs[0]?.hrCoilId || '',
     }
@@ -1383,9 +1394,10 @@ function buildDispatchRecords(rows, { skus, productions, existing = [] }) {
     return { ...d, selectedBundles: d.bundleEntries, theoreticalWeight: theo, variance: d.vehicleWeight ? Number(d.vehicleWeight) - theo : 0 }
   })
   const blankCustomer = builtEntries.filter(e => !e.customer).length
+  const blankShipToState = builtEntries.filter(e => !e.shipToState).length
   return {
     newRecords, newCatalogSkus,
-    stats: { invoiceCount: newRecords.length, lineCount, skippedDuplicateLines, unknownSkus: [...unknownSkus], blankCustomer, noRows: false },
+    stats: { invoiceCount: newRecords.length, lineCount, skippedDuplicateLines, unknownSkus: [...unknownSkus], blankCustomer, blankShipToState, noRows: false },
   }
 }
 
@@ -2368,6 +2380,13 @@ function mapOrderRow(row, cols = {}) {
     lineId:               String(pick('skuid')).trim(),               // per-line id (reference)
     customer:             String(pick(...DISTRIBUTOR_HEADER_ALIASES)).trim(),
     distributorCode:      String(pick('distributorcode')).trim(),     // stable identity key (matches invoice/dispatch)
+    // Ship-to state — the Orders sheet fills "Ship to State" on every row; its "Ship to GST" is the
+    // literal 0, so the GSTIN fallback lands on bill-to. Stored UPPER-CASE, matching invoice lines.
+    shipToState:          resolveShipToState({
+      state:     pick('shiptostate'),
+      shipToGst: pick('shiptogst', 'shiptogstin', 'shiptogstno'),
+      billToGst: pick('billto-gst', 'billtogst', 'billtogstin', 'gstin', 'gstno'),
+    }),
     mmId:                 String(pick('mmid', 'skucode', 'sku')).trim(), // == SKU master skuCode
     description:          String(pick('mmdescription', 'description')).trim(),
     quantity:             num(pick('quantity')),                       // ordered qty in MT
@@ -2426,7 +2445,7 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
       const newOrders = parsedOrders.map(r => ({ ...r, id: uid(), deleted: false }))
 
       // Invoice → dispatches (rebuild fresh; existing:[] so dedup is within-file only).
-      let disp = { newRecords: [], newCatalogSkus: [], stats: { invoiceCount: 0, lineCount: 0, unknownSkus: [], blankCustomer: 0 } }
+      let disp = { newRecords: [], newCatalogSkus: [], stats: { invoiceCount: 0, lineCount: 0, unknownSkus: [], blankCustomer: 0, blankShipToState: 0 } }
       if (invoiceWs) {
         const iRows = XLSX.utils.sheet_to_json(invoiceWs, { defval: '', raw: true })
         disp = buildDispatchRecords(iRows, { skus, productions, existing: [] })
@@ -2445,19 +2464,24 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
 
       const totConf = newOrders.reduce((s, o) => s + Number(o.confirmed || 0), 0)
       const totNon = newOrders.reduce((s, o) => s + Number(o.nonConfirmed || 0), 0)
+      // Lines whose ship-to state could not be resolved are stored blank and REPORTED here (never
+      // guessed from a name/city/pincode) — a silent blank would quietly shrink every state total.
+      const ordersNoState = newOrders.filter(o => !o.shipToState).length
       const parts = [`Orders: ${newOrders.length} line(s) · Confirmed ${fmtT(totConf)}T · Non-confirmed ${fmtT(totNon)}T`]
+      if (ordersNoState) parts.push(`${ordersNoState} order line(s) with no ship-to state`)
       if (didReplaceDispatches) {
         parts.push(`Invoice: ${disp.stats.invoiceCount} invoice(s), ${disp.stats.lineCount} line(s)`)
         if (disp.newCatalogSkus.length) parts.push(`+${disp.newCatalogSkus.length} new SKU(s)`)
         if (disp.stats.unknownSkus.length) parts.push(`${disp.stats.unknownSkus.length} unresolved SKU(s): ${disp.stats.unknownSkus.slice(0, 3).join(', ')}${disp.stats.unknownSkus.length > 3 ? '…' : ''}`)
         if (disp.stats.blankCustomer) parts.push(`${disp.stats.blankCustomer} invoice line(s) with no distributor`)
+        if (disp.stats.blankShipToState) parts.push(`${disp.stats.blankShipToState} invoice line(s) with no ship-to state`)
       } else if (invoiceWs) {
         parts.push('Invoice sheet had no valid rows — dispatch data left unchanged')
       } else {
         parts.push('no "Invoice" sheet — dispatch data unchanged')
       }
       const bad = !didReplaceDispatches && invoiceWs ? true
-        : (invoiceWs && (disp.stats.unknownSkus.length || disp.stats.blankCustomer))
+        : !!(ordersNoState || (invoiceWs && (disp.stats.unknownSkus.length || disp.stats.blankCustomer || disp.stats.blankShipToState)))
       setUploadMsg({ kind: bad ? 'err' : 'ok', text: parts.join(' · ') })
     } catch (err) {
       console.error(err)

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -749,6 +749,49 @@ export function toISODate(v) {
   return `${snapped.getUTCFullYear()}-${String(snapped.getUTCMonth() + 1).padStart(2, '0')}-${String(snapped.getUTCDate()).padStart(2, '0')}`
 }
 
+// ── Ship-to STATE for the daily Sales upload (orders + invoice lines). ──────────────────────
+// The two sheets of the One Helix workbook carry state differently:
+//   • Orders sheet  — has a populated "Ship to State" column (its "Ship to GST" is the literal 0).
+//   • Invoice sheet — has NO state column; state comes from the first two digits of the ship-to
+//                     GSTIN (the statutory GST state code), falling back to the bill-to GSTIN.
+// The full state/UT table is here, not just the codes seen in today's file, so a first shipment
+// to a new state resolves on the day it happens instead of importing blank.
+// Names are stored UPPER-CASE because that is how the Orders sheet writes them ("TAMIL NADU"), so
+// an order line and an invoice line for the same state group under one identical key.
+export const GST_STATE_CODES = {
+  '01': 'JAMMU AND KASHMIR', '02': 'HIMACHAL PRADESH', '03': 'PUNJAB', '04': 'CHANDIGARH',
+  '05': 'UTTARAKHAND', '06': 'HARYANA', '07': 'DELHI', '08': 'RAJASTHAN', '09': 'UTTAR PRADESH',
+  '10': 'BIHAR', '11': 'SIKKIM', '12': 'ARUNACHAL PRADESH', '13': 'NAGALAND', '14': 'MANIPUR',
+  '15': 'MIZORAM', '16': 'TRIPURA', '17': 'MEGHALAYA', '18': 'ASSAM', '19': 'WEST BENGAL',
+  '20': 'JHARKHAND', '21': 'ODISHA', '22': 'CHHATTISGARH', '23': 'MADHYA PRADESH', '24': 'GUJARAT',
+  '25': 'DAMAN AND DIU',                                  // legacy — merged into 26 in 2020
+  '26': 'DADRA AND NAGAR HAVELI AND DAMAN AND DIU',
+  '27': 'MAHARASHTRA',
+  '28': 'ANDHRA PRADESH',                                 // legacy pre-bifurcation code; live code is 37
+  '29': 'KARNATAKA', '30': 'GOA', '31': 'LAKSHADWEEP', '32': 'KERALA', '33': 'TAMIL NADU',
+  '34': 'PUDUCHERRY', '35': 'ANDAMAN AND NICOBAR ISLANDS', '36': 'TELANGANA',
+  '37': 'ANDHRA PRADESH', '38': 'LADAKH',
+  '97': 'OTHER TERRITORY', '99': 'CENTRE JURISDICTION',
+}
+
+// State name from a GSTIN's first two digits. '' for blank, the Orders sheet's literal `0`, a
+// non-numeric prefix, or a code outside the table — an unknown prefix is never guessed at. ──
+export function gstStateName(gst) {
+  const digits = String(gst ?? '').trim().slice(0, 2)
+  if (!/^\d{2}$/.test(digits)) return ''
+  return GST_STATE_CODES[digits] || ''
+}
+
+// Resolve one line's ship-to state: the sheet's own state column first (Orders), else the ship-to
+// GSTIN prefix, else the bill-to GSTIN prefix (the Orders sheet stores `0` in "Ship to GST", and a
+// stray invoice line can miss it too). Unresolvable ⇒ '' — the caller counts those and reports
+// them; state is NEVER inferred from a customer name, city or pincode. ──
+export function resolveShipToState({ state = '', shipToGst = '', billToGst = '' } = {}) {
+  const named = String(state ?? '').replace(/\s+/g, ' ').trim().toUpperCase()
+  if (named && named !== '0') return named
+  return gstStateName(shipToGst) || gstStateName(billToGst)
+}
+
 // ── SKU-wise inventory / booked / free rows for the dashboard. Union of SKUs with
 // production/dispatch activity AND SKUs with open orders. All weights in MT:
 //   inventory = produced − dispatched                       (producedPool.availableWeight)

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -9,6 +9,7 @@ import {
   reservedBySku, skuSizeLabel, canonicalSkuKey, skuKeyResolver, skuImportResolver, requiredStripWidth, WIDTH_TOL_MM,
   distributorCode, normDistributorName, distributorOrderIndex, resolveDistributorIdentity,
   dispatchLineKey, dedupeDispatchLines, toISODate,
+  GST_STATE_CODES, gstStateName, resolveShipToState,
   salesKpis, salesByDistributor, salesByMonth,
   estimateNum, distributorEstimateIndex, plantBestEstimate,
 } from './calc'
@@ -968,6 +969,43 @@ describe('toISODate', () => {
     expect(toISODate('')).toBe('')
     expect(toISODate(null)).toBe('')
     expect(toISODate(undefined)).toBe('')
+  })
+})
+
+describe('ship-to state (GST state codes)', () => {
+  it('reads the state straight from the Orders sheet column, upper-cased', () => {
+    // Orders sheet: "Ship to State" is filled on every row, "Ship to GST" is the literal 0.
+    expect(resolveShipToState({ state: 'TELANGANA', shipToGst: 0, billToGst: '36AACCV0269P1ZU' })).toBe('TELANGANA')
+    expect(resolveShipToState({ state: ' Tamil  Nadu ' })).toBe('TAMIL NADU')
+  })
+
+  it('decodes the state from the ship-to GSTIN prefix when no state column exists (Invoice sheet)', () => {
+    expect(resolveShipToState({ shipToGst: '33AAACO6811C1Z0' })).toBe('TAMIL NADU')
+    expect(resolveShipToState({ shipToGst: '29ABDCS6950L1Z0' })).toBe('KARNATAKA')
+    expect(gstStateName('36AACCV0269P1ZU')).toBe('TELANGANA')
+    expect(gstStateName('27AAACO6811C1Z0')).toBe('MAHARASHTRA')
+  })
+
+  it('covers every state/UT code, not just the ones in today\'s data', () => {
+    expect(gstStateName('24AAAAA0000A1Z5')).toBe('GUJARAT')       // never shipped to yet
+    expect(gstStateName('38AAAAA0000A1Z5')).toBe('LADAKH')
+    expect(Object.keys(GST_STATE_CODES).length).toBeGreaterThanOrEqual(36)
+  })
+
+  it('falls back to the bill-to GSTIN when ship-to GST is the Orders sheet\'s literal 0 (or blank)', () => {
+    expect(resolveShipToState({ state: '', shipToGst: 0, billToGst: '33AAACO6811C1Z0' })).toBe('TAMIL NADU')
+    expect(resolveShipToState({ state: '', shipToGst: '0', billToGst: '29AAACO6811C1Z0' })).toBe('KARNATAKA')
+    expect(resolveShipToState({ shipToGst: '', billToGst: '36AACCV0269P1ZU' })).toBe('TELANGANA')
+  })
+
+  it('stores blank for an unknown/unparseable prefix — never a guess', () => {
+    expect(resolveShipToState({ shipToGst: '88AAACO6811C1Z0' })).toBe('')   // no such state code
+    expect(resolveShipToState({ shipToGst: 'XXAAACO6811C1Z0' })).toBe('')   // non-numeric prefix
+    expect(resolveShipToState({})).toBe('')
+    expect(resolveShipToState({ state: '0', shipToGst: 0, billToGst: 0 })).toBe('')
+    expect(gstStateName(null)).toBe('')
+    // A pincode/city is never a source — 600019 must not resolve to Tamil Nadu.
+    expect(resolveShipToState({ shipToGst: 600019 })).toBe('')
   })
 })
 

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -151,6 +151,7 @@ create table if not exists orders (
   confirmed numeric,
   non_confirmed numeric,
   distributor_code text,
+  ship_to_state text,
   order_status text,
   expected_delivery_date date,
   deleted boolean default false,
@@ -162,6 +163,10 @@ alter table orders add column if not exists release_qty numeric;
 alter table orders add column if not exists confirmed numeric;
 alter table orders add column if not exists non_confirmed numeric;
 alter table orders add column if not exists distributor_code text;
+-- Region/state reporting — the Orders sheet's "Ship to State", UPPER-CASE (idempotent). Invoice
+-- lines keep their state inside dispatches.bundle_entries (no column there). Both stores are
+-- replace-all on upload, so one Sales Excel upload backfills every historical row.
+alter table orders add column if not exists ship_to_state text;
 alter table orders enable row level security;
 drop policy if exists "Allow all access" on orders;
 create policy "Allow all access" on orders for all using (true) with check (true);


### PR DESCRIPTION
Closes #101

After one "Upload Sales Excel" run, every order line and every invoice line carries the state it shipped to, so sales can be grouped by region.

## Where the state comes from

The two sheets of the One Helix workbook supply it differently:

```
Orders sheet ──"Ship to State" (TELANGANA)──────────► orders.ship_to_state   (new column)
                    │ blank? → Bill to - GST prefix
Invoice sheet ──"Ship to GST" 33AAACO…──► "33" ─────► bundle_entries[].shipToState
                    │ blank/0? → Bill to - GST prefix
   unresolvable ────────────────────────────────────► ""  + counted in the banner
```

The Orders sheet fills `Ship to State` on every row (the mapper read and discarded it) and stores the literal `0` in `Ship to GST`, so its GSTIN fallback lands on `Bill to - GST`. The Invoice sheet has **no state column** — state is the first two digits of the ship-to GSTIN (the statutory GST state code).

## Changes

- **`src/lib/calc.js`** — `GST_STATE_CODES` (every state/UT code 01–38 plus 97/99, not only the three present in today's data), `gstStateName(gst)`, `resolveShipToState({state, shipToGst, billToGst})`. Names are stored UPPER-CASE so `TAMIL NADU` from an order and from an invoice group under one identical key.
- **`src/App.jsx`** — `mapOrderRow` keeps `Ship to State` case- and spacing-insensitively, like every other column it reads; `mapDispatchRow` decodes the GSTIN prefix. Invoice state is stored **per entry inside `bundleEntries`** — `dispatches` has no such column, and a stray top-level key makes Supabase reject the whole upsert.
- **Upload summary** — reports `N order line(s) with no ship-to state` and `N invoice line(s) with no ship-to state`, and marks the banner bad, the same way blank distributor already does. An unresolvable state stores blank; it is never guessed from a customer name, city or pincode.
- **`supabase-setup.sql`** — `alter table orders add column if not exists ship_to_state text;` in the style of the existing idempotent alters, plus the column in `create table`. Both stores are replace-all on upload, so one upload backfills the whole history — no row migration.
- **Docs** — new "Ship-to state" section in `docs/DATA-MODEL.md` (source per sheet, GST derivation, blank handling) and a row in the invoice column table in `blueprints/import-daily-dispatch.md`.

## Tests

5 new cases in `src/lib/calc.test.js`: state read straight from the Orders column, state decoded from a GST prefix, unknown/non-numeric prefix falling back to blank, the `0` ship-to GST fallback to bill-to, and a pincode never resolving to a state.

- `npm test` — 230 passed (3 files)
- `npm run build` — clean

Verified against the repo's own `Pipes and Tube - ERP Data _ One Helix.xlsx` by running both mappers' exact header-normalisation and pick logic over it:

| Sheet | Rows | Resolved | Blank |
|---|---|---|---|
| Orders | 366 | TELANGANA 135 · TAMIL NADU 123 · KARNATAKA 108 | 0 |
| Invoice | 298 | TAMIL NADU 117 · KARNATAKA 109 · TELANGANA 72 | 0 |

## Before merging

Run the new `alter table orders add column if not exists ship_to_state text;` on the Supabase project. No DDL was applied to the live database from this branch; until that column exists the orders replace fails with *"Could not find the 'ship_to_state' column"*.

## Not in this PR

No UI or reporting change — the state is not shown as a table column or filter, and nothing groups by it yet. Ticket 101 is storage-only; grouping the PB MTD dashboard by region is the follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPUVswg5f5pokVRCbbX4Rs)_