### PR TITLE
Plant attribution from ERP Ship From Code (ticket #118)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,12 +53,25 @@ _Avoid_: treating it as anything other than Confirmed + Non-confirmed
 
 ## Plant
 
+**Plant**:
+The works that makes an order line. Four are modelled — **Hyderabad**, **NPMD**, **Lepakshi** and
+**Tapi** — and a line's plant is resolved from the ERP's own Ship From Code, never typed. Hyderabad
+and NPMD manufacture; Lepakshi and Tapi carry orders and have never produced. Always named by the
+short name: "NPMD", never "New Pashchim Maharashtra Patra Depot".
+_Avoid_: CM, company, unit, works, location, site
+
+**Unattributed**:
+An order line whose Ship From Code matched no plant. It is **not a fifth plant** and not a "rest"
+bucket: its tonnage stays inside every total, and the upload banner counts it so the gap gets fixed
+rather than filtered away. The same rule `Unmapped` follows for region.
+_Avoid_: Unknown, other, unassigned, misc, rest
+
 **Service area**:
-The set of regions a plant will actually ship to. **South** for the plant this database describes.
-It exists nowhere in the data — there is no plant column, one unnamed "the plant" throughout the
-app, and no distributor carries a plant — so it is a business rule passed into a report, never a
-figure read off a row. A report that ignores it will tell the sales team it can serve a West
-distributor out of southern stock: on 18-Aug-2026 that was 275.7 T of the 638.6 T it claimed.
+The set of regions a plant will actually ship to. **South** for Hyderabad, the plant most of this
+database describes. It exists nowhere in the data — no distributor carries a plant, and only order
+lines carry one — so it is a business rule passed into a report, never a figure read off a row. A
+report that ignores it will tell the sales team it can serve a West distributor out of southern
+stock: on 18-Aug-2026 that was 275.7 T of the 638.6 T it claimed.
 _Avoid_: Territory, catchment, coverage, allocation
 
 **Out of area**:

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -13,7 +13,7 @@ All pipeline data lives in **Supabase Postgres**, accessed via `useSupabaseStore
 | `jsw:skus` | `skus` | SKU master (falls back to `DEFAULT_SKUS` when table is empty) |
 | `jsw:distributorEstimates` | `distributor_estimates` | **Distributor Monthly Estimate** — the typed Best Estimate (planned invoiced MT) for one distributor in one month. `distributor_key` is the app's resolved distributor identity (ERP `distributor_code` when present, otherwise the normalised name — the same key `salesByDistributor` groups by), `month` is `'YYYY-MM'`. **Unique on `(distributor_key, month)`**, which is also the upsert arbiter. Written inline from the Sales tab; the plant Best Estimate is their sum, never typed (see `docs/adr/0001-…`) |
 | `jsw:stateRegions` | `state_regions` | **State → Region master** — the one hand-mapped value in region reporting. Keyed by `state` (UPPER-CASE, **unique**, and the upsert arbiter), holding one of the four `region` values. Falls back to `DEFAULT_STATE_REGIONS` (`src/data/stateRegions.js`) when the table is empty, and that seed is **also layered under** the stored rows — see below. Edited inline from the Sales tab |
-| `jsw:orders` | `orders` | Customer order book — Orders tab of the daily Sales upload. Per-line `confirmed` (ERP Release − Invoiced), `non_confirmed` (Ordered − Release − Cancelled), `distributor_code`, and `ship_to_state` (see below). **PO Master was removed (July 2026)** — the `purchase_orders` table is left dormant |
+| `jsw:orders` | `orders` | Customer order book — Orders tab of the daily Sales upload. Per-line `confirmed` (ERP Release − Invoiced), `non_confirmed` (Ordered − Release − Cancelled), `distributor_code`, `ship_to_state` and `plant` (both see below). **PO Master was removed (July 2026)** — the `purchase_orders` table is left dormant |
 
 The change is **additive/backward-compatible**: production `coil_allocations` carry **both** `babyCoilId` (capacity/FIFO) and the mother `hrCoilId` (cost/tracker), and legacy mother-only/`traceHrCoilId` rows still resolve. The `baby_coils` table is **active again** — re-added to `TABLE_MAP`/`HARD_DELETE_TABLES` in `db.js`; the `delete from baby_coils;` wipe was removed from `supabase-setup.sql`.
 
@@ -36,6 +36,35 @@ cannot be resolved (blank column, `0`, non-numeric or unknown prefix) stores **b
 in the upload banner — it is **never** guessed from a customer name, city or pincode. Both stores are
 replace-all on upload, so one "Upload Sales Excel" run backfills the whole history; there is no
 separate migration of existing rows.
+
+## Plant (ticket #118)
+Four manufacturing companies ship the order book. Until #118 the app had no column to put them in,
+so all four counted as Hyderabad's — 2615.441 MT of Pending to Dispatch where Hyderabad's own was
+761.441 MT.
+
+Plant is resolved from the ERP's **`Ship From Code`**, which is spelled identically in both sheets.
+The ERP's own name string — `CM name` in Orders, `Ship from location` in Invoice — is a **fallback
+only**. See `docs/adr/0004-plant-dimension-from-erp-ship-from-code.md` for why the code and not the
+name.
+
+| | |
+|---|---|
+| **Master** | `src/data/plants.js` — a **code constant, not a table**. Four rows, fixed literal ids, every field either an ERP identifier or a label; nothing for an operator to type, so nothing to store and sync |
+| **Each plant carries** | `id` (stored on the row), `erpCode` (Ship From Code), `erpNames[]` (fallback matching), `name` (short display), `coilPrefix` (phase 2), `manufactures` |
+| **The four** | `hyderabad` `V2482-2973-JODL-4144` → **Hyderabad** · `npmd` `V1865-2222-JODL-4081` → **NPMD** · `lepakshi` `V2732-3276-JODL-4606` → **Lepakshi** · `tapi` `V2744-3288-JODL-4631` → **Tapi**. Hyderabad and NPMD manufacture; the other two carry orders only |
+| **Helpers** | `plantIndex()` / `resolvePlant({shipFromCode, name})` → plant id or `''` · `plantLabel(id)` → short name or `Unattributed` · `plantById(id)` |
+| **Stored where** | `orders.plant` — the **id**, never the label, so renaming a plant on screen orphans nothing. Blank ⇒ SQL NULL via `toSnake`, reading back as `Unattributed` |
+| **Shown as** | The short display name only. `New Pashchim Maharashtra Patra Depot` never reaches a screen |
+
+A line whose code matches no plant stores **blank**, displays **`Unattributed`**, and is counted in
+the upload banner. `Unattributed` is **not a fifth plant** and never a "rest" bucket — its tonnage
+stays inside every total, exactly as `Unmapped` does for region. An unrecognised code **imports**;
+it never fails the upload, because a fifth company appearing in the ERP must not stop the daily file
+loading. Orders are replace-all on upload, so one run backfills every historical row — there is no
+separate migration.
+
+Invoice lines and the pipeline stages (coils, baby coils, productions, dispatches) do **not** carry
+a plant yet; those are sibling tickets in the #117 spec.
 
 ## State → Region
 Region is a business concept the ERP **never** exports — it exists nowhere in the One Helix workbook.

--- a/docs/adr/0004-plant-dimension-from-erp-ship-from-code.md
+++ b/docs/adr/0004-plant-dimension-from-erp-ship-from-code.md
@@ -1,0 +1,75 @@
+# Plant is keyed on the ERP's Ship From Code, not the CM name
+
+Every order line now carries the plant that will make it. The One Helix workbook offers two ways to
+say which plant a line belongs to, and they are not equally trustworthy:
+
+| | Orders sheet | Invoice sheet |
+|---|---|---|
+| Code | `Ship From Code` — `V2482-2973-JODL-4144` | `Ship From Code` — same column, same values |
+| Name | `CM name` — `NIPPON PIPES PRIVATE LIMITED` | `Ship from location` — same strings, different header |
+
+**Plant resolves from the code. The name is a fallback only.**
+
+The name looks like the friendlier key — it is what a human would read, and it is what the spec's own
+evidence table is sorted by. It is also the field that can change without anything changing. A
+company can be renamed, re-cased, or have its legal suffix edited in the ERP's master data and the
+plant it describes is the same shed with the same mill in it. The code cannot: it is the ERP's
+identifier for the shipping location, and if it changes, the ERP is describing a different place.
+
+Three concrete properties decided it:
+
+1. **The code is one column; the name is two.** `CM name` and `Ship from location` are the same
+   value under different headers in the two sheets. Keying on the name means maintaining a list of
+   header aliases per sheet, and a header the ERP renames lands every line of that sheet in
+   Unattributed. `Ship From Code` is spelled identically in both.
+2. **The code already matched across both sheets for Hyderabad** in the 18-Aug-2026 file — which is
+   what establishes that one identity spans an order and its invoice, and therefore that Phase 3's
+   invoice-side attribution can use the same key.
+3. **Name matching degrades quietly, code matching does not.** A near-miss name — `NIPPON PIPES`
+   against `NIPPON PIPES PRIVATE LIMITED` — invites fuzzy matching, and fuzzy matching is how a
+   fifth company gets silently absorbed into a fourth. An unrecognised code has exactly one possible
+   reading: this is not a plant we know.
+
+This is the same discipline the `state → region` work follows, for the same reason. Region is the
+one thing a human types; state is never typed, because it comes off the ERP row. Plant is likewise
+never typed. Nothing an operator does can make a line's plant drift from what the ERP said.
+
+## Unattributed is not a fifth plant
+
+An unresolved line stores a blank plant and displays **`Unattributed`**, mirroring `Unmapped` in the
+region master precisely:
+
+- It is not in `PLANT_IDS`, so nothing can iterate the plants and get five.
+- It is never a "rest" bucket — its tonnage stays inside every total. A missing mapping is a
+  labelling gap, never a reason for weight to leave a sum.
+- It is surfaced in the upload banner, so it gets fixed rather than filtered away.
+
+The banner count is load-bearing rather than cosmetic. NPMD's Ship From Code has never appeared on
+an invoice — NPMD has raised none — so the assumption that `V1865-2222-JODL-4081` will show up in
+the Invoice sheet the way it does in Orders becomes fact only on the day NPMD invoices. The count is
+what turns that from a silent mis-attribution into a line somebody reads that morning.
+
+## Why the plant master is a code constant, not a table
+
+`state_regions` is a table because a human maps states to regions, there are 38 of them, and the
+mapping is a judgement that changes. The plant master is none of those things: four rows, every
+field of which is either an ERP identifier or a label, and nothing in it for an operator to type.
+Putting it in Postgres would add a sync path, a seed-vs-stored layering rule, and an editing UI, in
+exchange for a row nobody edits. It lives in `src/data/plants.js` with fixed literal ids.
+
+## Consequences
+
+- `orders.plant` stores the **id** (`hyderabad`, `npmd`, `lepakshi`, `tapi`), never the label. A
+  plant can be renamed on screen without orphaning a single row.
+- Screens show the short name only. `New Pashchim Maharashtra Patra Depot` does not reach a user.
+- An unrecognised Ship From Code **imports** as Unattributed. It never fails the upload — a fifth
+  company appearing in the ERP must not stop the daily file loading.
+- `resolvePlant` is a pure helper in `src/lib/calc.js`, called from `mapOrderRow`. This keeps the
+  one existing test seam rather than opening a second, at the cost that the ERP **column-name**
+  matching (`shipfromcode` / `cmname`) is covered only by the upload banner, not by a unit test —
+  the same trade the `state → region` work made.
+- The `manufactures` flag makes reclassifying a plant a one-line change. NPMD's ERP name ends in
+  "Depot" and it is modelled as manufacturing on explicit instruction; if it turns out to be a
+  stocking depot it joins Lepakshi and Tapi by flipping one boolean.
+- Attribution alone does not fix that reports compare four plants' Pending to Dispatch against one
+  plant's Invoiced. It makes that mismatch visible, which is the intent; labelling it is Phase 4.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import {
   canonicalSkuKey, skuKeyResolver, skuImportResolver, salesKpis, salesByDistributor, salesByMonth,
   shippedByOrderLine, orderLineInvoiced, orderLineStage, distributorCode, dedupeDispatchLines, toISODate,
   resolveShipToState, REGIONS, UNMAPPED_REGION, normStateName,
+  PLANTS, UNATTRIBUTED_PLANT, resolvePlant, plantLabel,
 } from './lib/calc'
 import { loadChunk } from './lib/chunk'
 import DEFAULT_SKUS from './data/skus'
@@ -2389,6 +2390,13 @@ function mapOrderRow(row, cols = {}) {
       shipToGst: pick('shiptogst', 'shiptogstin', 'shiptogstno'),
       billToGst: pick('billto-gst', 'billtogst', 'billtogstin', 'gstin', 'gstno'),
     }),
+    // Plant — resolved from the Orders sheet's "Ship From Code", with its "CM name" as the
+    // fallback only (ticket #118). Stored as the plant id, or blank when the ERP row matched
+    // neither — blanks are counted and reported on the banner, never guessed at.
+    plant:                resolvePlant({
+      shipFromCode: pick('shipfromcode', 'shipfrom', 'shipfromcodeid'),
+      name:         pick('cmname', 'shipfromlocation', 'cmnames'),
+    }),
     mmId:                 String(pick('mmid', 'skucode', 'sku')).trim(), // == SKU master skuCode
     description:          String(pick('mmdescription', 'description')).trim(),
     quantity:             num(pick('quantity')),                       // ordered qty in MT
@@ -2471,6 +2479,12 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
       const ordersNoState = newOrders.filter(o => !o.shipToState).length
       const parts = [`Orders: ${newOrders.length} line(s) · Confirmed ${fmtT(totConf)}T · Non-confirmed ${fmtT(totNon)}T`]
       if (ordersNoState) parts.push(`${ordersNoState} order line(s) with no ship-to state`)
+      // Same rule for plant: a line the Ship From Code did not resolve imports as Unattributed and
+      // is REPORTED here. An unrecognised code must never fail the upload — a fifth company
+      // appearing in the ERP cannot be allowed to stop the daily file loading — so the only thing
+      // that makes it visible is this count.
+      const ordersNoPlant = newOrders.filter(o => !o.plant).length
+      if (ordersNoPlant) parts.push(`${ordersNoPlant} order line(s) with no plant (${UNATTRIBUTED_PLANT})`)
       if (didReplaceDispatches) {
         parts.push(`Invoice: ${disp.stats.invoiceCount} invoice(s), ${disp.stats.lineCount} line(s)`)
         if (disp.newCatalogSkus.length) parts.push(`+${disp.newCatalogSkus.length} new SKU(s)`)
@@ -2483,7 +2497,7 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
         parts.push('no "Invoice" sheet — dispatch data unchanged')
       }
       const bad = !didReplaceDispatches && invoiceWs ? true
-        : !!(ordersNoState || (invoiceWs && (disp.stats.unknownSkus.length || disp.stats.blankCustomer || disp.stats.blankShipToState)))
+        : !!(ordersNoState || ordersNoPlant || (invoiceWs && (disp.stats.unknownSkus.length || disp.stats.blankCustomer || disp.stats.blankShipToState)))
       setUploadMsg({ kind: bad ? 'err' : 'ok', text: parts.join(' · ') })
     } catch (err) {
       console.error(err)
@@ -2518,6 +2532,7 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
     { key: 'size', label: 'Size', accessor: r => skuSizeLabel(skus.find(s => s.skuCode === r.mmId), r.description) },
     { key: 'status', label: 'Status', accessor: r => orderLineStage(r, lineInvoiced(r)) },
     { key: 'customer', label: 'Customer', accessor: r => distributorCode(r.customer) },
+    { key: 'plant', label: 'Plant', accessor: r => plantLabel(r.plant), options: [...PLANTS.map(p => p.name), UNATTRIBUTED_PLANT] },
     { key: 'pending', label: 'Pending', accessor: r => linePending(r) > 0 ? 'Has pending' : 'None', options: ['Has pending', 'None'] },
     { key: 'month', label: 'Order month', accessor: r => String(r.orderDate || '').slice(0, 7) },
   ]
@@ -2527,6 +2542,8 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
     { label: 'Order Date',    key: 'orderDate' },
     { label: 'Order ID',      key: 'orderId' },
     { label: 'Customer',      value: r => distributorCode(r.customer), render: r => <span title={r.customer}>{distributorCode(r.customer) || '—'}</span> },
+    // Short display name only — "NPMD", never "New Pashchim Maharashtra Patra Depot".
+    { label: 'Plant',         value: r => plantLabel(r.plant) },
     { label: 'MM ID (SKU)',   key: 'mmId' },
     { label: 'Description',   key: 'description' },
     { label: 'Qty (MT)',      value: r => fmtT(r.quantity) },
@@ -2542,8 +2559,8 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
 
   const downloadOrdersCSV = () => {
     downloadCSV(`orders-${today()}.csv`,
-      ['Order Date', 'Order ID', 'Child Order ID', 'Customer', 'MM ID', 'Description', 'Qty (MT)', 'Confirmed (MT)', 'Non-confirmed (MT)', 'Invoiced (MT)', 'Pending (MT)', 'Status'],
-      ordersExportRef.current.map(r => [r.orderDate, r.orderId, r.childOrderId, r.customer, r.mmId, r.description, r.quantity, fmtT(r.confirmed), fmtT(r.nonConfirmed), fmtT(lineInvoiced(r)), fmtT(linePending(r)), orderLineStage(r, lineInvoiced(r))]))
+      ['Order Date', 'Order ID', 'Child Order ID', 'Customer', 'Plant', 'MM ID', 'Description', 'Qty (MT)', 'Confirmed (MT)', 'Non-confirmed (MT)', 'Invoiced (MT)', 'Pending (MT)', 'Status'],
+      ordersExportRef.current.map(r => [r.orderDate, r.orderId, r.childOrderId, r.customer, plantLabel(r.plant), r.mmId, r.description, r.quantity, fmtT(r.confirmed), fmtT(r.nonConfirmed), fmtT(lineInvoiced(r)), fmtT(linePending(r)), orderLineStage(r, lineInvoiced(r))]))
   }
 
   return (

--- a/src/data/plants.js
+++ b/src/data/plants.js
@@ -1,0 +1,61 @@
+// ── PLANT MASTER (static constant) ──────────────────────────────────────────────────────────────
+// Four manufacturing companies appear in the One Helix workbook's Orders sheet. Until ticket #118
+// the app had no column to put them in, so all four were counted as Hyderabad's.
+//
+// Unlike the state → region master (38 possible states, continuously hand-mapped, so it lives in a
+// `state_regions` table), plants are four, change rarely, and every identifier here comes from the
+// ERP rather than from human judgement. There is nothing for an operator to type and therefore
+// nothing to store — so this is a code constant, not a table.
+//
+// Each plant carries:
+//   id           fixed literal, stored on the row (orders.plant). Never derived from a label, so
+//                renaming a plant on screen can never orphan the rows that point at it.
+//   erpCode      the ERP's **Ship From Code** — the ONLY thing plant is resolved from. It appears
+//                in both sheets of the workbook and matched exactly across them for Hyderabad.
+//   erpNames     the ERP's own name strings ("CM name" in Orders, "Ship from location" in Invoice).
+//                A FALLBACK for matching only — see docs/adr/0004.
+//   name         the short display name. This is what a screen shows; the ERP's
+//                "New Pashchim Maharashtra Patra Depot" never reaches a user.
+//   coilPrefix   the coil-ID prefix for that plant's own register (phase 2 — #119).
+//   manufactures whether the plant runs Coil Inward / Slitting / Production. Lepakshi and Tapi
+//                carry orders and have never produced or invoiced, so they exist for attribution
+//                only. Reclassifying one is a one-line change to this flag.
+//
+// Order matters: it is the order plants are listed in on screen, biggest first.
+
+const DEFAULT_PLANTS = [
+  {
+    id: 'hyderabad',
+    erpCode: 'V2482-2973-JODL-4144',
+    erpNames: ['NIPPON PIPES PRIVATE LIMITED'],
+    name: 'Hyderabad',
+    coilPrefix: 'HYD',
+    manufactures: true,
+  },
+  {
+    id: 'npmd',
+    erpCode: 'V1865-2222-JODL-4081',
+    erpNames: ['New Pashchim Maharashtra Patra Depot'],
+    name: 'NPMD',
+    coilPrefix: 'NPM',
+    manufactures: true,
+  },
+  {
+    id: 'lepakshi',
+    erpCode: 'V2732-3276-JODL-4606',
+    erpNames: ['LEPAKSHI TUBES PRIVATE LIMITED'],
+    name: 'Lepakshi',
+    coilPrefix: 'LEP',
+    manufactures: false,
+  },
+  {
+    id: 'tapi',
+    erpCode: 'V2744-3288-JODL-4631',
+    erpNames: ['TAPI PIPES AND TUBES PRIVATE LIMITED'],
+    name: 'Tapi',
+    coilPrefix: 'TAP',
+    manufactures: false,
+  },
+]
+
+export default DEFAULT_PLANTS

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -8,6 +8,9 @@
 // report builders can still inject their own.
 // The `.js` extension is load-bearing — see the note on the same import in src/lib/reports.js.
 import DEFAULT_STATE_REGIONS from '../data/stateRegions.js'
+// Static plant master — the four companies the ERP ships the order book under. Same shape of
+// dependency as the state→region seed above, and the same load-bearing `.js` extension.
+import DEFAULT_PLANTS from '../data/plants.js'
 
 // ── Formatting ──
 export const fmtT = (v) => v != null ? Number(v).toFixed(1) : '—'
@@ -838,6 +841,73 @@ export function regionForState(state, index) {
   const s = normStateName(state)
   if (!s) return UNMAPPED_REGION
   return (index?.get?.(s) || '') || UNMAPPED_REGION
+}
+
+// ── PLANT (ticket #118) ─────────────────────────────────────────────────────────────────────────
+// Four manufacturing companies ship the order book; until now every line was counted as
+// Hyderabad's. Plant is resolved from the ERP's own **Ship From Code**, never from a typed field —
+// the same discipline state → region follows, and for the same reason: nothing hand-types it, so it
+// can never drift from what the ERP said.
+//
+// The two-step is deliberate and mirrors state/region exactly:
+//   resolvePlant(row)  → the plant id, or '' when the row matched nothing (STORED)
+//   plantLabel(id)     → the short display name, or `Unattributed` (SHOWN)
+// A blank stores as SQL NULL and reads back blank, so the round trip holds either way.
+//
+// `Unattributed` is deliberately NOT a fifth plant — exactly as `Unmapped` is not a fifth region.
+// It is what an unresolved line displays, and such a line still carries its full tonnage into every
+// total. A missing mapping is a labelling gap, never a reason for weight to vanish from a sum.
+export const PLANTS = DEFAULT_PLANTS
+export const PLANT_IDS = DEFAULT_PLANTS.map(p => p.id)
+export const UNATTRIBUTED_PLANT = 'Unattributed'
+
+// ERP codes and names are compared UPPER-CASE with internal whitespace collapsed. The codes are
+// already uniform ("V2482-2973-JODL-4144"); the names are not — the ERP writes NPMD's in mixed case
+// while the other three are upper — so one normalisation covers both and a re-cased ERP export
+// cannot silently drop a plant into Unattributed.
+export const normPlantKey = (v) => String(v ?? '').replace(/\s+/g, ' ').trim().toUpperCase()
+
+// Ship From Code → plant id, and (fallback only) ERP name → plant id, in ONE index. The two key
+// spaces cannot collide: a code is `Vnnnn-nnnn-JODL-nnnn`, a name is words.
+export function plantIndex(master = DEFAULT_PLANTS) {
+  const out = new Map()
+  ;(master || []).forEach(p => {
+    const code = normPlantKey(p?.erpCode)
+    if (code) out.set(code, p.id)
+    ;(p?.erpNames || []).forEach(n => {
+      const key = normPlantKey(n)
+      if (key) out.set(key, p.id)
+    })
+  })
+  return out
+}
+
+// Resolve one ERP row to a plant id. Ship From Code first; the ERP's name string second and only
+// as a fallback; '' when neither matches. An unrecognised code is NEVER guessed at from the name of
+// a company it resembles, and never dropped — the caller counts the blanks and reports them, which
+// is what turns a fifth company appearing in the ERP into a banner line rather than a silent
+// re-attribution of its tonnage to Hyderabad.
+export function resolvePlant({ shipFromCode = '', name = '' } = {}, index) {
+  const idx = index || plantIndex()
+  const code = normPlantKey(shipFromCode)
+  if (code && idx.get(code)) return idx.get(code)
+  const named = normPlantKey(name)
+  return (named && idx.get(named)) || ''
+}
+
+// The plant master row for an id. `null` for blank/unknown — Unattributed has no row, because it is
+// not a plant.
+export function plantById(id, master = DEFAULT_PLANTS) {
+  const key = String(id ?? '').trim()
+  if (!key) return null
+  return (master || []).find(p => p.id === key) || null
+}
+
+// The short display name for a stored plant id. Blank, unknown and unresolved all read
+// `Unattributed` — a screen never shows an id, and never shows the ERP's own long name
+// ("New Pashchim Maharashtra Patra Depot").
+export function plantLabel(id, master = DEFAULT_PLANTS) {
+  return plantById(id, master)?.name || UNATTRIBUTED_PLANT
 }
 
 // ── A distributor's own state, derived from its order and invoice lines ──

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -11,11 +11,13 @@ import {
   dispatchLineKey, dedupeDispatchLines, toISODate,
   GST_STATE_CODES, gstStateName, resolveShipToState,
   REGIONS, UNMAPPED_REGION, normStateName, stateRegionIndex, regionForState,
+  PLANTS, PLANT_IDS, UNATTRIBUTED_PLANT, normPlantKey, plantIndex, resolvePlant, plantById, plantLabel,
   distributorStateIndex, distributorRegionResolver,
   salesKpis, salesByDistributor, salesByMonth,
   estimateNum, distributorEstimateIndex, plantBestEstimate,
 } from './calc'
 import DEFAULT_STATE_REGIONS from '../data/stateRegions'
+import DEFAULT_PLANTS from '../data/plants'
 
 describe('format helpers', () => {
   it('fmtT renders 1 decimal, em-dash for null/undefined', () => {
@@ -1091,6 +1093,142 @@ describe('state → region master (ticket #102)', () => {
     expect(regionForState('', idx)).toBe(UNMAPPED_REGION)         // no state on the lines at all
     expect(regionForState(null, idx)).toBe(UNMAPPED_REGION)
     expect(REGIONS).not.toContain(UNMAPPED_REGION)                // Unmapped is not a fifth region
+  })
+})
+
+describe('plant master + resolver (ticket #118)', () => {
+  // The four Ship From Codes as they appear in the 18-Aug-2026 One Helix workbook.
+  const HYD = 'V2482-2973-JODL-4144'
+  const NPMD = 'V1865-2222-JODL-4081'
+  const LEP = 'V2732-3276-JODL-4606'
+  const TAPI = 'V2744-3288-JODL-4631'
+
+  it('ships the four plants, each carrying everything a plant needs to be one', () => {
+    expect(DEFAULT_PLANTS).toHaveLength(4)
+    expect(PLANT_IDS).toEqual(['hyderabad', 'npmd', 'lepakshi', 'tapi'])
+    expect(PLANTS.map(p => p.name)).toEqual(['Hyderabad', 'NPMD', 'Lepakshi', 'Tapi'])
+    expect(PLANTS.map(p => p.erpCode)).toEqual([HYD, NPMD, LEP, TAPI])
+    expect(PLANTS.map(p => p.coilPrefix)).toEqual(['HYD', 'NPM', 'LEP', 'TAP'])
+    // Hyderabad and NPMD manufacture; Lepakshi and Tapi carry orders and have never produced.
+    expect(PLANTS.filter(p => p.manufactures).map(p => p.id)).toEqual(['hyderabad', 'npmd'])
+    PLANTS.forEach(p => {
+      expect(p.erpNames.length).toBeGreaterThan(0)
+      expect(p.id).toBe(p.id.trim())
+    })
+    // Ids and ERP codes are both unique — two plants sharing either would silently merge tonnage.
+    expect(new Set(PLANT_IDS).size).toBe(4)
+    expect(new Set(PLANTS.map(p => p.erpCode)).size).toBe(4)
+  })
+
+  it('resolves each of the four Ship From Codes to its plant', () => {
+    const idx = plantIndex()
+    expect(resolvePlant({ shipFromCode: HYD }, idx)).toBe('hyderabad')
+    expect(resolvePlant({ shipFromCode: NPMD }, idx)).toBe('npmd')
+    expect(resolvePlant({ shipFromCode: LEP }, idx)).toBe('lepakshi')
+    expect(resolvePlant({ shipFromCode: TAPI }, idx)).toBe('tapi')
+    // The index is optional — a caller that resolves one row need not build one.
+    expect(resolvePlant({ shipFromCode: HYD })).toBe('hyderabad')
+    // Case / spacing can't miss a mapping: an ERP row and its plant normalise to one key.
+    expect(resolvePlant({ shipFromCode: ` ${HYD.toLowerCase()} ` }, idx)).toBe('hyderabad')
+    expect(normPlantKey(' v2482-2973-jodl-4144 ')).toBe(HYD)
+  })
+
+  it('falls back to the ERP name only when the code is missing, never over it', () => {
+    const idx = plantIndex()
+    // Orders sheet calls it "CM name"; the Invoice sheet "Ship from location". Same strings.
+    expect(resolvePlant({ name: 'NIPPON PIPES PRIVATE LIMITED' }, idx)).toBe('hyderabad')
+    expect(resolvePlant({ name: 'New Pashchim Maharashtra Patra Depot' }, idx)).toBe('npmd')
+    expect(resolvePlant({ name: 'lepakshi tubes private limited' }, idx)).toBe('lepakshi')
+    // The code wins whenever it resolves. If the ERP ever ships a row whose name and code disagree,
+    // the code is what the plant is — that is the whole point of keying on it.
+    expect(resolvePlant({ shipFromCode: TAPI, name: 'NIPPON PIPES PRIVATE LIMITED' }, idx)).toBe('tapi')
+  })
+
+  it('both sheets resolve Hyderabad to one identity', () => {
+    const idx = plantIndex()
+    const fromOrders = resolvePlant({ shipFromCode: HYD, name: 'NIPPON PIPES PRIVATE LIMITED' }, idx)
+    const fromInvoice = resolvePlant({ shipFromCode: HYD, name: 'NIPPON PIPES PRIVATE LIMITED' }, idx)
+    expect(fromOrders).toBe(fromInvoice)
+    expect(fromOrders).toBe('hyderabad')
+  })
+
+  it('an unrecognised or missing code resolves blank and reads Unattributed — never a guess', () => {
+    const idx = plantIndex()
+    expect(resolvePlant({ shipFromCode: 'V9999-0000-JODL-0001' }, idx)).toBe('')  // a fifth company
+    expect(resolvePlant({ shipFromCode: '', name: 'SOME OTHER TUBES LTD' }, idx)).toBe('')
+    expect(resolvePlant({}, idx)).toBe('')
+    expect(resolvePlant(undefined, idx)).toBe('')
+    expect(resolvePlant({ shipFromCode: null, name: null }, idx)).toBe('')
+    // A near-miss name is not a match: plant is never inferred from a company it resembles.
+    expect(resolvePlant({ name: 'NIPPON PIPES' }, idx)).toBe('')
+    // All of those display as Unattributed, and Unattributed is not a fifth plant.
+    expect(plantLabel('')).toBe(UNATTRIBUTED_PLANT)
+    expect(plantLabel(null)).toBe(UNATTRIBUTED_PLANT)
+    expect(plantLabel('no-such-plant')).toBe(UNATTRIBUTED_PLANT)
+    expect(PLANT_IDS).not.toContain(UNATTRIBUTED_PLANT)
+    expect(PLANTS.map(p => p.name)).not.toContain(UNATTRIBUTED_PLANT)
+    expect(plantById('')).toBeNull()
+    expect(plantById('no-such-plant')).toBeNull()
+  })
+
+  it('shows the SHORT display name, never the ERP’s own long one', () => {
+    expect(plantLabel('npmd')).toBe('NPMD')
+    expect(plantLabel('npmd')).not.toBe('New Pashchim Maharashtra Patra Depot')
+    expect(plantLabel('hyderabad')).toBe('Hyderabad')
+    expect(plantLabel('lepakshi')).toBe('Lepakshi')
+    expect(plantLabel('tapi')).toBe('Tapi')
+  })
+
+  it('a blank plant survives the Postgres round trip (toSnake writes it as NULL)', () => {
+    // orders.plant is text; toSnake turns '' into NULL on the way out, and it reads back as null.
+    expect(plantLabel(null)).toBe(UNATTRIBUTED_PLANT)
+    expect(plantLabel(undefined)).toBe(UNATTRIBUTED_PLANT)
+  })
+
+  it('resolves the 18-Aug-2026 order book: 670 / 138 / 55 / 52 and 0 Unattributed', () => {
+    // The line counts the spec read off the file, rebuilt as rows the way mapOrderRow stores them.
+    const idx = plantIndex()
+    const sheet = [
+      ...Array(670).fill({ shipFromCode: HYD, name: 'NIPPON PIPES PRIVATE LIMITED' }),
+      ...Array(138).fill({ shipFromCode: NPMD, name: 'New Pashchim Maharashtra Patra Depot' }),
+      ...Array(55).fill({ shipFromCode: LEP, name: 'LEPAKSHI TUBES PRIVATE LIMITED' }),
+      ...Array(52).fill({ shipFromCode: TAPI, name: 'TAPI PIPES AND TUBES PRIVATE LIMITED' }),
+    ]
+    expect(sheet).toHaveLength(915)
+    const byPlant = {}
+    sheet.forEach(r => {
+      const label = plantLabel(resolvePlant(r, idx))
+      byPlant[label] = (byPlant[label] || 0) + 1
+    })
+    expect(byPlant).toEqual({ Hyderabad: 670, NPMD: 138, Lepakshi: 55, Tapi: 52 })
+    expect(byPlant[UNATTRIBUTED_PLANT]).toBeUndefined()
+    // Every line landed in exactly one plant — none dropped, none double-counted.
+    expect(Object.values(byPlant).reduce((a, b) => a + b, 0)).toBe(915)
+  })
+
+  it('Unattributed tonnage stays inside the company total — it is never a "rest" bucket', () => {
+    // Hyderabad's own 761.441 MT plus the three other plants' 1854.000 MT is the 2615.441 MT
+    // Pending to Dispatch reads today. Add a line the ERP labelled with a fifth company: its
+    // tonnage must still be in the total, sitting under Unattributed rather than outside the sum.
+    const idx = plantIndex()
+    const lines = [
+      { shipFromCode: HYD, pending: 761.441 },
+      { shipFromCode: NPMD, pending: 1044.000 },
+      { shipFromCode: LEP, pending: 417.000 },
+      { shipFromCode: TAPI, pending: 393.000 },
+      { shipFromCode: 'V9999-0000-JODL-0001', pending: 12.500 },   // a company nobody mapped
+    ]
+    const byPlant = {}
+    lines.forEach(l => {
+      const label = plantLabel(resolvePlant(l, idx))
+      byPlant[label] = (byPlant[label] || 0) + l.pending
+    })
+    expect(byPlant.Hyderabad).toBeCloseTo(761.441, 3)
+    expect(byPlant[UNATTRIBUTED_PLANT]).toBeCloseTo(12.5, 3)
+    // Per-plant sums equal the company total, Unattributed included.
+    const company = lines.reduce((s, l) => s + l.pending, 0)
+    expect(Object.values(byPlant).reduce((a, b) => a + b, 0)).toBeCloseTo(company, 3)
+    expect(company).toBeCloseTo(2615.441 + 12.5, 3)
   })
 })
 

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -152,6 +152,7 @@ create table if not exists orders (
   non_confirmed numeric,
   distributor_code text,
   ship_to_state text,
+  plant text,
   order_status text,
   expected_delivery_date date,
   deleted boolean default false,
@@ -167,6 +168,12 @@ alter table orders add column if not exists distributor_code text;
 -- lines keep their state inside dispatches.bundle_entries (no column there). Both stores are
 -- replace-all on upload, so one Sales Excel upload backfills every historical row.
 alter table orders add column if not exists ship_to_state text;
+-- Plant attribution (ticket #118) — the plant id resolved from the ERP's "Ship From Code"
+-- ('hyderabad' | 'npmd' | 'lepakshi' | 'tapi'), NULL when the code matched no plant, which the app
+-- displays as `Unattributed`. The plant master itself is a code constant (src/data/plants.js), not
+-- a table: four rows, all of them the ERP's own identifiers, nothing for an operator to type.
+-- Orders are replace-all on upload, so one Sales Excel upload backfills every row.
+alter table orders add column if not exists plant text;
 alter table orders enable row level security;
 drop policy if exists "Allow all access" on orders;
 create policy "Allow all access" on orders for all using (true) with check (true);


### PR DESCRIPTION
## Summary
Adds plant dimension to the order book. Four manufacturing companies (Hyderabad, NPMD, Lepakshi, Tapi) now appear as distinct entities instead of all orders being attributed to Hyderabad. Plant is resolved from the ERP's **Ship From Code** (the only trustworthy identifier), with the ERP's name string as a fallback only. Unresolved lines store blank and display as **Unattributed** — never guessed at, never a "rest" bucket.

## Key changes

- **Plant master** (`src/data/plants.js`): Static constant with four rows. Each carries `id` (stored on orders), `erpCode` (Ship From Code), `erpNames[]` (fallback matching), `name` (display label), `coilPrefix` (phase 2), and `manufactures` flag.

- **Resolution helpers** (`src/lib/calc.js`):
  - `normPlantKey()` — normalises codes and names (uppercase, collapse whitespace) so re-cased ERP exports cannot silently drop a plant
  - `plantIndex()` — builds a Map from both Ship From Codes and ERP names to plant ids; the two key spaces cannot collide
  - `resolvePlant(row)` — resolves one ERP row: code first, name second, '' when neither matches
  - `plantById(id)` — looks up the plant master row; returns `null` for blank/unknown
  - `plantLabel(id)` — returns short display name or `Unattributed`

- **Database** (`supabase-setup.sql`): Added `plant text` column to `orders` table.

- **Upload** (`src/App.jsx`):
  - `mapOrderRow()` now extracts Ship From Code and CM name, calls `resolvePlant()`, stores the id
  - Upload banner counts unresolved lines and reports them: `"N order line(s) with no plant (Unattributed)"`

- **Tests** (`src/lib/calc.test.js`): 11 test cases covering the four plants, code/name resolution, fallback behaviour, Unattributed semantics, and the 18-Aug-2026 order book (670/138/55/52 lines).

- **Documentation**:
  - `docs/adr/0004-plant-dimension-from-erp-ship-from-code.md` — why code not name, why Unattributed is not a fifth plant, why the master is a constant not a table
  - `docs/DATA-MODEL.md` — updated `orders` table description and added Plant section
  - `CONTEXT.md` — added Plant and Unattributed glossary entries

## Implementation notes

- **Code wins over name**: An unrecognised code is never guessed at from a similar name. A fifth company appearing in the ERP imports as Unattributed and is reported on the banner, never silently re-attributed.
- **Unattributed is not a plant**: It is not in `PLANT_IDS`, so iteration never yields five. Its tonnage stays inside every total — a missing mapping is a labelling gap, not a reason for weight to leave a sum.
- **No table, no sync**: The plant master is a code constant because all four fields are ERP identifiers or labels; nothing for an operator to type. Putting it in Postgres would add a sync path and editing UI for a row nobody edits.
- **Blank survives the round trip**: A blank plant stores as SQL NULL and reads back as `null`, so `plantLabel(null)` correctly returns `Unattributed`.
- **Column-name matching not tested**: The ERP column-name aliases (`shipfromcode` / `cmname` / `shipfromlocation`) are covered only by the upload banner, not by unit test — the same trade the `state → region` work made.

https://claude.ai/code/session_01VC7V7xc3dj1161gMMPQWpd