### PR TITLE
Per-plant coil numbering and ID prefixes (ticket #122)

### DIFF
--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -106,10 +106,10 @@ Production ─ batch takes its baby coils' ───► productions.plant
 | | |
 |---|---|
 | **Columns** | `coils.plant`, `baby_coils.plant`, `productions.plant` — all `text`, all holding the **id** |
-| **Helpers** | `coilInwardPlants()` / `DEFAULT_COIL_PLANT` (what Coil Inward may offer) · `babyCoilPlant(motherCoil)` · `productionPlant(coilAllocations, babyCoils, coils)` |
+| **Helpers** | `coilInwardPlants()` / `DEFAULT_COIL_PLANT` (what Coil Inward may offer) · `nextCoilNumber(coils, plant)` (each plant's own running number, ticket #122) · `genHRCoilId(dateStr, num, plant, master)` (id's prefix from the plant master, ticket #122) · `babyCoilPlant(motherCoil)` · `productionPlant(coilAllocations, babyCoils, coils)` |
 | **Set where** | Coil Inward only. The form's Plant field is a select when registering and **disabled when editing** — an existing coil's plant is carried through untouched on save |
 | **Inherited how** | Slitting re-reads the mother's plant on **every** save rather than carrying the stored value forward, so an edit can never move a baby coil off its mother's plant. Production derives its plant from the allocations it actually persists |
-| **Offered** | **Hyderabad alone.** NPMD manufactures, but registering its own coils — the `NPM-` prefix and a per-plant running number — is phase 2, and until then an NPMD coil would be handed a Hyderabad-shaped id. Phase 2 widens `COIL_INWARD_PLANT_IDS`; nothing else changes |
+| **Offered** | **Hyderabad alone, still** — `COIL_INWARD_PLANT_IDS` is the one remaining gate. Its numbering is ready (ticket #122): `nextCoilNumber` counts each plant's coils separately (NPMD starts at 01 whatever number Hyderabad is on) and `genHRCoilId` takes the plant's prefix (`NPM-` for NPMD, matching `HYD-`'s three letters), both defaulting to Hyderabad so no existing call or legacy row changes. Widening `COIL_INWARD_PLANT_IDS` is the one line left to actually offer NPMD; nothing else changes when it moves |
 | **Backfill** | A one-off `update … set plant = 'hyderabad' where plant is null` on all three tables in `supabase-setup.sql`. **Unlike orders and dispatches, pipeline rows are not replace-all on upload** — nothing rewrites them, so the history needs an explicit statement. Idempotent, and safe to re-run after phase 2: a row the app wrote already carries its own plant |
 | **Never touched** | Coil **ids**, weights, costs and `coil_allocations`. A coil id is printed on a physical tag and embedded inside stored production allocations |
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -454,12 +454,12 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils }) {
   const [showForm, setShowForm] = useState(false)
   const f = (k, v) => setForm(p => ({ ...p, [k]: v }))
 
-  const nextNo = useMemo(() => nextCoilNumber(coils), [coils])
+  const nextNo = useMemo(() => nextCoilNumber(coils, form.plant), [coils, form.plant])
 
   const hrCoilId = useMemo(() => {
     const n = editId ? form.hrCoilNo : (form.hrCoilNo || nextNo)
-    return form.dateOfInward && n ? genHRCoilId(form.dateOfInward, n) : ''
-  }, [form.dateOfInward, form.hrCoilNo, nextNo, editId])
+    return form.dateOfInward && n ? genHRCoilId(form.dateOfInward, n, form.plant) : ''
+  }, [form.dateOfInward, form.hrCoilNo, nextNo, editId, form.plant])
 
   const isDupe = useMemo(() => coils.some(c => c.hrCoilId === hrCoilId && c.id !== editId), [coils, hrCoilId, editId])
 
@@ -472,7 +472,7 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils }) {
     // is where plant is RECORDED, so an empty pick blocks the save rather than quietly becoming
     // Hyderabad. `emptyForm` pre-selects the default, so the ordinary path is still one click.
     const plant = editId ? (form.plant || '') : form.plant
-    const record = { ...form, plant, hrCoilNo: no, hrCoilId: genHRCoilId(form.dateOfInward, no), id: editId || uid(), deleted: false }
+    const record = { ...form, plant, hrCoilNo: no, hrCoilId: genHRCoilId(form.dateOfInward, no, plant), id: editId || uid(), deleted: false }
     if (editId) {
       setCoils(prev => prev.map(c => c.id === editId ? record : c))
     } else {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import {
 } from 'recharts'
 import { useSupabaseStore, verifyLogin } from './lib/db'
 import {
-  fmtT, fmtT3, genHRCoilId, tolerance, periodRange, inDateRange,
+  fmtT, fmtT3, genHRCoilId, nextCoilNumber, tolerance, periodRange, inDateRange,
   weightPerPieceFromSku, resolveProductionWeights, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, dispatchCoilTrace,
   rmRollsFg, capAllocationRows, requiredStripWidth, WIDTH_TOL_MM, isOpenOrderStatus, skuInventoryRows, skuSizeLabel,
@@ -454,10 +454,7 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils }) {
   const [showForm, setShowForm] = useState(false)
   const f = (k, v) => setForm(p => ({ ...p, [k]: v }))
 
-  const nextNo = useMemo(() => {
-    const nums = coils.map(c => c.hrCoilNo)
-    return nums.length ? Math.max(...nums) + 1 : 1
-  }, [coils])
+  const nextNo = useMemo(() => nextCoilNumber(coils), [coils])
 
   const hrCoilId = useMemo(() => {
     const n = editId ? form.hrCoilNo : (form.hrCoilNo || nextNo)

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -58,6 +58,14 @@ export const inDateRange = (d, range) => {
   return true
 }
 
+// ── Coil Inward's running number: the next hrCoilNo to suggest. Extracted from an inline React
+// hook (ticket #122, step 1) so it can be reached by a test — behaviour is unchanged: the global
+// max across every coil passed in, plus one. Per-plant counting is step 2. ──
+export function nextCoilNumber(coils) {
+  const nums = (coils || []).map(c => c?.hrCoilNo)
+  return nums.length ? Math.max(...nums) + 1 : 1
+}
+
 // ── HR coil ID generator: HYD-MMYY-NN ──
 export function genHRCoilId(dateStr, num) {
   const d = new Date(dateStr)

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -59,19 +59,28 @@ export const inDateRange = (d, range) => {
 }
 
 // ── Coil Inward's running number: the next hrCoilNo to suggest. Extracted from an inline React
-// hook (ticket #122, step 1) so it can be reached by a test — behaviour is unchanged: the global
-// max across every coil passed in, plus one. Per-plant counting is step 2. ──
-export function nextCoilNumber(coils) {
-  const nums = (coils || []).map(c => c?.hrCoilNo)
+// hook (ticket #122) so it can be reached by a test. Scoped to ONE plant's own coils — the max
+// among only that plant's rows, plus one — so NPMD's first coil starts at 01 whatever number
+// Hyderabad is on, and Hyderabad's is never disturbed by how many coils NPMD holds. A coil with
+// no plant recorded (a pre-#120 row never backfilled) counts toward NEITHER plant, matching
+// `filterByPlant`'s Unattributed semantics — it can never inflate a real plant's next number.
+// `plant` defaults to Hyderabad, the same default every other plant-aware helper here uses.
+export function nextCoilNumber(coils, plant = DEFAULT_COIL_PLANT) {
+  const nums = (coils || []).filter(c => storedPlant(c) === plant).map(c => c?.hrCoilNo)
   return nums.length ? Math.max(...nums) + 1 : 1
 }
 
-// ── HR coil ID generator: HYD-MMYY-NN ──
-export function genHRCoilId(dateStr, num) {
+// ── HR coil ID generator: <PREFIX>-MMYY-NN. The prefix comes from the plant's own master row
+// (ticket #122) instead of a hardcoded 'HYD', so a mother coil's id says which plant's register
+// it belongs to — Hyderabad keeps HYD-, NPMD gets NPM-. `plant` defaults to Hyderabad, and a
+// blank/unknown plant or a master row missing its prefix falls back to it too, so an old 2-arg
+// call and a coil not yet backfilled both keep generating exactly the id they always have. ──
+export function genHRCoilId(dateStr, num, plant = DEFAULT_COIL_PLANT, master = DEFAULT_PLANTS) {
   const d = new Date(dateStr)
   const mm = String(d.getMonth() + 1).padStart(2, '0')
   const yy = String(d.getFullYear()).slice(2)
-  return `HYD-${mm}${yy}-${String(num).padStart(2, '0')}`
+  const prefix = plantById(plant, master)?.coilPrefix || 'HYD'
+  return `${prefix}-${mm}${yy}-${String(num).padStart(2, '0')}`
 }
 
 // ── ±tolerance check. NOTE: returns ok:true when either arg is falsy — callers
@@ -976,10 +985,10 @@ export function dispatchPlantLabel(record, master = DEFAULT_PLANTS) {
 // physically sits, and a coil does not move plant because someone corrected a form.
 
 // Which plants may register a mother coil TODAY. `manufactures` says a plant *can* run the
-// pipeline; this says which one actually does right now. NPMD manufactures, but its own
-// registration — the `NPM-` prefix and a per-plant running number — is phase 2 of the #117 spec.
-// Until that lands, a coil registered against NPMD would be handed a Hyderabad-shaped id, so
-// NPMD is not offered. Phase 2 widens this list; nothing else here changes.
+// pipeline; this says which one actually does right now. NPMD manufactures, and its own
+// numbering is ready — `nextCoilNumber` and `genHRCoilId` (above) are both plant-aware, so an
+// NPMD coil would get a correctly-shaped `NPM-` id (ticket #122). This list is the one thing
+// still gating it out: widening it is the one line left; nothing else changes when it moves.
 // A stored `plant` as the helpers below compare it: the id, or '' for a row written before this
 // ticket (SQL NULL reads back as null, and a half-filled form as ''). Deliberately NOT exported —
 // reading a row's plant field raw is never the interesting operation; the named rules below are.

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -62,11 +62,12 @@ export const inDateRange = (d, range) => {
 // hook (ticket #122) so it can be reached by a test. Scoped to ONE plant's own coils — the max
 // among only that plant's rows, plus one — so NPMD's first coil starts at 01 whatever number
 // Hyderabad is on, and Hyderabad's is never disturbed by how many coils NPMD holds. A coil with
-// no plant recorded (a pre-#120 row never backfilled) counts toward NEITHER plant, matching
-// `filterByPlant`'s Unattributed semantics — it can never inflate a real plant's next number.
-// `plant` defaults to Hyderabad, the same default every other plant-aware helper here uses.
+// no plant recorded (a pre-#120 row never backfilled) counts toward NEITHER plant — it is
+// filtered out by the same `filterByPlant` a real plant id always takes the non-ALL_PLANTS
+// branch of, so it can never inflate a real plant's next number.
+// `plant` defaults to Hyderabad, the same default every other plant-aware helper here uses. ──
 export function nextCoilNumber(coils, plant = DEFAULT_COIL_PLANT) {
-  const nums = (coils || []).filter(c => storedPlant(c) === plant).map(c => c?.hrCoilNo)
+  const nums = filterByPlant(coils, plant).map(c => c?.hrCoilNo)
   return nums.length ? Math.max(...nums) + 1 : 1
 }
 

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  fmtT, fmtT3, fmtPct, fmtINR, genHRCoilId, tolerance, periodRange, inDateRange,
+  fmtT, fmtT3, fmtPct, fmtINR, genHRCoilId, nextCoilNumber, tolerance, periodRange, inDateRange,
   weightPerPieceFromSku, resolveProductionWeights, bundleWeightCap, buildReconciliationRows, coilInventoryRow,
   coilFifoAllocate, coilConsumption, producedPool, unmatchedDispatch, skuAgeing, dispatchCoilTrace, THICKNESS_TOL_MM,
   RM_TO_FG_THICKNESS, allowedRmThickness, rmRollsFg, capAllocationRows,
@@ -88,6 +88,18 @@ describe('inDateRange', () => {
     expect(inDateRange('2026-06-30', r)).toBe(true)
     expect(inDateRange('2026-05-31', r)).toBe(false)
     expect(inDateRange('', r)).toBe(false)
+  })
+})
+
+describe('nextCoilNumber', () => {
+  it('is one past the highest hrCoilNo across the coils passed in — the inline hook it replaces did the same global max, unfiltered', () => {
+    expect(nextCoilNumber([{ hrCoilNo: 1 }, { hrCoilNo: 5 }, { hrCoilNo: 3 }])).toBe(6)
+    expect(nextCoilNumber([{ hrCoilNo: 7 }])).toBe(8)
+  })
+
+  it('starts at 1 with no coils yet', () => {
+    expect(nextCoilNumber([])).toBe(1)
+    expect(nextCoilNumber(undefined)).toBe(1)
   })
 })
 

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -91,15 +91,39 @@ describe('inDateRange', () => {
   })
 })
 
-describe('nextCoilNumber', () => {
-  it('is one past the highest hrCoilNo across the coils passed in — the inline hook it replaces did the same global max, unfiltered', () => {
-    expect(nextCoilNumber([{ hrCoilNo: 1 }, { hrCoilNo: 5 }, { hrCoilNo: 3 }])).toBe(6)
-    expect(nextCoilNumber([{ hrCoilNo: 7 }])).toBe(8)
+describe('nextCoilNumber (ticket #122 — per plant)', () => {
+  it("is one past the highest hrCoilNo among that plant's own coils — with only Hyderabad coils present, the same number the old unfiltered global-max hook computed", () => {
+    const coils = [
+      { hrCoilNo: 1, plant: 'hyderabad' },
+      { hrCoilNo: 5, plant: 'hyderabad' },
+      { hrCoilNo: 3, plant: 'hyderabad' },
+    ]
+    expect(nextCoilNumber(coils, 'hyderabad')).toBe(6)
+    expect(nextCoilNumber(coils)).toBe(6) // defaults to Hyderabad
   })
 
-  it('starts at 1 with no coils yet', () => {
+  it('starts at 1 for a plant with no coils yet', () => {
     expect(nextCoilNumber([])).toBe(1)
     expect(nextCoilNumber(undefined)).toBe(1)
+    expect(nextCoilNumber([{ hrCoilNo: 40, plant: 'hyderabad' }], 'npmd')).toBe(1)
+  })
+
+  it("one plant's next number is unaffected by how many coils the other plant holds, and vice versa", () => {
+    const coils = [
+      { hrCoilNo: 1, plant: 'hyderabad' },
+      { hrCoilNo: 2, plant: 'hyderabad' },
+      { hrCoilNo: 340, plant: 'hyderabad' },
+      { hrCoilNo: 1, plant: 'npmd' },
+    ]
+    // NPMD's single coil never pushes Hyderabad's count past its own 340.
+    expect(nextCoilNumber(coils, 'hyderabad')).toBe(341)
+    // Hyderabad's 340 coils never push NPMD's register past its own 1.
+    expect(nextCoilNumber(coils, 'npmd')).toBe(2)
+  })
+
+  it('ignores a coil with no plant recorded (a pre-#120 row never backfilled) — it counts toward no plant, so it can never inflate one', () => {
+    const coils = [{ hrCoilNo: 99 }, { hrCoilNo: 5, plant: 'hyderabad' }]
+    expect(nextCoilNumber(coils, 'hyderabad')).toBe(6)
   })
 })
 
@@ -107,6 +131,25 @@ describe('genHRCoilId', () => {
   it('formats HYD-MMYY-NN with zero-padded month and number', () => {
     expect(genHRCoilId('2026-06-15', 3)).toBe('HYD-0626-03')
     expect(genHRCoilId('2026-12-01', 12)).toBe('HYD-1226-12')
+  })
+
+  it("takes the prefix from the plant's own master row (ticket #122) — NPMD reads NPM-, three letters matching Hyderabad's", () => {
+    expect(genHRCoilId('2026-08-26', 1, 'npmd')).toBe('NPM-0826-01')
+    expect(genHRCoilId('2026-08-26', 1, 'hyderabad')).toBe('HYD-0826-01')
+  })
+
+  it('falls back to the Hyderabad prefix for a blank or unknown plant, so nothing breaks mid-change', () => {
+    expect(genHRCoilId('2026-06-15', 3, '')).toBe('HYD-0626-03')
+    expect(genHRCoilId('2026-06-15', 3, 'not-a-real-plant')).toBe('HYD-0626-03')
+  })
+
+  it('falls back to the Hyderabad prefix even if a known plant\'s own master row has none set', () => {
+    const brokenMaster = PLANTS.map(p => p.id === 'npmd' ? { ...p, coilPrefix: '' } : p)
+    expect(genHRCoilId('2026-08-26', 1, 'npmd', brokenMaster)).toBe('HYD-0826-01')
+  })
+
+  it('never collides across plants for the same date and number — full ids stay unique, so duplicate-ID detection (a plain string match in App.jsx) still works per plant with no new logic', () => {
+    expect(genHRCoilId('2026-08-26', 1, 'hyderabad')).not.toBe(genHRCoilId('2026-08-26', 1, 'npmd'))
   })
 })
 
@@ -1462,9 +1505,9 @@ describe('invoice lines carry their plant (ticket #119)', () => {
 
 describe('pipeline rows carry their plant (ticket #120)', () => {
   it('offers Hyderabad alone at Coil Inward, and defaults a new coil to it', () => {
-    // Plant is typed ONCE, here, and inherited downstream. NPMD manufactures, but registering its
-    // own coils — its `NPM-` prefix and its own running number — is phase 2. Until then a coil
-    // registered against NPMD would take a Hyderabad-shaped id, so NPMD is not offered yet.
+    // Plant is typed ONCE, here, and inherited downstream. NPMD manufactures, and its own `NPM-`
+    // prefix and running number are ready (see 'nextCoilNumber' / 'genHRCoilId' above, #122) —
+    // COIL_INWARD_PLANT_IDS is the one thing still holding it back, so NPMD is not offered yet.
     expect(coilInwardPlants().map(p => p.id)).toEqual(['hyderabad'])
     expect(coilInwardPlants().map(p => p.name)).toEqual(['Hyderabad'])
     expect(DEFAULT_COIL_PLANT).toBe('hyderabad')


### PR DESCRIPTION
## Summary
Extract coil numbering logic into testable helpers and make both numbering and ID generation plant-aware, so each plant (Hyderabad, NPMD) maintains its own running sequence and generates IDs with the correct prefix.

## Changes

**New helper: `nextCoilNumber(coils, plant)`**
- Extracted from an inline React hook in `CoilInward` so it can be tested
- Counts only the specified plant's own coils; a coil with no plant recorded is filtered out and cannot inflate any plant's sequence
- Defaults to Hyderabad (matching all other plant-aware helpers)
- NPMD's first coil will start at 01 regardless of Hyderabad's current number, and vice versa

**Updated helper: `genHRCoilId(dateStr, num, plant, master)`**
- Now accepts `plant` and optional `master` parameters (previously hardcoded to Hyderabad)
- Reads the prefix from the plant's master row (`coilPrefix` field) instead of hardcoding `'HYD'`
- Falls back to `'HYD'` if plant is blank, unknown, or the master row has no prefix set — preserves backward compatibility for old 2-arg calls and pre-#120 rows
- NPMD coils now generate `NPM-MMYY-NN` format; Hyderabad keeps `HYD-MMYY-NN`

**Updated `CoilInward` component**
- Replaced inline `nextNo` calculation with call to `nextCoilNumber(coils, form.plant)`
- Pass `form.plant` to `genHRCoilId()` so the generated ID reflects the selected plant
- Plant selection now affects both the suggested number and the ID preview in real time

**Test coverage**
- Added 4 test cases for `nextCoilNumber`: basic max+1, empty plant, cross-plant isolation, and handling of unplanted coils
- Added 5 test cases for `genHRCoilId`: plant-specific prefixes, fallback to Hyderabad, broken master rows, and uniqueness across plants

**Documentation**
- Updated `DATA-MODEL.md` to list the new helpers and clarify that `COIL_INWARD_PLANT_IDS` is now the only remaining gate for NPMD (numbering itself is ready)
- Updated comments in `calc.js` to explain the per-plant scoping and fallback behavior

## Implementation notes
- No changes to the database schema or stored data format
- Backward compatible: old 2-arg calls to `genHRCoilId()` and pre-#120 rows without a plant field continue to work
- `COIL_INWARD_PLANT_IDS` remains hardcoded to `['hyderabad']` — widening it to include NPMD is a one-line change when ready, and nothing else in the codebase will need to change

https://claude.ai/code/session_01NmXuvXm9586B5SUxVdgcCr