### PR TITLE
Role and plant decide what a user sees (ticket #126)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -107,7 +107,8 @@ the pre-existing shared login already had in all but name — and **plant** — 
 A plant login carries that plant's id; an admin carries none, which is read as **all plants** and
 never as **Unattributed**. It is **UI tidiness, not confidentiality**: every table keeps its
 permissive policy and the public key still reaches all data, so a role decides what a screen shows,
-never what is reachable. Nothing on screen reads it yet.
+never what is reachable. Since ticket #126 it decides which tabs render, which are read-only, and
+whether the plant selector is offered — one pure function, `accessFor` in `src/lib/calc.js`.
 _Avoid_: Permission, access level, privilege, user type, admin rights, security role
 
 **Service area**:

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -194,3 +194,36 @@ could ever catch the drift.
 selector. Gating tabs meant re-reading every string that assumed the reader could change the scope.
 `docs/ARCHITECTURE.md` also still described a "Reset Data" header button that no longer exists
 anywhere in the app.
+
+### Review round on #126 — what the two axes caught
+
+**The doc you skip is the one that governs the code you changed.** `CLAUDE.md`'s "Read before you
+change these areas" table binds `docs/UI-PATTERNS.md` to "Components, DataTable, stage forms". This
+ticket changed a stage form (Coil Inward's Plant field), two components' write controls and a
+DataTable's Actions column — and updated five other docs while skipping that one. Three of its
+statements were left false. Updating the docs you *thought of* is not the same as updating the ones
+the table names.
+
+**"All Plants" is the worst possible fallback for a scoped user.** `plantLabelForHeader` ended
+`|| 'All Plants'`. For an admin that is unreachable (the value always comes from the options). For a
+plant user whose credential names a plant id no master row matches, it fired — and the one place
+their plant is stated told them they were looking at the whole company. A fallback is only safe if
+it is safe on *every* path that can reach it. It now shows the unmatched id itself.
+
+**Unmounting a button is not withholding the feature.** The Orders upload's hidden
+`<input type="file">` was left mounted while only its `<Btn>` was gated — the whole write path one
+console line away, and the docs claiming controls were "withheld from the DOM". The trigger and the
+thing it triggers gate together.
+
+**Two mechanisms documented as separate will diverge — gate on the right one.** `accessFor` gated
+the manufacturing tabs on `manufactures`, but Coil Inward's admin picker honours
+`COIL_INWARD_PLANT_IDS`, a rollout list `calc.js` explicitly says is *not* the same question. A
+plant with `manufactures: true` not yet on the rollout list would have let a plant user register
+coils an admin cannot offer. Latent today (both lists match) — closed, with a test that flips
+Lepakshi to manufacturing to prove it.
+
+**Scoping hides the unattributed, and someone must still fix them.** `filterByPlant` matches the
+stored value exactly, so a legacy blank-plant row is invisible to a plant user in the pipeline
+stages. That is right — a row that cannot say where it sits is not one plant's to claim — but it
+silently makes backfilling an admin-only job. Written down in both `ARCHITECTURE.md` and
+`UI-PATTERNS.md` rather than left to be discovered by a plant user who cannot find their coil.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -145,3 +145,52 @@ Date | Component | Issue | Resolution | Insight
 2026-08-18 | E2E (Playwright) | `e2e/pipeline.spec.js` and `e2e/slitting-multi.spec.js` have been failing since the login gate shipped (July 2026) — all 7 specs, every run. They `page.goto('/')` and immediately look for the stage tabs; the app now renders `Sign in to continue` instead, so every locator times out. Verified identical on a clean checkout of `main`, so it is not a regression from the plant work. | Not fixed here — it needs either a real test credential or a `LoginGate` bypass in `--mode test`, and both are decisions about auth, not about #120. Recorded so the next ticket that claims "the existing specs pass unchanged" checks what "unchanged" currently means. | A guard nobody runs is not a guard. The specs were the stated regression net for the whole #117 multi-plant spec — "the existing pipeline and slitting specs must keep passing" is an acceptance criterion on three of its tickets — and they had been red for a month. Also worth noting: this image ships Chromium revision 1194 while `@playwright/test` 1.60 wants 1223, so `npx playwright test` fails with "Executable doesn't exist" before it ever reaches the app; run it through a throwaway config setting `launchOptions.executablePath: '/opt/pw-browsers/chromium'`.
 
 2026-08-19 | Migrations / seed paths | Gating a backfill closes the door behind it — so every OTHER write path has to carry the value itself. `supabase-setup.sql`'s plant backfill fires only when the column does not yet exist (so a re-run can never re-stamp a row the app deliberately left Unattributed). Correct, but it turns two forgotten seed paths into permanent holes: `scripts/import-excel.mjs` emitted `create table coils/baby_coils/productions` with no `plant` and inserted plant-less rows, and `restore-baby-coils.sql` likewise. Either one run after the migration writes rows the backfill will never revisit. | Both now state their own plant. The importer stamps `IMPORT_PLANT = 'hyderabad'` (guarded against a rename by `plantById()` at startup) into all three row builders — `buildInsertSql` derives its columns from the row objects, so it flows into the emitted SQL and the upsert `do update set` for free — and its schema preamble gained the column plus `add column if not exists`. `restore-baby-coils.sql` carries `'hyderabad'` in all 61 tuples. | Two lessons. (1) "Idempotent" and "self-healing" are not the same property, and making a migration properly idempotent can *cost* you the self-healing one. Once a backfill is one-shot, ask what else inserts into that table — the answer here was two files that no test and no code path touches, found only by a reviewer grepping for the table names. (2) When editing 61 hand-curated data tuples, verify arity with a real quoted-string-aware splitter rather than by eye: assert every row has the same column count as its header AND the literal landed in the right slot. Both files are historical artefacts nobody runs weekly, which is exactly why a silent shift would have surfaced years later.
+
+## 2026-08-19 — #126 Role and plant decide what a user sees
+
+**A test that cannot run is not a test that passes.** `TESTING.md` carried a "known environment
+blocker": Chromium could not be downloaded in the sandbox, so the Playwright specs were "authored
+and discoverable" but never executed. This session's machine had a pre-provisioned Chromium at
+`/opt/pw-browsers/chromium`, so they ran for the first time in a long while — and **all 7 failed**,
+none of it caused by this ticket:
+
+| The spec still did | Reality |
+|---|---|
+| Filled `Cost Price (₹)` at Coil Inward | The field was deleted; cost arrives via the daily Excel |
+| Clicked `Upload Dispatch Excel` | Dispatch has no upload — it is rebuilt from the Orders tab's workbook |
+| `selectOption` on the SKU and HR Coil ID pickers | Both are `SearchSelect` (an `<input>` + option buttons), not `<select>` |
+| Expected `Save Baby Coil` | The button counts: `Save 1 Baby Coil` |
+| Expected `No eligible baby coil` | The message reads `No eligible coil to suggest` |
+| Expected FIFO to allocate on its own | **Use suggestion** must be clicked — the never-auto-save rule |
+| Went straight to `page.goto('/')` | The login gate has stood in front of the app since July |
+
+Every one of those is a change that shipped, correctly, past a suite that could not object. The fix
+is two lines in `playwright.config.js` — an optional `PW_CHROMIUM_PATH` that sets
+`launchOptions.executablePath` — so a machine with a browser already on it never has to pretend it
+cannot test. **Before believing a suite, run it.** 28 E2E tests now pass.
+
+**Stub the backend, don't wait for it to fail.** With `.env.test` pointing at a host that does not
+resolve, the app sat on "Loading inventory data..." while six table reads died slowly through the
+proxy — longer than any test timeout. Answering `**/rest/v1/**` with `[]` is the same starting state
+the specs always assumed, and instant. One subtlety worth keeping: answer **writes** as accepted
+too. A rejected write makes `useSupabaseStore` re-pull so the UI stops showing rows Postgres
+refused, and a re-pull against an empty stub would throw away the very coil the test just registered.
+
+**A session can be well-formed and still grant nothing.** `parseStoredSession` asks "is this a
+session?" and `accessFor` asks "what may it do?" — and a `plant` credential with a NULL plant column
+passes the first and fails the second, because `verifyLoginDetails` maps NULL → `ALL_PLANTS` (right
+for an admin, meaningless for a plant login). Keeping them separate was correct; requiring **both**
+at the two call sites is what closes the hole. Reading that session as "every plant" would have
+handed a plant login the whole company; signing them into an app with zero tabs would have
+presented a credential to fix as a bug in the app. It now says which, and where it is fixed.
+
+**Two lists of tabs is one list too many.** `APP_TABS` moved from `App.jsx` into `calc.js` beside
+`accessFor`. A tab added to a component-local list and not to the rule is a tab shown to everyone by
+a rule that had never heard of it — and `App.jsx` cannot be imported by the test suite, so no test
+could ever catch the drift.
+
+**Copy has to survive the change it describes.** The Dispatch plant-filter notice ended "Switch to
+**All Plants** to delete" — an instruction a plant user cannot follow, because they have no
+selector. Gating tabs meant re-reading every string that assumed the reader could change the scope.
+`docs/ARCHITECTURE.md` also still described a "Reset Data" header button that no longer exists
+anywhere in the app.

--- a/TESTING.md
+++ b/TESTING.md
@@ -22,24 +22,49 @@ They run in Node (no DOM/Supabase needed). `db.test.js` mocks `./supabase` so im
 `db.js` doesn't try to construct a real client.
 
 ## E2E tests (Playwright)
-Drives the **Coil Inward → Bundle Formation → Dispatch** flow plus the over-fill
-Save-block and a guard that the removed Slit/Tube tabs are gone. Specs: `e2e/pipeline.spec.js`.
+Three specs, 28 tests:
+- `e2e/pipeline.spec.js` — **Coil Inward → Slitting → Production**, FIFO split across baby coils,
+  the shortfall warn-don't-block policy, and a guard that the removed stages are gone.
+- `e2e/slitting-multi.spec.js` — multi-row slitting and the baby-coil search.
+- `e2e/roles.spec.js` — **which tabs each of `admin`, `hyderabad` and `npmd` renders** (ticket #126),
+  the read-only SKU Master and order book, the pinned Coil Inward plant, the one-time clearing of a
+  pre-#126 session, and that no screen describes another plant's data as private or secure.
+
+**Every spec signs in**, through the real form, via `e2e/signin.js`. Only the one sign-in RPC is
+stubbed — `.env.test` points at a host that does not exist, so no password could verify, and the
+password check itself is covered elsewhere (bcrypt against a real Postgres, and `verifyLoginDetails`
+in `db.test.js`). The same helper answers the table reads with an empty table, which is the state
+the specs always assumed and is instant instead of waiting on a network failure.
 
 ```bash
 npx playwright install chromium   # one-time: download the browser binary
 npm run test:e2e
 ```
 
-`playwright.config.js` boots the Vite dev server in `test` mode, which loads
-`.env.test` (dummy Supabase creds) so the app renders. Because that backend is fake,
-writes don't persist — the tests exercise the **optimistic in-session UI state**, so
-each test runs in a single page session with no reloads mid-flow (a dismissible
-sync-error banner may appear; that's expected).
+`playwright.config.js` boots the Vite dev server in `test` mode, which loads `.env.test` (dummy
+Supabase creds) so the app renders. Nothing persists — the pipeline specs exercise the **optimistic
+in-session UI state**, so they run in a single page session with no reloads mid-flow. Since the
+stub answers writes as accepted there is no sync-error banner any more, and no re-pull to throw
+away a row a test just entered. `roles.spec.js` *does* reload on purpose: what survives a reload is
+the point of a session.
 
-### Known environment blocker
-Installing the Chromium binary requires downloading from `cdn.playwright.dev`. In
-network-restricted sandboxes where that host is not allow-listed, the download fails
-with `Host not in allowlist` and the E2E tests cannot run. The specs are authored and
-discoverable (`npx playwright test --list`), and the Vite webServer starts correctly —
-only the browser binary is missing. Run them in an environment with network access to
-`cdn.playwright.dev` (or a pre-provisioned browser image) to execute the suite.
+### When the Chromium download is blocked
+Installing the browser requires `cdn.playwright.dev`. Where that host is not allow-listed the
+download fails with `Host not in allowlist` — but if the machine already has a Chromium built for
+Playwright, point at it instead of downloading:
+
+```bash
+PW_CHROMIUM_PATH=/opt/pw-browsers/chromium npm run test:e2e
+```
+
+`playwright.config.js` sets `launchOptions.executablePath` only when that variable is present, so a
+normal `npx playwright install` run is unaffected.
+
+**These specs went unrun for a long time and it cost.** They could not execute in the sandbox, so
+nothing noticed as the app moved under them: they still filled a `Cost Price (₹)` field that had
+been deleted, clicked an `Upload Dispatch Excel` button that no longer existed, drove two
+`SearchSelect` pickers as if they were `<select>`s, and expected FIFO to allocate without clicking
+**Use suggestion** — which the never-auto-save rule requires. Then the login gate shipped and every
+one of them stopped at the sign-in screen. A test that cannot run is not a test that passes. If you
+change the app in a sandbox where these cannot execute, say so in the commit rather than assuming
+they still hold.

--- a/blueprints/manage-app-login.md
+++ b/blueprints/manage-app-login.md
@@ -21,15 +21,34 @@ Read this before you promise anyone anything.
   (`app_credentials`) that the app itself cannot read. The app only asks a database function
   whether the password is correct.
 - There are **two** such functions, both `security definer`, both bcrypt:
-  - `verify_login(p_login_id, p_password) → boolean` — the original yes/no.
+  - `verify_login(p_login_id, p_password) → boolean` — the original yes/no. **No longer used by
+    the app** since ticket #126: a yes/no cannot decide which tabs to render. Kept so a browser
+    tab still running an older build can sign in until it reloads.
   - `verify_login_details(p_login_id, p_password) → (login_id, plant, role)` — added by ticket
-    #125; answers **who** signed in. A wrong password returns **no rows**.
+    #125, and what the app signs in with today. A wrong password returns **no rows**.
   The second was added **beside** the first, not instead of it, so the SQL could be run against
   the database serving the live app without breaking sign-in before the new build shipped.
   Neither function ever returns the password hash.
-- After a correct sign-in, the browser remembers the login on **that device for ~30 days**
-  (stored under `jsw:auth`), so the user isn't asked every visit. **Logout** (top bar,
-  next to the dark-mode moon) clears it.
+- After a correct sign-in, the browser remembers the session on **that device for ~30 days**
+  (stored under `jsw:auth` as `{loginId, plant, role, at}`), so the user isn't asked every visit.
+  **Logout** (top bar, next to the dark-mode moon) clears it.
+
+## What each login SEES (ticket #126)
+| Tab | `admin` | `hyderabad` / `npmd` |
+|---|---|---|
+| Dashboard, Coil Tracker, Dispatch, Sales | All plants, plus the plant selector | Their plant only |
+| Coil Inward, Slitting, Production | All plants, plus the selector | Their plant, pinned — and only if that plant `manufactures` |
+| SKU Master | View and **edit** | View only |
+| Orders & Invoice | **Upload** and view | View, their plant |
+| Reports | **Yes** | Hidden |
+
+The three admin-only powers are admin-only for a reason worth knowing before you hand anyone the
+`admin` password: the **upload** replaces the whole company's order book in one go (a second
+uploader on a stale file overwrites everyone), **SKU Master** sets `weightPerTube` and therefore
+every plant's tonnage and cost, and **Reports** builds the company-wide workbooks.
+
+A plant user gets **no plant selector** — their plant is on their login, and the header names it.
+Read the box at the top of this file again before telling anyone what that does and does not mean.
 
 ## The three logins
 | Login ID | Role | Plant | Who |
@@ -128,7 +147,8 @@ plant id the app has never heard of, and then the sign-in has a plant nothing re
 
 A plant that does not manufacture (`manufactures: false` in the plant master — Lepakshi and Tapi
 today) is never offered the Coil Inward / Slitting / Production stages. That flag, not the login,
-decides it.
+decides it — `accessFor` in `src/lib/calc.js` reads it, and flipping it is still the one-line change
+`docs/adr/0004` promised.
 
 ## Steps — set up the logins on a brand-new database
 Running `supabase-setup.sql` creates the table + both functions but seeds **no** password (on
@@ -161,8 +181,10 @@ on conflict (login_id) do update
   reach **every plant's** data directly. Use strong, non-obvious passwords.
 - The password check is callable with the public key, so pick a strong password (bcrypt slows
   guessing, but don't use something trivial).
-- Nothing on screen reads the plant or the role **yet**. Ticket #125 laid the credential model only;
-  the tab gating is the next ticket. Until it ships, all three logins see the same app.
+- A login with `role = 'plant'` and **no plant** (a NULL `plant` column) cannot sign in: the app
+  refuses it with "This login is not set up correctly" rather than opening with no tabs. A NULL
+  plant means *all plants*, which is an admin, and a plant login with all plants would defeat the
+  point. Fix the row — the `select` above shows you which logins have no plant.
 
 ## Upgrade path (only if you need to protect the DATA too)
 Switch to **Supabase Auth** (real accounts) and replace the open `using (true)` policies on the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,14 +26,57 @@ no longer consumes mother coils — it FIFO-consumes **baby coils** on thickness
 ## Other Modules
 Plus: **SKU Master** (232-entry tube catalog — SHS/RHS/CHS, loaded from `src/data/skus.js`), **Coil Tracker** (mother-coil inventory + journey; **also a baby-coil view** — an "All Baby Coils" table with weight/used/free/% used/status when no mother is selected, and that mother's baby coils inside its journey when one is selected), **Dashboard** (KPIs, pipeline, yield, alerts), **Orders & Invoice** (ONE daily "Upload Sales Excel" of the One Helix workbook — Orders tab → `orders` with per-line Confirmed/Non-confirmed; Invoice tab → `dispatches`), and **Sales** (Confirmed / Non-confirmed / Pending to Dispatch / MTD Invoice / Total Orders KPIs + distributor-wise and month-wise tables). The distributor table also carries the **Best Estimate** — a typed monthly target per distributor, edited inline and measured against MTD Invoice; the plant-level Best Estimate in the PB MTD Dashboard report is their sum, no longer typed on the Reports tab (`docs/adr/0001-…`). Its **drill-down** shows unreserved plant on-hand stock against the distributor's pending, per SKU (`docs/adr/0002-…`). **PO Master, Open Order Backlog, and SKU Demand vs Supply were removed (July 2026).**
 
+## Role and plant decide what you see (ticket #126)
+Who signed in decides which tabs render, which of them can be edited, and whether the plant selector
+appears at all. **One pure function** — `accessFor(session)` in `src/lib/calc.js` — answers all
+three, so the rules are unit-tested without a browser and there is a single place to change them.
+`APP_TABS` (the ordered tab list) lives beside it for the same reason: a second list in `App.jsx`
+would eventually show a tab the rule had never heard of.
+
+| Tab | Admin | Plant user |
+|---|---|---|
+| Dashboard, Coil Tracker, Dispatch, Sales | All plants + selector | Their plant only |
+| Coil Inward, Slitting, Production | All plants + selector | Their plant, pinned — and only if their plant `manufactures` |
+| SKU Master | View and **edit** | View only |
+| Orders & Invoice | **Upload** and view | View, their plant |
+| Reports | **Yes** | Hidden |
+
+Three restrictions carry real weight, and each is admin-only for a stated reason: the **upload**
+rebuilds the whole company's order book by superseding every live row, so a second uploader working
+from a stale file would overwrite everyone; **SKU Master** drives `weightPerTube`, which drives every
+plant's tonnage and cost; **Reports** builds the company-wide workbooks.
+
+How it is wired in `InventoryApp`:
+- `access.tabs` renders the tab bar; a hidden tab has no button and no route.
+- `access.readOnly` is passed to `SKUMaster` and `Orders` as `readOnly`, which withholds the writing
+  controls **from the DOM**, not merely disables them. The tables and exports stay.
+- `access.plantSelector` decides whether the `<select>` is rendered. When it is not, `selectedPlant`
+  is pinned to `access.plant` and there is no setter — a plant user's scope is not a control they
+  could move.
+- `plantPinned` (the same distinction) also switches the **pipeline** stages onto the plant-scoped
+  arrays. #121 deliberately left those reading the raw register for an admin, and that is unchanged;
+  a plant user's stages read only their plant's rows, and Coil Inward registers against their plant
+  with nothing to pick.
+
+**This is not a data boundary.** Every table keeps its permissive row-level policy and the app's
+public key still reaches every plant's rows. It hides another plant's screens from an operator who
+has no use for them. No screen may tell a plant team their data is private, hidden or secure — an
+E2E test asserts that copy never appears. See `blueprints/manage-app-login.md`.
+
+**Sessions** are `{loginId, plant, role, at}` under `jsw:auth`, validated by `parseStoredSession`
+(also in `calc.js`, also pure). A session stored before this ticket has no `role`, so it is rejected
+and deleted — everyone signs in once more, a few seconds, no version stamp needed.
+
 ## Plant selector (ticket #121)
-One `<select>` in the header, next to the dark-mode toggle. It defaults to **All Plants**, so every
+One `<select>` in the header, next to the dark-mode toggle. **Offered to an admin only** (#126).
+It defaults to **All Plants**, so every
 figure the app shows on load reads exactly as it did before this ticket. Switching it scopes
 **Dashboard, Coil Tracker, Dispatch, Orders, Sales and Reports** — all six follow ONE control
 (`InventoryApp` holds the `selectedPlant` state; the tabs never filter themselves). **Coil Inward,
-Slitting, Production and SKU Master are deliberately not scoped** — an operator registers and
-consumes coils against the pipeline's own plant fields regardless of what the header happens to be
-showing. The header's former hardcoded "Inventory Management — Hyderabad" now reads the selection —
+Slitting, Production and SKU Master are deliberately not scoped by the selector** — an operator
+registers and consumes coils against the pipeline's own plant fields regardless of what the header
+happens to be showing. (For a **plant user** there is no selector and the stages are scoped to their
+plant structurally — see #126 above.) The header's former hardcoded "Inventory Management — Hyderabad" now reads the selection —
 "All Plants", a plant's short name, or "Unattributed".
 
 **Reports is scoped, and a scoped workbook says so three times over** — an amber banner on the tab,
@@ -89,7 +132,7 @@ browser-bound (React, `import.meta.env`) and throw under Node; talk to PostgREST
 **Workspace (/.workspace)** - Temp files. Never commit. Delete anytime.
 
 ## Seed Data
-**No pipeline data is auto-seeded.** On first launch the pipeline tables (coils, baby_coils, productions, dispatches) load whatever is in Supabase — the re-enabled `baby_coils` rows reappear if still present. The only fallback is **`DEFAULT_SKUS`** (232-entry catalog in `src/data/skus.js`, SHS/RHS/CHS), used when the `skus` table returns no rows. "Reset Data" in the header clears all pipeline tables and restores `DEFAULT_SKUS`.
+**No pipeline data is auto-seeded.** On first launch the pipeline tables (coils, baby_coils, productions, dispatches) load whatever is in Supabase — the re-enabled `baby_coils` rows reappear if still present. The only fallback is **`DEFAULT_SKUS`** (232-entry catalog in `src/data/skus.js`, SHS/RHS/CHS), used when the `skus` table returns no rows. (An earlier "Reset Data" header button that cleared the pipeline tables **no longer exists** — this line described it long after it was removed. Nothing in the app clears the pipeline tables today.)
 
 ## Running the App
 ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,7 @@ would eventually show a tab the rule had never heard of.
 | Tab | Admin | Plant user |
 |---|---|---|
 | Dashboard, Coil Tracker, Dispatch, Sales | All plants + selector | Their plant only |
-| Coil Inward, Slitting, Production | All plants + selector | Their plant, pinned — and only if their plant `manufactures` |
+| Coil Inward, Slitting, Production | All plants + selector | Their plant, pinned — and only if their plant `manufactures`. Coil Inward additionally requires the plant to be on `COIL_INWARD_PLANT_IDS`, the separate rollout list an admin's picker already honours |
 | SKU Master | View and **edit** | View only |
 | Orders & Invoice | **Upload** and view | View, their plant |
 | Reports | **Yes** | Hidden |
@@ -47,7 +47,10 @@ from a stale file would overwrite everyone; **SKU Master** drives `weightPerTube
 plant's tonnage and cost; **Reports** builds the company-wide workbooks.
 
 How it is wired in `InventoryApp`:
-- `access.tabs` renders the tab bar; a hidden tab has no button and no route.
+- `access.tabs` renders the tab bar. A hidden tab has **no button**; the `{tab === '…' && <X/>}`
+  render lines are unchanged, so this is unreachability by navigation, not a route guard. That is
+  enough here — `tab` only ever comes from a rendered button — but it is not a claim to lean on if
+  deep-linking or a URL router is ever added.
 - `access.readOnly` is passed to `SKUMaster` and `Orders` as `readOnly`, which withholds the writing
   controls **from the DOM**, not merely disables them. The tables and exports stay.
 - `access.plantSelector` decides whether the `<select>` is rendered. When it is not, `selectedPlant`
@@ -56,7 +59,10 @@ How it is wired in `InventoryApp`:
 - `plantPinned` (the same distinction) also switches the **pipeline** stages onto the plant-scoped
   arrays. #121 deliberately left those reading the raw register for an admin, and that is unchanged;
   a plant user's stages read only their plant's rows, and Coil Inward registers against their plant
-  with nothing to pick.
+  with nothing to pick. Because `filterByPlant` matches the stored value exactly, a legacy row whose
+  plant is **blank** is `Unattributed` and so invisible to a plant user in those stages — deliberate
+  (a row that cannot say where it sits is not one plant's to claim), and it makes backfilling such
+  rows an admin's job, from the All Plants view where they still appear.
 
 **This is not a data boundary.** Every table keeps its permissive row-level policy and the app's
 public key still reaches every plant's rows. It hides another plant's screens from an operator who
@@ -132,7 +138,7 @@ browser-bound (React, `import.meta.env`) and throw under Node; talk to PostgREST
 **Workspace (/.workspace)** - Temp files. Never commit. Delete anytime.
 
 ## Seed Data
-**No pipeline data is auto-seeded.** On first launch the pipeline tables (coils, baby_coils, productions, dispatches) load whatever is in Supabase — the re-enabled `baby_coils` rows reappear if still present. The only fallback is **`DEFAULT_SKUS`** (232-entry catalog in `src/data/skus.js`, SHS/RHS/CHS), used when the `skus` table returns no rows. (An earlier "Reset Data" header button that cleared the pipeline tables **no longer exists** — this line described it long after it was removed. Nothing in the app clears the pipeline tables today.)
+**No pipeline data is auto-seeded.** On first launch the pipeline tables (coils, baby_coils, productions, dispatches) load whatever is in Supabase — the re-enabled `baby_coils` rows reappear if still present. The only fallback is **`DEFAULT_SKUS`** (232-entry catalog in `src/data/skus.js`, SHS/RHS/CHS), used when the `skus` table returns no rows. (This line used to go on to describe a **"Reset Data"** header button that cleared the pipeline tables. There is no such control in `src/App.jsx`, and no commit in this repository's history adds or removes one — so it either predates this history or was never built. Either way: nothing in the app clears the pipeline tables today.)
 
 ## Running the App
 ```bash

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -147,8 +147,9 @@ coil list — because those are two pieces of state that can drift apart.
 | **Default is unchanged behaviour** | `plant` defaults to `ALL_PLANTS`. `scripts/coil-realloc-dryrun.mjs` and every other `coilFifoAllocate` caller allocate across all coils exactly as before |
 
 See `docs/ALGORITHMS.md` for why the filter's *position* is the load-bearing part, and
-`docs/UI-PATTERNS.md` for the form rules. Phase 3 (#117) moves the plant from the header selector to
-the operator's login, at which point the All Plants gate disappears for a plant user.
+`docs/UI-PATTERNS.md` for the form rules. Phase 3 (#117, ticket #126) moved the plant from the header
+selector to the operator's login: a plant user's `operatingPlant` is their own plant, never
+`ALL_PLANTS`, so the All Plants gate never fires for them. An admin still drives it from the header.
 
 ## Plant selector (ticket #121)
 Every plant-carrying store above (`orders`, `coils`, `baby_coils`, `productions`, plus the per-entry
@@ -209,7 +210,9 @@ Mutations update React state optimistically, then sync to Supabase in the backgr
 ## localStorage (preferences only)
 - `jsw:dark` — Dark mode preference (boolean)
 - `jsw:seeded` — Legacy seed flag toggled by "Reset Data" (boolean)
-- `jsw:auth` — Login-gate flag `{loginId, at}` set after a successful sign-in; ~30-day expiry, cleared by Logout
+- `jsw:auth` — The session, `{loginId, plant, role, at}`, set after a successful sign-in; ~30-day
+  expiry, cleared by Logout. Was `{loginId, at}` before ticket #126 — a stored session with no
+  `role` is rejected and deleted, so every pre-#126 session prompts one fresh sign-in
 
 ## Authentication (login gate)
 A login ID + password gates the app (added July 2026). The credential lives in a
@@ -236,10 +239,26 @@ documented upgrade path). **To add or change a login, see `blueprints/manage-app
 | **Why additive** | Changing `verify_login` in place would break the deployed app the moment the SQL ran, before the new build shipped. Two functions means no window in which the live app cannot sign anyone in |
 | **Backfill** | Gated on the `role` column not existing yet, the same rule the pipeline plant columns follow. It runs once and stamps **every** pre-existing login `role = 'admin'` with `plant` left NULL — a description, not a promotion: before this ticket the app had no roles, so any credential that existed could already do everything. Demoting an extra legacy login is one `update`, in the blueprint. No password is touched — the existing admin keeps working, not recreated, nobody locked out. Re-running `supabase-setup.sql` is a no-op |
 | **Three logins** | `admin` (all plants), `hyderabad`, `npmd`. Lepakshi and Tapi get none — modelled for attribution only, credentials wait until someone there asks. Passwords are set by a **human** in the Supabase SQL editor; no password is in this repository |
-| **Nothing reads it yet** | This is the credential model only. No screen, tab or store is gated on plant or role here — that is the next ticket in phase 3 of #117 |
+| **What reads it** | Ticket **#126**: `accessFor(session)` in `calc.js` turns role + plant into visible tabs, read-only tabs and whether the plant selector is offered. See the section below and `docs/ARCHITECTURE.md` |
 
 **This is UI tidiness, NOT a security boundary.** Every table keeps its permissive `using (true)`
 policy and the app's public key still reaches **all** data, every plant's, exactly as before. A
 plant login keeps the wrong plant's screens out of an operator's way; it does **not** make a
 plant's data private, and nobody may describe it that way to a plant team. Real enforcement is
 Supabase Auth with per-plant policies — the documented upgrade path, deliberately out of scope.
+
+### The session, and what it grants (ticket #126)
+Two pure functions in `src/lib/calc.js`, kept separate because they answer different questions:
+
+| | |
+|---|---|
+| `parseStoredSession(saved, now)` | **Is this a session?** `{loginId, plant, role, at}` or `null`. Rejects a missing/unknown role, a blank plant, a bad or missing timestamp, and anything past the 30-day window. Every session stored before #126 carries no `role`, so all of them return `null` — that *is* the one-time re-authentication, and it needs no version stamp |
+| `accessFor(session)` | **What may it do?** `{tabs, readOnly, plantSelector, plant}`. Admin ⇒ every tab, nothing read-only, the selector, starting on `ALL_PLANTS`. Plant ⇒ their plant pinned, no selector, no Reports, no manufacturing tabs unless the plant `manufactures`, and SKU Master + Orders read-only |
+
+A credential can pass the first and fail the second, and the case is real: a `plant` role whose
+`plant` column is NULL arrives as **`ALL_PLANTS`** (that mapping is `verifyLoginDetails`'s, and
+correct — it is what an *admin's* NULL means). It is a well-formed session that `accessFor`
+refuses, because reading it as "every plant" would hand a plant login the whole company. So
+`App.jsx` requires **both**: a session that parses *and* grants at least one tab. Sign-in says the
+credential is not set up correctly and names where it is fixed, rather than opening an app with no
+tabs. `blueprints/manage-app-login.md` carries the `update`.

--- a/docs/UI-PATTERNS.md
+++ b/docs/UI-PATTERNS.md
@@ -29,11 +29,29 @@
 - Badges are **informational, never block save** (`canSave = skuCode && pieces`): green "Fully allocated", amber "Within tolerance", amber/red "Shortfall", red "No eligible baby coil". Status column shows `Allocated` / `Partial` / `Unallocated`.
 - Baby-coil-delete guard: a baby coil consumed by any production cannot be deleted (Slitting blocks it). `coilAllocations` store `{babyCoilId, hrCoilId, pieces, weight}` (baby + mother).
 
+## Read-only tabs (ticket #126)
+- **`readOnly` withholds the writing controls; it never hides the data.** `SKUMaster` and `Orders`
+  each take a `readOnly` prop. The catalog, the order book, every figure and the CSV exports all
+  stay — a plant user looks SKUs up constantly. What goes is the add form, `onEdit`/`onDelete`
+  (passing `undefined` drops DataTable's whole Actions column, the same move Dispatch makes above)
+  and the upload button.
+- **Withheld means unmounted, not disabled.** Including the things a button merely triggers: the
+  Orders upload's hidden `<input type="file">` is rendered inside the same `!readOnly` branch as its
+  button, because leaving it mounted keeps the whole write path one console line away from a user
+  the app is withholding it from.
+- **Say why, once, where the control was.** Each read-only tab carries a short note — the SKU
+  catalog is central because `weightPerTube` sets every plant's tonnage; one upload replaces every
+  plant's orders. A missing button with no explanation reads as a bug.
+
 ## Plant across the pipeline stages (ticket #120)
-- **Coil Inward is the only place plant is typed.** `<Field label="Plant">` holding a `<Select>` of
-  `coilInwardPlants()` — Hyderabad and NPMD (ticket #123; Lepakshi and Tapi never appear, they
-  don't manufacture) — with `emptyForm` pre-selecting `DEFAULT_COIL_PLANT` (still Hyderabad), so
-  the ordinary path is one click.
+- **Coil Inward is the only place plant is typed** — and since ticket #126, only for an **admin**.
+  `<Field label="Plant">` holding a `<Select>` of `coilInwardPlants()` — Hyderabad and NPMD (ticket
+  #123; Lepakshi and Tapi never appear, they don't manufacture) — with `emptyForm` pre-selecting
+  `DEFAULT_COIL_PLANT` (still Hyderabad), so the ordinary path is one click.
+- **A plant user types nothing: the field is pinned.** `CoilInward` takes `operatingPlant`, non-null
+  only for a plant user, and renders the same read-only `<Input>` the edit case uses. They are
+  standing in one plant, so where an arriving coil sits is not a question to put to them. It changes
+  only what is OFFERED — `emptyForm.plant` is that plant and the set-once rule below is untouched.
 - **On edit it becomes a read-only `<Input>` showing `plantLabel(form.plant)`, not a disabled
   `<Select>`.** A select must fall back to *some* option, and for a coil registered before #120 and
   never backfilled that fallback printed **Hyderabad** over a row storing blank, while the table
@@ -61,8 +79,16 @@
 - `InventoryApp` filters once, with `filterByPlant`/`filterDispatchesByPlant` (`calc.js`), and passes
   the scoped arrays down as ordinary props. **Dashboard, Coil Tracker, Dispatch, Orders, Sales and
   Reports** receive the scoped arrays; **Coil Inward, Slitting, Production and SKU Master** keep
-  receiving the raw, unfiltered store arrays — nothing in those four components changed for this
-  ticket, because they never see a filtered prop.
+  receiving the raw, unfiltered store arrays **for an admin** — nothing in those four components
+  changed for ticket #121, because they never saw a filtered prop.
+  - **Ticket #126 splits that by who is signed in.** `plantPinned` (a plant user — no selector, the
+    plant is their login) switches the three stages onto `pipelineCoils`/`BabyCoils`/`Productions`/
+    `Dispatches`, which are the scoped arrays. An admin's stages are unchanged. **Consequence worth
+    knowing:** `filterByPlant` matches the stored value exactly, so a legacy row with a **blank**
+    plant (registered before #120, never backfilled) is `Unattributed` and therefore invisible to a
+    plant user in those stages. That is deliberate — a row that does not say where it sits cannot be
+    shown to one plant as theirs — but it means **backfilling those rows is an admin's job**, done
+    from the All Plants view where they are still visible.
   - **Production is the one exception, added in #124.** It still receives the **raw** arrays, and it
     receives the selector's value as `operatingPlant` so it can scope them **itself**. It has to: the scope of
     a batch being edited is *that record's* plant, not the header's, so a filtered prop would hide the
@@ -93,7 +119,10 @@ rather than quietly returning a different answer.
 - **Dispatch withholds Delete.** `deleted` lives on the **record** — one whole invoice — while plant
   lives on its entries, so there is no per-entry delete. Scoped, the operator sees only some of an
   invoice's lines, so deleting would remove lines they cannot see. `onDelete` is passed `undefined`
-  (which drops DataTable's whole Actions column) and an amber note says to switch to All Plants.
+  (which drops DataTable's whole Actions column) and an amber note explains why. Since #126 that
+  note branches on `canWiden`: an admin is told to *switch to All Plants*, a plant user — who has no
+  selector — is told only that deleting is done from that view. **Copy that tells a user to operate
+  a control they do not have is a bug**; check any scope message against both roles.
 
 - **Reports stamps the scope onto the file itself.** A workbook is the one scoped output READ
   SOMEWHERE ELSE — mailed, broadcast, opened next week by someone who never saw the header. So a

--- a/e2e/pipeline.spec.js
+++ b/e2e/pipeline.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { signIn } from './signin'
 
 // E2E for the 5-stage flow: Coil Inward → Slitting → Production → Dispatch (Excel).
 //
@@ -16,6 +17,10 @@ const inputFor = (page, label) =>
   page.locator('label', { hasText: label }).locator('xpath=following-sibling::input[1]')
 const selectFor = (page, label) =>
   page.locator('label', { hasText: label }).locator('xpath=following-sibling::select[1]')
+// A SearchSelect renders an <input> inside a wrapping <div>, not a <select> — Production's SKU
+// picker is one (232 SKUs is not a dropdown you scroll).
+const searchInputFor = (page, label) =>
+  page.locator('label', { hasText: label }).locator('xpath=following-sibling::div[1]//input')
 
 const gotoTab = (page, name) => page.getByRole('button', { name, exact: true }).click()
 
@@ -26,16 +31,34 @@ const gotoTab = (page, name) => page.getByRole('button', { name, exact: true }).
 // in the header, so the aria-label is what a screen reader and this test both read.
 const selectPlant = (page, name) => page.getByLabel('Plant', { exact: true }).selectOption({ label: name })
 
-// SKU option index 1 = first published SKU (SKU-001, a 25x25x2.50 → 2.5mm tube), which is
-// thickness-compatible with the 2.5mm coils registered below. Index 0 is the placeholder.
-const SKU_INDEX = 1
+// SKU-001, a 25x25x2.50 → 2.5mm tube, thickness-compatible with the 2.5mm coils registered below.
+// Searched by the size in its description, which is unique across the whole 232-SKU catalog — an
+// option's label IS its description, so this both filters the list and names the option to click.
+const SKU_SIZE = '25x25x2.50x6000'
 
-async function addCoil(page, { thickness = '2.5', actualWeight, costPrice, width = '150' }) {
+// Drive a SearchSelect: focus, type a query to filter, then click the matching option. `name` is a
+// substring match, so a query that identifies the option is enough — the label carries more.
+async function pickSearch(page, label, query) {
+  const input = searchInputFor(page, label)
+  await input.click()
+  await input.fill(query)
+  await page.getByRole('button', { name: query }).first().click()
+}
+
+const pickSku = (page, size = SKU_SIZE) => pickSearch(page, 'SKU', size)
+
+// Take the FIFO suggestion. It is never applied on its own — a non-negotiable of this app: the
+// suggestion is GUIDANCE, and what a production saves is the operator's own allocation. So every
+// flow that means to consume coils has to click this, exactly as an operator does.
+const useSuggestion = (page) => page.getByRole('button', { name: 'Use suggestion' }).click()
+
+// Coil Inward carries no cost field — a coil's cost reaches the pipeline through the daily Excel,
+// not through this form — so the only figures a registration needs are the physical ones.
+async function addCoil(page, { thickness = '2.5', actualWeight, width = '150' }) {
   await page.getByRole('button', { name: '+ Add Coil' }).click()
   await inputFor(page, 'Thickness (mm)').fill(thickness)
   await inputFor(page, 'Width (mm)').fill(width)
   await inputFor(page, 'Actual Weight (T)').fill(actualWeight)
-  await inputFor(page, 'Cost Price (₹)').fill(costPrice)
   await page.getByRole('button', { name: 'Save Coil' }).click()
 }
 
@@ -43,18 +66,19 @@ async function addCoil(page, { thickness = '2.5', actualWeight, costPrice, width
 async function slit(page, coilId, width = '100') {
   await gotoTab(page, '2. Slitting')
   await page.getByRole('button', { name: '+ Add Baby Coil' }).click()
-  await selectFor(page, 'HR Coil ID').selectOption(coilId)
+  await pickSearch(page, 'HR Coil ID', coilId)
   await inputFor(page, 'Width (mm)').fill(width)
-  await page.getByRole('button', { name: 'Save Baby Coil' }).click()
+  // The button counts what it will save — "Save 1 Baby Coil" for a single row.
+  await page.getByRole('button', { name: /Save 1 Baby Coil/ }).click()
 }
 
 test.describe('5-stage pipeline', () => {
   test('Coil Inward → Slitting → Production happy path (baby-coil FIFO)', async ({ page }) => {
-    await page.goto('/')
+    await signIn(page, 'admin')
 
     // ── Stage 1: register a mother coil (2.5mm, 10T) ──
     await gotoTab(page, '1. Coil Inward')
-    await addCoil(page, { actualWeight: '10', costPrice: '500000' })
+    await addCoil(page, { actualWeight: '10' })
     const coilId = await page.locator('table tbody tr').first().locator('td').first().innerText()
     expect(coilId).toMatch(/^HYD-\d{4}-\d{2}$/)
 
@@ -66,8 +90,9 @@ test.describe('5-stage pipeline', () => {
     await selectPlant(page, 'Hyderabad')
     await gotoTab(page, '3. Production')
     await page.getByRole('button', { name: '+ Record Production' }).click()
-    await selectFor(page, 'SKU').selectOption({ index: SKU_INDEX })
+    await pickSku(page)
     await inputFor(page, 'No. of Pieces').fill('10')
+    await useSuggestion(page)
     await expect(page.getByText(/Fully allocated/)).toBeVisible()  // FIFO matched the baby coil
     await page.getByRole('button', { name: 'Save Production' }).click()
     // The Assigned Coils cell traces back to the baby coil.
@@ -75,10 +100,10 @@ test.describe('5-stage pipeline', () => {
   })
 
   test('Production splits across baby coils FIFO (oldest first, spill to next)', async ({ page }) => {
-    await page.goto('/')
+    await signIn(page, 'admin')
     await gotoTab(page, '1. Coil Inward')
-    await addCoil(page, { actualWeight: '0.05', costPrice: '5000' })  // -01: small, filled first
-    await addCoil(page, { actualWeight: '10', costPrice: '500000' })  // -02: absorbs the spill
+    await addCoil(page, { actualWeight: '0.05' })  // -01: small, filled first
+    await addCoil(page, { actualWeight: '10' })  // -02: absorbs the spill
     const rows = page.locator('table tbody tr')
     const coil1 = await rows.nth(0).locator('td').first().innerText()
     const coil2 = await rows.nth(1).locator('td').first().innerText()
@@ -90,51 +115,56 @@ test.describe('5-stage pipeline', () => {
     await selectPlant(page, 'Hyderabad')
     await gotoTab(page, '3. Production')
     await page.getByRole('button', { name: '+ Record Production' }).click()
-    await selectFor(page, 'SKU').selectOption({ index: SKU_INDEX })
+    await pickSku(page)
     await inputFor(page, 'No. of Pieces').fill('10') // ~0.106T > baby -01's 0.05T → spill to -02
+    await useSuggestion(page)
     // Two source baby coils means the batch split across coils.
     await expect(inputFor(page, '# Source Coils')).toHaveValue('2')
   })
 
   test('Production shortfall is allowed (saved as Partial) but flagged', async ({ page }) => {
-    await page.goto('/')
+    await signIn(page, 'admin')
     await gotoTab(page, '1. Coil Inward')
-    await addCoil(page, { actualWeight: '0.05', costPrice: '5000' }) // far too little for the batch
+    await addCoil(page, { actualWeight: '0.05' }) // far too little for the batch
     const coilId = await page.locator('table tbody tr').first().locator('td').first().innerText()
     await slit(page, coilId, '100')
 
     await selectPlant(page, 'Hyderabad')
     await gotoTab(page, '3. Production')
     await page.getByRole('button', { name: '+ Record Production' }).click()
-    await selectFor(page, 'SKU').selectOption({ index: SKU_INDEX })
+    await pickSku(page)
     await inputFor(page, 'No. of Pieces').fill('100') // ~1.06T ≫ 0.05T capacity
+    await useSuggestion(page)
     await expect(page.getByText(/Shortfall/)).toBeVisible()
     // Allow + warn policy: save stays enabled.
     await expect(page.getByRole('button', { name: 'Save Production' })).toBeEnabled()
   })
 
   test('no eligible baby coil until slitting is done', async ({ page }) => {
-    await page.goto('/')
+    await signIn(page, 'admin')
     await gotoTab(page, '1. Coil Inward')
-    await addCoil(page, { actualWeight: '10', costPrice: '500000' })
+    await addCoil(page, { actualWeight: '10' })
 
     // Skip slitting → Production finds no eligible baby coil.
     await selectPlant(page, 'Hyderabad')
     await gotoTab(page, '3. Production')
     await page.getByRole('button', { name: '+ Record Production' }).click()
-    await selectFor(page, 'SKU').selectOption({ index: SKU_INDEX })
+    await pickSku(page)
     await inputFor(page, 'No. of Pieces').fill('10')
-    await expect(page.getByText(/No eligible baby coil/)).toBeVisible()
+    await expect(page.getByText(/No eligible coil to suggest/)).toBeVisible()
   })
 
   test('pipeline tabs reflect the new flow (Slitting in, Bundle Formation out)', async ({ page }) => {
-    await page.goto('/')
+    await signIn(page, 'admin')
     await expect(page.getByRole('button', { name: '2. Slitting', exact: true })).toBeVisible()
     await expect(page.getByRole('button', { name: '3. Production', exact: true })).toBeVisible()
     await expect(page.getByRole('button', { name: '4. Dispatch', exact: true })).toBeVisible()
     await expect(page.getByRole('button', { name: /Bundle Formation/ })).toHaveCount(0)
-    // Dispatch is upload-driven now.
+    // Dispatch is upload-driven now — and the upload lives on the Orders tab (one daily workbook
+    // whose Invoice sheet rebuilds these records), so this view offers no entry and no upload of
+    // its own. Asserting the absence is the point: hand-entering a dispatch is a non-negotiable.
     await gotoTab(page, '4. Dispatch')
-    await expect(page.getByRole('button', { name: 'Upload Dispatch Excel' })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Add Dispatch|Upload Dispatch/ })).toHaveCount(0)
+    await expect(page.getByText('This view is read-only')).toBeVisible()
   })
 })

--- a/e2e/roles.spec.js
+++ b/e2e/roles.spec.js
@@ -54,6 +54,9 @@ for (const [login, plantName] of [['hyderabad', 'Hyderabad'], ['npmd', 'NPMD']])
       await signIn(page, login)
       await expect(page.getByLabel('Plant', { exact: true })).toHaveCount(0)
       await expect(page.getByText(`Inventory Management — ${plantName}`)).toBeVisible()
+      // The header is the ONLY place a plant user's plant is stated, so it must never read as the
+      // whole company.
+      await expect(page.getByText('Inventory Management — All Plants')).toHaveCount(0)
     })
 
     test('sees the four viewing tabs and the three stages, and no Reports', async ({ page }) => {
@@ -134,6 +137,19 @@ test.describe('the session', () => {
     await expect(tab(page, 'Dashboard')).toHaveCount(0)
   })
 
+  test('never tells a plant user with a broken plant id that they see All Plants', async ({ page }) => {
+    // A credential naming a plant no master row matches is a row to fix, not a case to widen. The
+    // header must not answer "which plant's numbers are these?" with the whole company.
+    await stubSignIn(page, [{ login_id: 'typo', plant: 'hyderbad', role: 'plant' }])   // sic
+    await page.goto('/')
+    await page.getByLabel('Login ID').fill('typo')
+    await page.getByLabel('Password').fill('correct-horse')
+    await page.getByRole('button', { name: 'Sign in' }).click()
+    await expect(tab(page, 'Dashboard')).toBeVisible()
+    await expect(page.getByText('Inventory Management — All Plants')).toHaveCount(0)
+    await expect(page.getByText('Inventory Management — hyderbad')).toBeVisible()
+  })
+
   test('tells a wrong password apart from a dead connection', async ({ page }) => {
     await stubSignIn(page, [])            // no rows = wrong login id or password
     await page.goto('/')
@@ -149,7 +165,10 @@ test.describe('what the screens say about other plants', () => {
   // UI tidiness, NOT confidentiality. Every table keeps its permissive row-level policy and the
   // public key still reaches every plant's rows. So no screen may tell a plant team their data is
   // private, hidden or secure — it would be a claim the system does not back.
-  const FORBIDDEN = /\b(private|confidential|secure[dl]?|restricted|protected|no access|not authori[sz]ed|permission denied)\b/i
+  // `hidden` is named in the acceptance criterion, so it is checked — even though it is the one
+  // word here with an innocent everyday use. If a screen ever legitimately needs it ("show hidden
+  // columns"), narrow this to the claim rather than dropping the word.
+  const FORBIDDEN = /\b(private|confidential|secure[dl]?|restricted|protected|hidden|no access|not authori[sz]ed|permission denied)\b/i
 
   for (const login of Object.keys(LOGINS)) {
     test(`says nothing about privacy or security to ${login}`, async ({ page }) => {

--- a/e2e/roles.spec.js
+++ b/e2e/roles.spec.js
@@ -1,0 +1,165 @@
+import { test, expect } from '@playwright/test'
+import { signIn, stubSignIn, LOGINS } from './signin'
+
+// E2E for ticket #126 — role and plant decide what a user sees.
+//
+// The rules themselves are a pure function with its own unit tests (`accessFor` in src/lib/calc.js);
+// what only a browser can answer is whether the app is actually WIRED to them — that the tab bar
+// renders what the rule returns, that the controls a plant user must not have are absent from the
+// DOM rather than merely disabled, and that a session stored before roles existed asks for a fresh
+// sign-in instead of opening the app.
+//
+// Sign-in goes through the real form; only the one database call is stubbed (see ./signin.js).
+
+const tab = (page, name) => page.getByRole('button', { name, exact: true })
+const ALL_TABS = ['Dashboard', 'Coil Tracker', '1. Coil Inward', '2. Slitting', '3. Production',
+  '4. Dispatch', 'SKU Master', 'Orders & Invoice', 'Sales', 'Reports']
+const MANUFACTURING_TABS = ['1. Coil Inward', '2. Slitting', '3. Production']
+
+test.describe('admin', () => {
+  test('sees every tab, with the plant selector', async ({ page }) => {
+    await signIn(page, 'admin')
+    for (const name of ALL_TABS) await expect(tab(page, name)).toBeVisible()
+    await expect(page.getByLabel('Plant', { exact: true })).toBeVisible()
+    // Starts on All Plants, exactly as #121 left it — deploy day must change no figure on screen.
+    await expect(page.getByLabel('Plant', { exact: true })).toHaveValue('__all__')
+    await expect(page.getByText('Inventory Management — All Plants')).toBeVisible()
+  })
+
+  test('can edit the SKU master and upload the sales workbook', async ({ page }) => {
+    await signIn(page, 'admin')
+    await tab(page, 'SKU Master').click()
+    await expect(page.getByRole('button', { name: '+ Add SKU' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Edit' }).first()).toBeVisible()
+
+    await tab(page, 'Orders & Invoice').click()
+    await expect(page.getByRole('button', { name: 'Upload Sales Excel' })).toBeVisible()
+  })
+
+  test('can still move the selector onto one plant', async ({ page }) => {
+    await signIn(page, 'admin')
+    await page.getByLabel('Plant', { exact: true }).selectOption({ label: 'NPMD' })
+    await expect(page.getByText('Inventory Management — NPMD')).toBeVisible()
+    // A view, not an identity: the stages stay, unlike for a plant user at a non-manufacturing plant.
+    for (const name of MANUFACTURING_TABS) await expect(tab(page, name)).toBeVisible()
+  })
+})
+
+// Both plant logins manufacture, so both get the shop-floor stages. They are run through the same
+// table rather than one spec each: the rule is "your plant", and a rule stated once for Hyderabad
+// would not catch NPMD being wired to Hyderabad's data.
+for (const [login, plantName] of [['hyderabad', 'Hyderabad'], ['npmd', 'NPMD']]) {
+  test.describe(`plant user — ${login}`, () => {
+    test('opens on their own plant with no selector to get wrong', async ({ page }) => {
+      await signIn(page, login)
+      await expect(page.getByLabel('Plant', { exact: true })).toHaveCount(0)
+      await expect(page.getByText(`Inventory Management — ${plantName}`)).toBeVisible()
+    })
+
+    test('sees the four viewing tabs and the three stages, and no Reports', async ({ page }) => {
+      await signIn(page, login)
+      for (const name of ['Dashboard', 'Coil Tracker', '4. Dispatch', 'Sales', ...MANUFACTURING_TABS]) {
+        await expect(tab(page, name)).toBeVisible()
+      }
+      await expect(tab(page, 'Reports')).toHaveCount(0)
+    })
+
+    test('reads the SKU master but cannot change it', async ({ page }) => {
+      await signIn(page, login)
+      await tab(page, 'SKU Master').click()
+      // The catalog itself is fully there — a plant user looks SKUs up all day.
+      await expect(page.getByText(/SKU Catalog \(\d+ items\)/)).toBeVisible()
+      // Every control that writes is absent from the DOM, not merely disabled.
+      await expect(page.getByRole('button', { name: '+ Add SKU' })).toHaveCount(0)
+      await expect(page.getByRole('button', { name: 'Edit' })).toHaveCount(0)
+      await expect(page.getByRole('button', { name: 'Del' })).toHaveCount(0)
+    })
+
+    test('reads the order book but cannot upload it', async ({ page }) => {
+      await signIn(page, login)
+      await tab(page, 'Orders & Invoice').click()
+      await expect(page.getByRole('button', { name: 'Upload Sales Excel' })).toHaveCount(0)
+      // The CSV export stays — reading your own orders out is not the risk being managed.
+      await expect(page.getByRole('button', { name: /Download CSV/ })).toBeVisible()
+    })
+
+    test('registers a coil against their own plant, with nothing to pick', async ({ page }) => {
+      await signIn(page, login)
+      await tab(page, '1. Coil Inward').click()
+      await page.getByRole('button', { name: '+ Add Coil' }).click()
+      const plantField = page.locator('label', { hasText: 'Plant' }).locator('xpath=following-sibling::input[1]')
+      await expect(plantField).toHaveValue(plantName)
+      await expect(plantField).toBeDisabled()
+      // The coil id it will mint carries that plant's prefix, not the default Hyderabad one.
+      await expect(page.locator('label', { hasText: 'HR Coil ID' }).locator('xpath=following-sibling::input[1]'))
+        .toHaveValue(new RegExp(`^${login === 'npmd' ? 'NPM' : 'HYD'}-`))
+    })
+  })
+}
+
+test.describe('the session', () => {
+  test('stored before roles existed is cleared, prompting one fresh sign-in', async ({ page }) => {
+    await signIn(page, 'admin')
+    // Overwrite with the exact pre-#126 shape: a login id and a timestamp, and no role.
+    await page.evaluate(() => localStorage.setItem('jsw:auth',
+      JSON.stringify({ loginId: 'admin', at: Date.now() })))
+    await page.reload()
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
+    // …and it is cleared, so the next visit is not asked again for the same stale session.
+    expect(await page.evaluate(() => localStorage.getItem('jsw:auth'))).toBe(null)
+  })
+
+  test('is remembered across a reload, so signing in is a once-a-month event', async ({ page }) => {
+    await signIn(page, 'npmd')
+    await page.reload()
+    await expect(page.getByText('Inventory Management — NPMD')).toBeVisible()
+    await expect(tab(page, 'Reports')).toHaveCount(0)
+  })
+
+  test('is dropped by Logout, returning to the sign-in screen', async ({ page }) => {
+    await signIn(page, 'hyderabad')
+    await page.getByRole('button', { name: 'Logout' }).click()
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
+  })
+
+  test('does not open the app when the credential row cannot say what the user may do', async ({ page }) => {
+    // A `plant` role whose plant column is NULL arrives as "all plants" — read as such it would
+    // hand a plant login the whole company, so the app refuses it and says where it is fixed.
+    await stubSignIn(page, [{ login_id: 'broken', plant: null, role: 'plant' }])
+    await page.goto('/')
+    await page.getByLabel('Login ID').fill('broken')
+    await page.getByLabel('Password').fill('correct-horse')
+    await page.getByRole('button', { name: 'Sign in' }).click()
+    await expect(page.getByText(/not set up correctly/)).toBeVisible()
+    await expect(tab(page, 'Dashboard')).toHaveCount(0)
+  })
+
+  test('tells a wrong password apart from a dead connection', async ({ page }) => {
+    await stubSignIn(page, [])            // no rows = wrong login id or password
+    await page.goto('/')
+    await page.getByLabel('Login ID').fill('admin')
+    await page.getByLabel('Password').fill('wrong')
+    await page.getByRole('button', { name: 'Sign in' }).click()
+    await expect(page.getByText('Invalid login ID or password.')).toBeVisible()
+  })
+})
+
+test.describe('what the screens say about other plants', () => {
+  // An acceptance criterion of #126, and a promise made in blueprints/manage-app-login.md: this is
+  // UI tidiness, NOT confidentiality. Every table keeps its permissive row-level policy and the
+  // public key still reaches every plant's rows. So no screen may tell a plant team their data is
+  // private, hidden or secure — it would be a claim the system does not back.
+  const FORBIDDEN = /\b(private|confidential|secure[dl]?|restricted|protected|no access|not authori[sz]ed|permission denied)\b/i
+
+  for (const login of Object.keys(LOGINS)) {
+    test(`says nothing about privacy or security to ${login}`, async ({ page }) => {
+      await signIn(page, login)
+      const tabs = await page.locator('nav button').allInnerTexts()
+      for (const name of tabs) {
+        await tab(page, name.trim()).click()
+        const body = await page.locator('body').innerText()
+        expect(body, `on the ${name} tab`).not.toMatch(FORBIDDEN)
+      }
+    })
+  }
+})

--- a/e2e/signin.js
+++ b/e2e/signin.js
@@ -62,8 +62,7 @@ export async function stubSignIn(page, rows) {
 export async function signIn(page, who = 'admin', { password = 'correct-horse' } = {}) {
   const row = LOGINS[who]
   if (!row) throw new Error(`No such test login: ${who}`)
-  await stubTables(page)
-  await stubSignIn(page, [row])
+  await stubSignIn(page, [row])   // installs the table stub too
   await page.goto('/')
   await page.getByLabel('Login ID').fill(row.login_id)
   await page.getByLabel('Password').fill(password)

--- a/e2e/signin.js
+++ b/e2e/signin.js
@@ -1,0 +1,73 @@
+import { expect } from '@playwright/test'
+
+// ── Signing in, for E2E (ticket #126) ──────────────────────────────────────────────────────────
+// Every spec goes through the login gate, because the app does. Before this ticket the specs
+// called `page.goto('/')` and drove the tabs directly — which stopped working the day the gate
+// shipped, silently, since the specs cannot run in a sandbox with no Chromium binary. They do not
+// bypass it now: they sign in through the real form, so the whole chain the ticket is about
+// (form → verify_login_details → the stored session → which tabs render) is what runs.
+//
+// What IS faked is the ONE database call, and only that. `.env.test` points at a Supabase host
+// that does not exist, so no password on earth would verify — but the password check is not what
+// these tests are for; it is a bcrypt function tested against a real Postgres (see TESTING.md),
+// and `verifyLoginDetails` itself is covered in src/lib/db.test.js. Here we say "this user signed
+// in correctly" and test what the app does with the answer.
+//
+// A wrong password returns NO ROWS from `verify_login_details` (never a row saying "false"), so
+// the fake returns rows the same way: `[row]` or `[]`. NULL plant = all plants, exactly as the
+// credential table stores it for `admin`.
+export const LOGINS = {
+  admin:     { login_id: 'admin',     plant: null,        role: 'admin' },
+  hyderabad: { login_id: 'hyderabad', plant: 'hyderabad', role: 'plant' },
+  npmd:      { login_id: 'npmd',      plant: 'npmd',      role: 'plant' },
+}
+
+const RPC = '**/rest/v1/rpc/verify_login_details'
+const REST = '**/rest/v1/**'
+
+// ── The rest of Supabase ───────────────────────────────────────────────────────────────────────
+// `.env.test` points at a host that does not resolve, so every table read used to fail — slowly,
+// through the sandbox's proxy, one stalled request per table, and the app sat on "Loading inventory
+// data..." for longer than any sensible test timeout. Answering them here with an EMPTY table is
+// the same starting state the specs always assumed (no persistence, drive the optimistic in-session
+// state) and it is instant and deterministic instead of depending on how a network fails.
+//
+// An empty read is not "no data" to the app: `useSupabaseStore` keeps its fallback when a table
+// comes back empty, which is what still puts the 232-SKU DEFAULT_SKUS catalog behind the SKU
+// picker — the specs pick SKU-001 out of it by index.
+//
+// Writes are answered as accepted, so nothing here re-reads the table mid-flow. That matters more
+// than it looks: a REJECTED write makes the store re-pull to stop showing rows Postgres refused,
+// and a re-pull against an empty table would throw away the very coil the test just registered.
+async function stubTables(page) {
+  await page.route(REST, route => {
+    if (route.request().url().includes('/rpc/')) return route.fallback()
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  })
+}
+
+// Stand in for the sign-in RPC. `rows` decides the answer: a credential row for a correct
+// sign-in, `[]` for a wrong password.
+export async function stubSignIn(page, rows) {
+  await stubTables(page)
+  await page.route(RPC, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(rows),
+  }))
+}
+
+// Open the app and sign in as one of the three logins. Returns once the tab bar is on screen, so
+// a caller can go straight to clicking tabs exactly as the specs did before the gate existed.
+export async function signIn(page, who = 'admin', { password = 'correct-horse' } = {}) {
+  const row = LOGINS[who]
+  if (!row) throw new Error(`No such test login: ${who}`)
+  await stubTables(page)
+  await stubSignIn(page, [row])
+  await page.goto('/')
+  await page.getByLabel('Login ID').fill(row.login_id)
+  await page.getByLabel('Password').fill(password)
+  await page.getByRole('button', { name: 'Sign in' }).click()
+  // Dashboard is the landing tab for every role, so it is the one signal that works for all three.
+  await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible()
+}

--- a/e2e/slitting-multi.spec.js
+++ b/e2e/slitting-multi.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { signIn } from './signin'
 
 // E2E for Stage 2 Slitting: multi-row baby-coil entry (one mother → many baby coils in a
 // SINGLE save) and the dedicated Baby Coil ID table search.
@@ -38,11 +39,11 @@ const rowWidths = (page) =>
 
 test.describe('Slitting — multi-row entry + search', () => {
   test('one mother → three baby coils saved together', async ({ page }) => {
-    await page.goto('/')
+    await signIn(page, 'admin')
 
     // Register a mother coil (12T, 150mm wide).
     await gotoTab(page, '1. Coil Inward')
-    await addCoil(page, { actualWeight: '12', costPrice: '600000', width: '150' })
+    await addCoil(page, { actualWeight: '12', width: '150' })
     const coilId = await page.locator('table tbody tr').first().locator('td').first().innerText()
     expect(coilId).toMatch(/^HYD-\d{4}-\d{2}$/)
 
@@ -74,9 +75,9 @@ test.describe('Slitting — multi-row entry + search', () => {
   })
 
   test('dedicated Baby Coil ID search narrows the table', async ({ page }) => {
-    await page.goto('/')
+    await signIn(page, 'admin')
     await gotoTab(page, '1. Coil Inward')
-    await addCoil(page, { actualWeight: '12', costPrice: '600000', width: '150' })
+    await addCoil(page, { actualWeight: '12', width: '150' })
     const coilId = await page.locator('table tbody tr').first().locator('td').first().innerText()
 
     await gotoTab(page, '2. Slitting')

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,9 +4,11 @@ import { defineConfig, devices } from '@playwright/test'
 // dev server in `test` mode (loads .env.test → dummy Supabase creds so the app
 // renders). Tests drive optimistic in-session state; they must not reload mid-flow.
 //
-// NOTE: requires a Chromium binary (`npx playwright install chromium`). In network-
-// restricted environments where cdn.playwright.dev is not allow-listed, the download
-// fails and these tests cannot run — see TESTING.md.
+// NOTE: requires a Chromium binary (`npx playwright install chromium`). Where that
+// download is blocked but a browser is already provisioned on the machine, point
+// PW_CHROMIUM_PATH at it instead of downloading — see TESTING.md.
+const chromiumPath = process.env.PW_CHROMIUM_PATH
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
@@ -20,7 +22,16 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Only set when PW_CHROMIUM_PATH is given; otherwise Playwright resolves its own
+        // downloaded build exactly as before, so a normal `npx playwright install` run is
+        // unaffected by this escape hatch.
+        ...(chromiumPath ? { launchOptions: { executablePath: chromiumPath } } : {}),
+      },
+    },
   ],
   webServer: {
     command: 'npm run dev -- --mode test --port 3000',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import {
   BarChart, Bar, Cell,
   XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts'
-import { useSupabaseStore, verifyLogin } from './lib/db'
+import { useSupabaseStore, verifyLoginDetails } from './lib/db'
 import {
   fmtT, fmtT3, genHRCoilId, nextCoilNumber, tolerance, periodRange, inDateRange,
   weightPerPieceFromSku, resolveProductionWeights, buildReconciliationRows, coilInventoryRow,
@@ -15,6 +15,7 @@ import {
   UNATTRIBUTED_PLANT, plantLabel, dispatchPlantLabel, plantForErpRow, erpRowPicker,
   coilInwardPlants, DEFAULT_COIL_PLANT, babyCoilPlant, productionPlant, crossPlantAllocationRows,
   ALL_PLANTS, plantFilterOptions, filterByPlant, filterDispatchesByPlant, withDispatchEntries,
+  APP_TABS, accessFor, parseStoredSession,
 } from './lib/calc'
 import { loadChunk } from './lib/chunk'
 import DEFAULT_SKUS from './data/skus'
@@ -447,8 +448,13 @@ function DataTable({ columns, data, actions, onEdit, onDelete, onRowClick, highl
 // ═══════════════════════════════════════════════════════════════
 // STAGE 1: COIL INWARD
 // ═══════════════════════════════════════════════════════════════
-function CoilInward({ coils, setCoils, dispatches, productions, babyCoils }) {
-  const emptyForm = { dateOfInward: today(), plant: DEFAULT_COIL_PLANT, hrCoilNo: '', inputCoilNumber: '', coilGrade: '', heatNumber: '', thickness: '', width: '', length: '', invoiceWeight: '', actualWeight: '', poNumber: '' }
+// `operatingPlant` (ticket #126) pins the plant a NEW coil is registered against. Non-null only for
+// a plant user, whose plant comes from their login: they are standing in one plant, so the plant of
+// a coil arriving there is not a question to put to them. An admin passes null and keeps the picker.
+// It changes only what is OFFERED — the stored value and the "set once at inward" rule below are
+// untouched, and an edit still shows the plant already recorded.
+function CoilInward({ coils, setCoils, dispatches, productions, babyCoils, operatingPlant = null }) {
+  const emptyForm = { dateOfInward: today(), plant: operatingPlant || DEFAULT_COIL_PLANT, hrCoilNo: '', inputCoilNumber: '', coilGrade: '', heatNumber: '', thickness: '', width: '', length: '', invoiceWeight: '', actualWeight: '', poNumber: '' }
   const [form, setForm] = useState(emptyForm)
   const [editId, setEditId] = useState(null)
   const [showForm, setShowForm] = useState(false)
@@ -546,9 +552,10 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils }) {
                 select would have to fall back to some option, and for a coil registered before
                 ticket #120 and never backfilled that fallback would show Hyderabad over a row
                 that stores blank. The label reads what is actually there: Unattributed. */}
-            <Field label="Plant" auto={!!editId} helper={editId ? 'Set at inward — not editable' : 'Where this coil physically sits'}>
-              {editId
-                ? <Input value={plantLabel(form.plant)} disabled />
+            <Field label="Plant" auto={!!editId || !!operatingPlant}
+              helper={editId ? 'Set at inward — not editable' : operatingPlant ? 'Your plant' : 'Where this coil physically sits'}>
+              {editId || operatingPlant
+                ? <Input value={plantLabel(editId ? form.plant : operatingPlant)} disabled />
                 : <Select value={form.plant} onChange={v => f('plant', v)}
                     options={coilInwardPlants().map(p => ({ value: p.id, label: p.name }))} placeholder="Select plant..." />}
             </Field>
@@ -1516,7 +1523,10 @@ function buildDispatchRecords(rows, { skus, productions, existing = [] }) {
 
 // ── Stage 4 Dispatch — now a records + reconciliation VIEW. Dispatch data arrives via the daily
 // "Upload Sales Excel" (Orders tab), which feeds the Invoice sheet through buildDispatchRecords.
-function Dispatch({ dispatches, setDispatches, coils, skus, plantScoped = false }) {
+// `canWiden` (ticket #126) says whether the plant scope is one the user can drop. An admin moved
+// the header selector and can move it back; a plant user's scope is their login, and telling them
+// to "switch to All Plants" would name a control they do not have.
+function Dispatch({ dispatches, setDispatches, coils, skus, plantScoped = false, canWiden = true }) {
   const skuDesc = useCallback((code) => skus.find(s => s.skuCode === code)?.description || code, [skus])
 
   // Soft-deletes the WHOLE invoice record, by id, in the raw store — `dispatches` here may be a
@@ -1601,9 +1611,12 @@ function Dispatch({ dispatches, setDispatches, coils, skus, plantScoped = false 
           offered only when every line of every record is on screen. */}
       {plantScoped && (
         <p className="text-xs text-amber-600 dark:text-amber-400">
-          Filtered to one plant — <strong>Delete is unavailable</strong>. A dispatch record is one
-          whole invoice and can only be deleted entire, which would also remove lines belonging to
-          other plants that are hidden by this filter. Switch to <strong>All Plants</strong> to delete.
+          Showing one plant — <strong>Delete is unavailable</strong>. A dispatch record is one whole
+          invoice and can only be deleted entire, so deleting one here would also remove lines
+          belonging to other plants.{' '}
+          {canWiden
+            ? <>Switch to <strong>All Plants</strong> to delete.</>
+            : <>Deleting an invoice is done from the <strong>All Plants</strong> view.</>}
         </p>
       )}
 
@@ -1625,7 +1638,12 @@ function Dispatch({ dispatches, setDispatches, coils, skus, plantScoped = false 
 // ═══════════════════════════════════════════════════════════════
 // SKU MASTER
 // ═══════════════════════════════════════════════════════════════
-function SKUMaster({ skus, setSkus, productions }) {
+// `readOnly` (ticket #126) withholds every control that WRITES — the add form, Edit and Del. The
+// catalog itself still renders in full: a plant user needs to look up a SKU's weight and price
+// constantly, and it is one company-wide catalog, so there is nothing here to scope, only to lock.
+// The reason it is admin-only is weightPerTube: it drives every plant's tonnage and cost, so two
+// people editing it is two people changing every plant's numbers.
+function SKUMaster({ skus, setSkus, productions, readOnly = false }) {
   const emptySku = { productType: 'SHS', skuCode: '', description: '', height: '', breadth: '', thickness: '', length: 6000, nominalBore: '', outsideDiameter: '', hsnCode: '72080000', status: 'published', weightPerTube: '', baseConversion: 2900, thicknessExtra: 0, ladderPrice: 2900, totalConversion: '' }
   const [form, setForm] = useState(emptySku)
   const [editId, setEditId] = useState(null)
@@ -1708,10 +1726,17 @@ function SKUMaster({ skus, setSkus, productions }) {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h2 className="text-xl font-semibold text-slate-900 dark:text-white">SKU Master</h2>
-        <Btn onClick={() => { setForm(emptySku); setEditId(null); setShowForm(!showForm) }}>{showForm ? 'Cancel' : '+ Add SKU'}</Btn>
+        {!readOnly && <Btn onClick={() => { setForm(emptySku); setEditId(null); setShowForm(!showForm) }}>{showForm ? 'Cancel' : '+ Add SKU'}</Btn>}
       </div>
 
-      {showForm && (
+      {readOnly && (
+        <p className="text-xs text-slate-400">
+          The SKU catalog is maintained centrally — weight per tube sets the tonnage and cost every
+          plant reports, so it is edited in one place. Ask an administrator to add or change a SKU.
+        </p>
+      )}
+
+      {showForm && !readOnly && (
         <Section title={editId ? 'Edit SKU' : 'Add New SKU'}>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <Field label="Product Type"><Select value={form.productType} onChange={v => f('productType', v)} options={['SHS', 'RHS', 'CHS', 'ERW']} /></Field>
@@ -1739,7 +1764,8 @@ function SKUMaster({ skus, setSkus, productions }) {
       )}
 
       <Section title={`SKU Catalog (${skus.length} items)`}>
-        <DataTable columns={columns} data={skus} onEdit={startEdit} onDelete={deleteSku} />
+        <DataTable columns={columns} data={skus}
+          onEdit={readOnly ? undefined : startEdit} onDelete={readOnly ? undefined : deleteSku} />
       </Section>
     </div>
   )
@@ -2536,7 +2562,11 @@ function mapOrderRow(row, cols = {}) {
   }
 }
 
-function Orders({ orders, replaceOrders, dispatches, replaceDispatches, productions, skus, setSkus }) {
+// `readOnly` (ticket #126) withholds the UPLOAD only — the order book, the CSV export and every
+// figure stay. The upload rebuilds the WHOLE company's order book by superseding every live row,
+// so a second uploader working from a stale file would overwrite everyone's orders, not just their
+// own plant's. One operator, once a day.
+function Orders({ orders, replaceOrders, dispatches, replaceDispatches, productions, skus, setSkus, readOnly = false }) {
   const [uploadMsg, setUploadMsg] = useState(null)
   const fileRef = useRef(null)
 
@@ -2700,7 +2730,7 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
         <div className="flex gap-2">
           <input ref={fileRef} type="file" accept=".xlsx,.xls" onChange={onUpload} className="hidden" />
           <Btn variant="ghost" onClick={downloadOrdersCSV} disabled={activeOrders.length === 0}>⬇ Download CSV</Btn>
-          <Btn onClick={() => fileRef.current?.click()}>Upload Sales Excel</Btn>
+          {!readOnly && <Btn onClick={() => fileRef.current?.click()}>Upload Sales Excel</Btn>}
         </div>
       </div>
 
@@ -2708,6 +2738,13 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
         <div className={`px-3 py-2 rounded text-sm ${uploadMsg.kind === 'ok' ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300'}`}>
           {uploadMsg.text}
         </div>
+      )}
+
+      {readOnly && (
+        <p className="text-xs text-slate-400">
+          One upload replaces <strong>every</strong> plant’s orders at once, so the daily upload is
+          done centrally. Ask an administrator if the order book looks out of date.
+        </p>
       )}
 
       <p className="text-xs text-slate-400">
@@ -3120,19 +3157,6 @@ function SalesDashboard({ orders, dispatches, skus, productions = [], estimates 
 // ═══════════════════════════════════════════════════════════════
 // MAIN APP
 // ═══════════════════════════════════════════════════════════════
-const TABS = [
-  { key: 'dashboard', label: 'Dashboard' },
-  { key: 'coilTracker', label: 'Coil Tracker' },
-  { key: 'coilInward', label: '1. Coil Inward' },
-  { key: 'slitting', label: '2. Slitting' },
-  { key: 'production', label: '3. Production' },
-  { key: 'dispatch', label: '4. Dispatch' },
-  { key: 'skuMaster', label: 'SKU Master' },
-  { key: 'orders', label: 'Orders & Invoice' },
-  { key: 'sales', label: 'Sales' },
-  { key: 'reports', label: 'Reports' },
-]
-
 const TABLE_LABELS = {
   coils: 'Coil Inward',
   baby_coils: 'Slitting',
@@ -3265,16 +3289,29 @@ function Reports({ skus, productions, dispatches, coils, babyCoils, orders, esti
   )
 }
 
-function InventoryApp({ onLogout }) {
+function InventoryApp({ session, onLogout }) {
   const [dark, setDark] = useState(() => LS.get('jsw:dark') ?? false)
-  const [tab, setTab] = useState('dashboard')
-  // ── Plant selector (ticket #121) — one control in the header, applied globally. Defaults to
-  // All Plants so every figure reads exactly as it did before this ticket; switching it scopes
-  // Dashboard, Coil Tracker, Dispatch, Orders and Sales at once. Coil Inward/Slitting/Production/
-  // SKU Master/Reports are deliberately NOT scoped — Reports keeps its company-wide total (a
-  // per-plant split is phase 4 of the #117 spec) and the pipeline stages register/consume coils
-  // regardless of what the header happens to be showing.
-  const [selectedPlant, setSelectedPlant] = useState(ALL_PLANTS)
+  // ── Who signed in decides what renders (ticket #126) ──
+  // One pure function, one call site. Everything below reads `access` and never `session.role`
+  // directly, so the rules stay in calc.js where they are tested and there is exactly one place to
+  // change them. See accessFor's own comment for what this does NOT do — it is not a data boundary.
+  const access = useMemo(() => accessFor(session), [session])
+  const isReadOnly = useCallback((key) => access.readOnly.includes(key), [access])
+
+  const [tab, setTab] = useState(access.tabs[0]?.key || 'dashboard')
+  // ── Plant selector (tickets #121, #126) — one control in the header, applied globally. An admin
+  // gets it and starts on All Plants, so every figure reads exactly as it did before #121;
+  // switching it scopes Dashboard, Coil Tracker, Dispatch, Orders and Sales at once. A plant user
+  // gets NO selector: their plant comes from their login and is the only value this can hold.
+  // Coil Inward/Slitting/SKU Master/Reports are deliberately not scoped BY THE SELECTOR — Reports
+  // keeps its company-wide total (a per-plant split is phase 4 of the #117 spec) and the pipeline
+  // stages register coils regardless of what the header happens to be showing. For a plant user
+  // the scoping that matters is instead structural: they are only offered their own plant's tabs
+  // and Coil Inward only offers their own plant to register against.
+  const [chosenPlant, setChosenPlant] = useState(access.plant)
+  // The plant everything reads. A plant user's is pinned to their login — never derived from a
+  // control they could be shown, because there is no such control to get wrong.
+  const selectedPlant = access.plantSelector ? chosenPlant : access.plant
   const [coils, setCoils, coilsLoading] = useSupabaseStore('jsw:coils', [])
   const [babyCoils, setBabyCoils, babyCoilsLoading] = useSupabaseStore('jsw:babyCoils', [])
   const [productions, setProductions, productionsLoading] = useSupabaseStore('jsw:productions', [])
@@ -3302,7 +3339,28 @@ function InventoryApp({ onLogout }) {
   const plantProductions = useMemo(() => filterByPlant(resolvedProductions, selectedPlant), [resolvedProductions, selectedPlant])
   const plantOrders = useMemo(() => filterByPlant(orders, selectedPlant), [orders, selectedPlant])
   const plantDispatches = useMemo(() => filterDispatchesByPlant(dispatches, selectedPlant), [dispatches, selectedPlant])
+  // The plant named in the header subtitle. For an admin it follows the selector; for a plant user
+  // it is the only plant they have, and is the ONLY place their plant is stated — which is why it
+  // is not dropped when the selector is: without a selector the header would otherwise not say
+  // which plant's numbers these are.
   const plantLabelForHeader = useMemo(() => plantFilterOptions().find(o => o.id === selectedPlant)?.name || 'All Plants', [selectedPlant])
+
+  // ── What the PIPELINE stages read (ticket #126) ──
+  // #121 deliberately left Coil Inward / Slitting / Production reading the raw register: an admin
+  // registers and slits coils regardless of what the header selector happens to be showing, and
+  // moving the selector must not hide the coil in front of them. That stays exactly as it was.
+  //
+  // A plant user is a different case, and not a stricter version of the same one: their plant is
+  // not a view they chose, it is where they are, and there is no selector for them to move. So the
+  // stages read their plant's rows and only those. `plantPinned` is that distinction — the plant
+  // comes from the login rather than from a control — and it is the ONE place it is decided.
+  const plantPinned = !access.plantSelector
+  const pipelineCoils = plantPinned ? plantCoils : coils
+  const pipelineBabyCoils = plantPinned ? plantBabyCoils : babyCoils
+  const pipelineProductions = plantPinned ? plantProductions : resolvedProductions
+  // Dispatches feed Production's "already dispatched" guards; scoping them for a plant user keeps
+  // that guard reading the same set of records the rest of their app does.
+  const pipelineDispatches = plantPinned ? plantDispatches : dispatches
 
   // Dark mode
   useEffect(() => {
@@ -3332,15 +3390,19 @@ function InventoryApp({ onLogout }) {
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <select
-                value={selectedPlant}
-                onChange={e => setSelectedPlant(e.target.value)}
-                title="Scopes Dashboard, Coil Tracker, Dispatch, Orders and Sales to one plant, and sets the plant a new Production consumes coils from"
-                aria-label="Plant"
-                className="px-2 py-1.5 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100"
-              >
-                {plantFilterOptions().map(o => <option key={o.id} value={o.id}>{o.name}</option>)}
-              </select>
+              {/* Offered to an admin only. A plant user has one plant and it is on their login,
+                  so there is no control here to get wrong — the header names it instead. */}
+              {access.plantSelector ? (
+                <select
+                  value={selectedPlant}
+                  onChange={e => setChosenPlant(e.target.value)}
+                  title="Scopes Dashboard, Coil Tracker, Dispatch, Orders and Sales to one plant, and sets the plant a new Production consumes coils from"
+                  aria-label="Plant"
+                  className="px-2 py-1.5 rounded-md border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 dark:text-slate-100"
+                >
+                  {plantFilterOptions().map(o => <option key={o.id} value={o.id}>{o.name}</option>)}
+                </select>
+              ) : null}
               <button
                 onClick={() => setDark(!dark)}
                 className="p-2 rounded-md text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
@@ -3366,7 +3428,7 @@ function InventoryApp({ onLogout }) {
       <nav className="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 overflow-x-auto">
         <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex gap-0 -mb-px">
-            {TABS.map(t => (
+            {access.tabs.map(t => (
               <button
                 key={t.key} onClick={() => setTab(t.key)}
                 className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
@@ -3386,25 +3448,26 @@ function InventoryApp({ onLogout }) {
       <main className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         {tab === 'dashboard' && <Dashboard coils={plantCoils} productions={plantProductions} dispatches={plantDispatches} skus={skus} babyCoils={plantBabyCoils} orders={plantOrders} />}
         {tab === 'coilTracker' && <CoilTracker coils={plantCoils} productions={plantProductions} dispatches={plantDispatches} babyCoils={plantBabyCoils} />}
-        {tab === 'coilInward' && <CoilInward coils={coils} setCoils={setCoils} dispatches={dispatches} productions={resolvedProductions} babyCoils={babyCoils} />}
-        {tab === 'slitting' && <Slitting coils={coils} babyCoils={babyCoils} setBabyCoils={setBabyCoils} productions={resolvedProductions} />}
+        {tab === 'coilInward' && <CoilInward coils={pipelineCoils} setCoils={setCoils} dispatches={pipelineDispatches} productions={pipelineProductions} babyCoils={pipelineBabyCoils}
+          operatingPlant={plantPinned ? selectedPlant : null} />}
+        {tab === 'slitting' && <Slitting coils={pipelineCoils} babyCoils={pipelineBabyCoils} setBabyCoils={setBabyCoils} productions={pipelineProductions} />}
         {/* Production reads the RAW stores and scopes them itself (ticket #124): its plant filter is
             the batch's own plant — the operating plant for a new one, the record's stored plant when
             editing — so opening another plant's record never hides the coils it already consumed.
             The selector doubles as the operating plant until phase 3 puts it on the login, so it is
             passed under that name rather than as `selectedPlant`: inside Production it answers
             "which plant am I working as", not "which plant am I looking at". */}
-        {tab === 'production' && <Production coils={coils} babyCoils={babyCoils} productions={resolvedProductions} setProductions={setProductions} dispatches={dispatches} skus={skus}
+        {tab === 'production' && <Production coils={pipelineCoils} babyCoils={pipelineBabyCoils} productions={pipelineProductions} setProductions={setProductions} dispatches={pipelineDispatches} skus={skus}
           operatingPlant={selectedPlant} />}
         {tab === 'dispatch' && <Dispatch dispatches={plantDispatches} setDispatches={setDispatches} coils={plantCoils} skus={skus}
-          plantScoped={selectedPlant !== ALL_PLANTS} />}
-        {tab === 'skuMaster' && <SKUMaster skus={skus} setSkus={setSkus} productions={productions} />}
+          plantScoped={selectedPlant !== ALL_PLANTS} canWiden={access.plantSelector} />}
+        {tab === 'skuMaster' && <SKUMaster skus={skus} setSkus={setSkus} productions={productions} readOnly={isReadOnly('skuMaster')} />}
         {/* `productions` stays the FULL unfiltered set here — it feeds the upload's coil trace
             (buildDispatchRecords), which must resolve against every plant's coils regardless of
             what the header selector shows, or an upload made while filtered to one plant would
             silently lose every other plant's coil trace. `orders`/`dispatches` are the scoped
             display data; replaceOrders/replaceDispatches (the upload's write path) are untouched. */}
-        {tab === 'orders' && <Orders orders={plantOrders} replaceOrders={replaceOrders} dispatches={plantDispatches} replaceDispatches={replaceDispatches} productions={resolvedProductions} skus={skus} setSkus={setSkus} />}
+        {tab === 'orders' && <Orders orders={plantOrders} replaceOrders={replaceOrders} dispatches={plantDispatches} replaceDispatches={replaceDispatches} productions={resolvedProductions} skus={skus} setSkus={setSkus} readOnly={isReadOnly('orders')} />}
         {/* `estimates` and `stateRegions` stay UNFILTERED — Best Estimate is keyed by distributor
             and Region by state; neither carries a plant, and #117 puts a per-plant Best Estimate
             out of scope. `selectedPlant` goes in so the tab can withhold the BE comparisons that
@@ -3436,24 +3499,35 @@ function InventoryApp({ onLogout }) {
 
 // ═══════════════════════════════════════════════════════════════
 // LOGIN GATE — the app is shown only after a correct login ID + password.
-// The check runs against Supabase (verifyLogin → the verify_login DB function);
-// the password never reaches the browser. On success we remember the login on
+// The check runs against Supabase (verifyLoginDetails → the verify_login_details DB
+// function); the password never reaches the browser. What comes back is WHO signed
+// in — a login id, a role and a plant (ticket #125) — and that decides what the app
+// shows (ticket #126, accessFor in calc.js). On success we remember the session on
 // THIS device for ~30 days so the user isn't asked every visit. This guards the
 // app UI, not the raw database. To change the login ID / password, or the login
 // model, see blueprints/manage-app-login.md.
 // ═══════════════════════════════════════════════════════════════
 const AUTH_KEY = 'jsw:auth'
-const AUTH_TTL_MS = 30 * 24 * 60 * 60 * 1000 // stay logged in ~30 days per device
 
-function loadAuth() {
-  const saved = LS.get(AUTH_KEY)
-  if (!saved || !saved.at) return false
-  if (Date.now() - saved.at > AUTH_TTL_MS) { LS.del(AUTH_KEY); return false }
-  return true
+// A session is only a session if it also GRANTS something. Shape and rules are two questions and
+// stay two functions, but a credential can pass the first and fail the second — a `plant` role
+// whose plant column is NULL arrives as ALL_PLANTS, which is a well-formed session that accessFor
+// correctly refuses to read as "every plant". Signing that user into an app with no tabs would
+// present a credential to fix as a bug in the app.
+const grantsAccess = (session) => !!session && accessFor(session).tabs.length > 0
+
+// The stored session, or null. The shape rules — including "no role means this was stored before
+// roles existed, so sign in once more" — live in parseStoredSession (calc.js), where they are
+// tested; this is only the read. An invalid session is DELETED rather than left to be re-read and
+// re-rejected on every visit, which is what makes the one-time re-authentication actually once.
+function loadSession() {
+  const session = parseStoredSession(LS.get(AUTH_KEY))
+  if (!grantsAccess(session)) { LS.del(AUTH_KEY); return null }
+  return session
 }
 
 export default function App() {
-  const [authed, setAuthed] = useState(loadAuth)
+  const [session, setSession] = useState(loadSession)
 
   // Theme the login screen too: apply the saved dark-mode class on mount.
   // (InventoryApp owns the live toggle once the user is signed in.)
@@ -3461,9 +3535,12 @@ export default function App() {
     document.documentElement.classList.toggle('dark', LS.get('jsw:dark') ?? false)
   }, [])
 
-  if (!authed) return <LoginGate onSuccess={() => setAuthed(true)} />
+  if (!session) return <LoginGate onSuccess={setSession} />
 
-  return <InventoryApp onLogout={() => { LS.del(AUTH_KEY); setAuthed(false) }} />
+  // `key` remounts the whole app when a different user signs in on the same device, so no tab
+  // selection, filter or form draft from the previous session survives into the next one.
+  return <InventoryApp key={session.loginId} session={session}
+    onLogout={() => { LS.del(AUTH_KEY); setSession(null) }} />
 }
 
 function LoginGate({ onSuccess }) {
@@ -3478,10 +3555,19 @@ function LoginGate({ onSuccess }) {
     setError('')
     setBusy(true)
     try {
-      const ok = await verifyLogin(loginId.trim(), password)
-      if (ok) {
-        LS.set(AUTH_KEY, { loginId: loginId.trim(), at: Date.now() })
-        onSuccess()
+      // null = wrong login id or password. A THROW is a dead connection — the two must keep
+      // reading differently on screen, or "the server is down" reads as "you typed it wrong".
+      const who = await verifyLoginDetails(loginId.trim(), password)
+      const session = who && parseStoredSession({ ...who, at: Date.now() })
+      if (grantsAccess(session)) {
+        LS.set(AUTH_KEY, session)
+        onSuccess(session)
+      } else if (who) {
+        // The password was right, but the credential row cannot say what this user may do — a role
+        // the app does not know, or a `plant` login with no plant. Nothing is guessed at: say what
+        // is wrong and where it is fixed, rather than signing them into an app with no tabs.
+        setError('This login is not set up correctly (no valid role or plant). Ask an administrator to fix it.')
+        setPassword('')
       } else {
         setError('Invalid login ID or password.')
         setPassword('')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ import {
   UNATTRIBUTED_PLANT, plantLabel, dispatchPlantLabel, plantForErpRow, erpRowPicker,
   coilInwardPlants, DEFAULT_COIL_PLANT, babyCoilPlant, productionPlant, crossPlantAllocationRows,
   ALL_PLANTS, plantFilterOptions, filterByPlant, filterDispatchesByPlant, withDispatchEntries,
-  APP_TABS, accessFor, parseStoredSession,
+  accessFor, parseStoredSession,
 } from './lib/calc'
 import { loadChunk } from './lib/chunk'
 import DEFAULT_SKUS from './data/skus'
@@ -2728,9 +2728,14 @@ function Orders({ orders, replaceOrders, dispatches, replaceDispatches, producti
       <div className="flex justify-between items-center">
         <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Orders &amp; Invoice</h2>
         <div className="flex gap-2">
-          <input ref={fileRef} type="file" accept=".xlsx,.xls" onChange={onUpload} className="hidden" />
           <Btn variant="ghost" onClick={downloadOrdersCSV} disabled={activeOrders.length === 0}>⬇ Download CSV</Btn>
-          {!readOnly && <Btn onClick={() => fileRef.current?.click()}>Upload Sales Excel</Btn>}
+          {/* The hidden file input goes with the button. Leaving it mounted would keep the whole
+              upload path — input, onUpload, replaceOrders — one line of console away for a user
+              the app is withholding it from, and would make "withheld from the DOM" untrue. */}
+          {!readOnly && <>
+            <input ref={fileRef} type="file" accept=".xlsx,.xls" onChange={onUpload} className="hidden" />
+            <Btn onClick={() => fileRef.current?.click()}>Upload Sales Excel</Btn>
+          </>}
         </div>
       </div>
 
@@ -3343,7 +3348,18 @@ function InventoryApp({ session, onLogout }) {
   // it is the only plant they have, and is the ONLY place their plant is stated — which is why it
   // is not dropped when the selector is: without a selector the header would otherwise not say
   // which plant's numbers these are.
-  const plantLabelForHeader = useMemo(() => plantFilterOptions().find(o => o.id === selectedPlant)?.name || 'All Plants', [selectedPlant])
+  //
+  // The fallback matters more than it looks. An admin's value always comes from the options, so it
+  // is always found. A PINNED value comes from the credential row and may match no plant master row
+  // (blueprints/manage-app-login.md: fix the row, don't work around it) — and falling back to
+  // "All Plants" there would tell someone scoped to nothing that they were looking at everything,
+  // the exact opposite of the truth. So an unmatched pinned id shows the id itself: wrong-looking,
+  // which is what it is, and it names the value to correct.
+  const plantLabelForHeader = useMemo(() => {
+    const option = plantFilterOptions().find(o => o.id === selectedPlant)
+    if (option) return option.name
+    return access.plantSelector ? 'All Plants' : selectedPlant
+  }, [selectedPlant, access.plantSelector])
 
   // ── What the PIPELINE stages read (ticket #126) ──
   // #121 deliberately left Coil Inward / Slitting / Production reading the raw register: an admin

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -1876,3 +1876,125 @@ export function coilInventoryRow(coil, dispatches, productions = []) {
     producedInvPcs: producedPcs - dispatchedPcs,
   }
 }
+
+// ── ACCESS: what one signed-in user may see (ticket #126) ──────────────────────────────────────
+// Sign-in says WHO signed in (ticket #125: a login id, a role and a plant). This section is the one
+// place that turns that into what the app shows — which tabs render, which of them are read-only,
+// and whether the plant selector is offered at all.
+//
+// It is a pure function of role and plant on purpose. The rules are a table in the ticket, they
+// will be edited (a plant is onboarded, a tab moves), and a rule you can only check by signing in
+// and clicking is a rule nobody checks. Here it is 30 lines of data and one `filter`, and the
+// tests below it read like the ticket's table.
+//
+// What it is NOT: a security boundary. Every data table keeps its permissive row-level policy and
+// the app's public key still reaches every plant's rows, exactly as blueprints/manage-app-login.md
+// says out loud. This hides another plant's screens from an operator who has no use for them. It
+// does not protect that plant's data, and nothing on screen may claim it does.
+export const ROLE_ADMIN = 'admin'
+export const ROLE_PLANT = 'plant'
+
+// The tab bar, in the order it is shown. It lives here rather than in App.jsx because `accessFor`
+// decides which of these render, and a second list in the component is a list that drifts: a tab
+// added there and not here would be shown to everyone by a rule that had never heard of it.
+export const APP_TABS = [
+  { key: 'dashboard', label: 'Dashboard' },
+  { key: 'coilTracker', label: 'Coil Tracker' },
+  { key: 'coilInward', label: '1. Coil Inward' },
+  { key: 'slitting', label: '2. Slitting' },
+  { key: 'production', label: '3. Production' },
+  { key: 'dispatch', label: '4. Dispatch' },
+  { key: 'skuMaster', label: 'SKU Master' },
+  { key: 'orders', label: 'Orders & Invoice' },
+  { key: 'sales', label: 'Sales' },
+  { key: 'reports', label: 'Reports' },
+]
+
+// The three shop-floor stages. Offered only to a plant that actually manufactures — `manufactures`
+// in the plant master is the single flag that decides it, exactly as ADR-0004 promised, so
+// reclassifying Lepakshi is still a one-line change there and not an edit here.
+const MANUFACTURING_TABS = ['coilInward', 'slitting', 'production']
+
+// Admin-only tabs: Reports builds the company-wide workbooks.
+const ADMIN_ONLY_TABS = ['reports']
+
+// Read-only for a plant user — visible, but without the control that changes company-wide data.
+// Both are company-wide by nature, which is why they are one operator's job rather than four:
+//   skuMaster  weightPerTube drives EVERY plant's tonnage and cost (see the non-negotiables).
+//   orders     the upload supersedes every live order row, so a second uploader working from a
+//              stale file would overwrite the whole company's order book, not just their own.
+const PLANT_READ_ONLY_TABS = ['skuMaster', 'orders']
+
+// Granting nothing. Returned for any session that does not name a role and a plant this app knows
+// — deliberately empty rather than "the safe subset", because every such case is a credential row
+// to fix (blueprints/manage-app-login.md) and a half-working app hides that.
+const NO_ACCESS = { tabs: [], readOnly: [], plantSelector: false, plant: '' }
+
+// role + plant → what renders.
+//   tabs          the APP_TABS entries to show, IN APP_TABS ORDER
+//   readOnly      keys of visible tabs whose editing controls are withheld
+//   plantSelector whether the header offers the plant selector
+//   plant          the plant every scoped view is filtered to — ALL_PLANTS for an admin (who then
+//                  moves it with the selector), the user's own plant for a plant user (who cannot)
+//
+// An admin's `plant` is where the selector STARTS; a plant user's is where it is pinned. That is
+// the whole difference, and it is why `plantSelector` and `plant` come out of the same function:
+// offering a selector and deciding the value it starts on is one decision, not two.
+export function accessFor(session, master = DEFAULT_PLANTS) {
+  const role = String(session?.role ?? '').trim()
+  const plant = String(session?.plant ?? '').trim()
+
+  if (role === ROLE_ADMIN) {
+    return { tabs: [...APP_TABS], readOnly: [], plantSelector: true, plant: ALL_PLANTS }
+  }
+
+  if (role !== ROLE_PLANT) return { ...NO_ACCESS }
+
+  // A plant user must have a plant of their own. ALL_PLANTS is what a NULL plant column arrives as
+  // (db.js), and blank is Unattributed — the labelling gap, not a plant. Neither is a plant to be
+  // scoped to, and reading either as "all of them" would hand a plant login the whole company.
+  if (!plant || plant === ALL_PLANTS) return { ...NO_ACCESS }
+
+  // An id matching no master row is a credential to fix, not a case to widen: it stays the scope
+  // (so the tabs read empty and the fault is visible) and it does not manufacture.
+  const manufactures = !!plantById(plant, master)?.manufactures
+  const hidden = new Set([
+    ...ADMIN_ONLY_TABS,
+    ...(manufactures ? [] : MANUFACTURING_TABS),
+  ])
+  const tabs = APP_TABS.filter(t => !hidden.has(t.key))
+  const visible = new Set(tabs.map(t => t.key))
+
+  return {
+    tabs,
+    readOnly: PLANT_READ_ONLY_TABS.filter(k => visible.has(k)),
+    plantSelector: false,
+    plant,
+  }
+}
+
+// ── The stored session ─────────────────────────────────────────────────────────────────────────
+// A correct sign-in is remembered on that device for ~30 days so the app is not a password prompt
+// every morning. This is the pure half of that: given whatever came out of storage, is it a
+// session, and is it still valid? The impure half (reading and writing localStorage) stays in
+// App.jsx, which is what keeps this testable at all — App.jsx cannot be imported by the suite.
+export const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+// Anything that is not a complete, unexpired session is `null` — one answer, so the caller has one
+// branch. In particular EVERY session stored before this ticket is null: they carry a login id and
+// a timestamp and no role, because roles did not exist. That is the one-time re-authentication the
+// ticket calls for, and it needs no version stamp to arrange — a session that cannot say what it
+// may do is not a session. Everyone signs in once more; nobody is locked out.
+export function parseStoredSession(saved, now = Date.now()) {
+  if (!saved || typeof saved !== 'object' || Array.isArray(saved)) return null
+  const loginId = String(saved.loginId ?? '').trim()
+  const role = String(saved.role ?? '').trim()
+  const plant = String(saved.plant ?? '').trim()
+  const at = saved.at
+  if (!loginId) return null                                   // a session names WHO signed in
+  if (role !== ROLE_ADMIN && role !== ROLE_PLANT) return null  // …and what they may do
+  if (!plant) return null                                     // admin carries ALL_PLANTS, not blank
+  if (typeof at !== 'number' || !Number.isFinite(at)) return null
+  if (now - at > SESSION_TTL_MS) return null
+  return { loginId, plant, role, at }
+}

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -1915,6 +1915,16 @@ export const APP_TABS = [
 // reclassifying Lepakshi is still a one-line change there and not an edit here.
 const MANUFACTURING_TABS = ['coilInward', 'slitting', 'production']
 
+// Coil Inward carries a SECOND condition, and it is not the same question. `manufactures` says a
+// plant runs the pipeline at all; COIL_INWARD_PLANT_IDS is the separate rollout list of who may
+// register a mother coil *today* (see coilInwardPlants above — the two are documented as distinct
+// mechanisms that would diverge the day a plant lands on the master as manufacturing before Coil
+// Inward is ready for it). The admin's plant picker already honours the rollout list, so gating
+// this tab on `manufactures` alone would let a plant user register coils an admin cannot offer.
+// Slitting and Production are NOT gated on it: they consume what Coil Inward registered, so
+// without it they are empty, never wrong.
+const ROLLED_OUT_ONLY_TABS = ['coilInward']
+
 // Admin-only tabs: Reports builds the company-wide workbooks.
 const ADMIN_ONLY_TABS = ['reports']
 
@@ -1958,9 +1968,11 @@ export function accessFor(session, master = DEFAULT_PLANTS) {
   // An id matching no master row is a credential to fix, not a case to widen: it stays the scope
   // (so the tabs read empty and the fault is visible) and it does not manufacture.
   const manufactures = !!plantById(plant, master)?.manufactures
+  const rolledOut = COIL_INWARD_PLANT_IDS.includes(plant)
   const hidden = new Set([
     ...ADMIN_ONLY_TABS,
     ...(manufactures ? [] : MANUFACTURING_TABS),
+    ...(rolledOut ? [] : ROLLED_OUT_ONLY_TABS),
   ])
   const tabs = APP_TABS.filter(t => !hidden.has(t.key))
   const visible = new Set(tabs.map(t => t.key))

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -19,6 +19,7 @@ import {
   distributorStateIndex, distributorRegionResolver,
   salesKpis, salesByDistributor, salesByMonth,
   estimateNum, distributorEstimateIndex, plantBestEstimate,
+  APP_TABS, accessFor, parseStoredSession, ROLE_ADMIN, ROLE_PLANT, SESSION_TTL_MS,
 } from './calc'
 import DEFAULT_STATE_REGIONS from '../data/stateRegions'
 import DEFAULT_PLANTS from '../data/plants'
@@ -2832,5 +2833,177 @@ describe('salesByDistributor — unreserved plant stock in the drill-down (ADR-0
     expect(row.allConfirmed).toBe(0)
     expect(row.freeStock).toBeCloseTo(45)
     expect(row.freeStock).toBeCloseTo(row.onhand)
+  })
+})
+
+// ── ACCESS: what role + plant may see (ticket #126) ────────────────────────────────────────────
+describe('APP_TABS', () => {
+  it('is the one ordered list of tabs, keys unique', () => {
+    const keys = APP_TABS.map(t => t.key)
+    expect(new Set(keys).size).toBe(keys.length)
+    expect(keys[0]).toBe('dashboard')          // the landing tab; every role sees it
+    expect(keys).toContain('reports')
+  })
+
+  it('carries no tab for the stages ticket #117 removed', () => {
+    const keys = APP_TABS.map(t => t.key)
+    expect(keys).not.toContain('tubes')
+    expect(keys).not.toContain('bundles')
+  })
+})
+
+describe('accessFor', () => {
+  const keysOf = (a) => a.tabs.map(t => t.key)
+  const admin = { role: 'admin', plant: ALL_PLANTS }
+  const hyd = { role: 'plant', plant: 'hyderabad' }
+  const npmd = { role: 'plant', plant: 'npmd' }
+  const lepakshi = { role: 'plant', plant: 'lepakshi' }   // manufactures: false
+
+  it('gives an admin every tab, nothing read-only, and the plant selector', () => {
+    const a = accessFor(admin)
+    expect(keysOf(a)).toEqual(APP_TABS.map(t => t.key))
+    expect(a.readOnly).toEqual([])
+    expect(a.plantSelector).toBe(true)
+    expect(a.plant).toBe(ALL_PLANTS)
+  })
+
+  it('scopes a plant user to their own plant and offers no selector', () => {
+    expect(accessFor(hyd).plant).toBe('hyderabad')
+    expect(accessFor(hyd).plantSelector).toBe(false)
+    expect(accessFor(npmd).plant).toBe('npmd')
+    expect(accessFor(npmd).plantSelector).toBe(false)
+  })
+
+  it('hides Reports from a plant user and keeps it for an admin', () => {
+    expect(keysOf(accessFor(hyd))).not.toContain('reports')
+    expect(keysOf(accessFor(admin))).toContain('reports')
+  })
+
+  it('gives a plant user the four viewing tabs', () => {
+    const keys = keysOf(accessFor(hyd))
+    expect(keys).toEqual(expect.arrayContaining(['dashboard', 'coilTracker', 'dispatch', 'sales']))
+  })
+
+  it('offers the manufacturing tabs only to a plant that manufactures', () => {
+    const mfg = ['coilInward', 'slitting', 'production']
+    expect(keysOf(accessFor(hyd))).toEqual(expect.arrayContaining(mfg))
+    expect(keysOf(accessFor(npmd))).toEqual(expect.arrayContaining(mfg))
+    // Lepakshi carries orders and has never produced — manufactures: false in the plant master.
+    mfg.forEach(k => expect(keysOf(accessFor(lepakshi))).not.toContain(k))
+    // …but it keeps everything that is not a shop-floor stage.
+    expect(keysOf(accessFor(lepakshi))).toEqual(expect.arrayContaining(['dashboard', 'sales', 'orders']))
+  })
+
+  it('keeps an admin’s manufacturing tabs regardless of the selected plant', () => {
+    // The selector is a VIEW, not an identity — an admin looking at Lepakshi still has the stages.
+    expect(keysOf(accessFor({ role: 'admin', plant: 'lepakshi' }))).toContain('coilInward')
+  })
+
+  it('makes SKU Master and Orders read-only for a plant user, and neither for an admin', () => {
+    expect(accessFor(hyd).readOnly).toEqual(expect.arrayContaining(['skuMaster', 'orders']))
+    expect(accessFor(admin).readOnly).toEqual([])
+  })
+
+  it('never marks a tab read-only that it also hides', () => {
+    ;[admin, hyd, npmd, lepakshi].forEach(s => {
+      const a = accessFor(s)
+      const visible = new Set(a.tabs.map(t => t.key))
+      a.readOnly.forEach(k => expect(visible.has(k)).toBe(true))
+    })
+  })
+
+  it('returns tabs in APP_TABS order, never the order the rules happened to run in', () => {
+    const order = APP_TABS.map(t => t.key)
+    const keys = keysOf(accessFor(hyd))
+    expect(keys).toEqual(order.filter(k => keys.includes(k)))
+  })
+
+  it('grants nothing to a plant role carrying no plant of its own', () => {
+    // A `plant` credential with a NULL plant column arrives as ALL_PLANTS (db.js). Reading that as
+    // "every plant" would hand a plant login the whole company — the one failure worth refusing.
+    ;[ALL_PLANTS, '', null, undefined].forEach(p => {
+      const a = accessFor({ role: 'plant', plant: p })
+      expect(a.tabs).toEqual([])
+      expect(a.plantSelector).toBe(false)
+    })
+  })
+
+  it('grants nothing for an unknown, missing or empty role', () => {
+    ;[{ role: 'superuser', plant: 'hyderabad' }, { role: '', plant: 'hyderabad' }, {}, null, undefined]
+      .forEach(s => expect(accessFor(s).tabs).toEqual([]))
+  })
+
+  it('still scopes a plant id no plant master row matches, showing empty rather than everything', () => {
+    // Documented in blueprints/manage-app-login.md: fix the credential row, don't work around it
+    // here. What must NOT happen is the unknown id widening into All Plants.
+    const a = accessFor({ role: 'plant', plant: 'not-a-plant' })
+    expect(a.plant).toBe('not-a-plant')
+    expect(a.plantSelector).toBe(false)
+    expect(a.tabs.map(t => t.key)).not.toContain('coilInward')   // unknown ⇒ does not manufacture
+  })
+})
+
+describe('parseStoredSession', () => {
+  const now = Date.UTC(2026, 7, 19)
+  const day = 24 * 60 * 60 * 1000
+  const fresh = { loginId: 'hyderabad', plant: 'hyderabad', role: 'plant', at: now - day }
+
+  it('accepts a session carrying a login, a role and a plant', () => {
+    expect(parseStoredSession(fresh, now)).toEqual({ loginId: 'hyderabad', plant: 'hyderabad', role: 'plant', at: now - day })
+  })
+
+  it('accepts an admin session, whose plant is the All Plants sentinel', () => {
+    const s = parseStoredSession({ loginId: 'admin', plant: ALL_PLANTS, role: 'admin', at: now }, now)
+    expect(s.role).toBe('admin')
+    expect(s.plant).toBe(ALL_PLANTS)
+  })
+
+  it('rejects a session stored before roles existed, so it is signed in once more', () => {
+    // Every pre-#126 session is exactly this shape: a login id and a timestamp, no role.
+    expect(parseStoredSession({ loginId: 'admin', at: now }, now)).toBe(null)
+  })
+
+  it('rejects a role it does not recognise rather than treating it as a plant user', () => {
+    expect(parseStoredSession({ loginId: 'x', plant: 'hyderabad', role: 'superuser', at: now }, now)).toBe(null)
+  })
+
+  it('rejects a plant session with no plant, and an admin session with no plant', () => {
+    expect(parseStoredSession({ loginId: 'x', role: 'plant', at: now }, now)).toBe(null)
+    expect(parseStoredSession({ loginId: 'admin', role: 'admin', at: now }, now)).toBe(null)
+  })
+
+  it('expires after the 30-day window, and holds inside it', () => {
+    expect(parseStoredSession({ ...fresh, at: now - 29 * day }, now)).not.toBe(null)
+    expect(parseStoredSession({ ...fresh, at: now - 31 * day }, now)).toBe(null)
+  })
+
+  it('rejects junk, a missing timestamp and nothing at all', () => {
+    ;[null, undefined, 'admin', 42, {}, { ...fresh, at: undefined }, { ...fresh, at: 'yesterday' }]
+      .forEach(v => expect(parseStoredSession(v, now)).toBe(null))
+  })
+
+  it('rejects a session with no login id — a session names WHO signed in', () => {
+    expect(parseStoredSession({ ...fresh, loginId: '' }, now)).toBe(null)
+  })
+})
+
+describe('parseStoredSession + accessFor together', () => {
+  // The two answer different questions and a credential can pass one and fail the other. This is
+  // the case that matters: a `plant` role whose plant column is NULL reaches the app as ALL_PLANTS
+  // (db.js), which is a WELL-FORMED session — and must still grant nothing.
+  it('parses a plant session with no plant of its own, and grants it nothing', () => {
+    const session = parseStoredSession({ loginId: 'broken', plant: ALL_PLANTS, role: 'plant', at: Date.now() })
+    expect(session).not.toBe(null)
+    expect(accessFor(session).tabs).toEqual([])
+  })
+
+  it('grants tabs to every session the three real logins produce', () => {
+    ;[{ loginId: 'admin', plant: ALL_PLANTS, role: 'admin' },
+      { loginId: 'hyderabad', plant: 'hyderabad', role: 'plant' },
+      { loginId: 'npmd', plant: 'npmd', role: 'plant' }].forEach(row => {
+      const session = parseStoredSession({ ...row, at: Date.now() })
+      expect(session, row.loginId).not.toBe(null)
+      expect(accessFor(session).tabs.length, row.loginId).toBeGreaterThan(0)
+    })
   })
 })

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -2933,6 +2933,19 @@ describe('accessFor', () => {
       .forEach(s => expect(accessFor(s).tabs).toEqual([]))
   })
 
+  it('offers Coil Inward only to a plant on the rollout list, not merely one that manufactures', () => {
+    // COIL_INWARD_PLANT_IDS and `manufactures` are deliberately separate mechanisms (see the
+    // comment on coilInwardPlants): a plant can land on the master as manufacturing before Coil
+    // Inward is ready to offer it. An admin's picker already honours the rollout list, so gating
+    // the TAB on `manufactures` alone would let a plant user register coils the admin cannot.
+    const notRolledOut = PLANTS.map(p => p.id === 'lepakshi' ? { ...p, manufactures: true } : p)
+    const keys = accessFor({ role: 'plant', plant: 'lepakshi' }, notRolledOut).tabs.map(t => t.key)
+    expect(keys).not.toContain('coilInward')
+    // Slitting and Production follow `manufactures` — they consume what Coil Inward registered,
+    // so they are useless without it but never wrong, and the rollout list does not govern them.
+    expect(keys).toEqual(expect.arrayContaining(['slitting', 'production']))
+  })
+
   it('still scopes a plant id no plant master row matches, showing empty rather than everything', () => {
     // Documented in blueprints/manage-app-login.md: fix the credential row, don't work around it
     // here. What must NOT happen is the unknown id widening into All Plants.

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -294,6 +294,13 @@ async function syncToSupabase(tableName, prev, next, prevIdsRef, onReject = () =
 // password is correct and get back a plain yes/no — the password/hash never
 // reaches the browser. Returns true/false; throws only on a network/RPC error
 // so the UI can tell "wrong password" (false) apart from "couldn't connect".
+//
+// NO LONGER CALLED BY THIS BUILD. Ticket #126 moved sign-in onto
+// `verifyLoginDetails` below, which answers WHO signed in — a yes/no cannot
+// decide which tabs to render. It is kept, with its SQL function, for the
+// deployment window: a browser tab still running the previous build calls
+// `verify_login` until it is reloaded, and that call must keep working. Delete
+// both once no such tab can plausibly be open.
 // ═══════════════════════════════════════════════════════════════
 export async function verifyLogin(loginId, password) {
   const { data, error } = await supabase.rpc('verify_login', {
@@ -312,6 +319,7 @@ export async function verifyLogin(loginId, password) {
 // SECOND database function. `verifyLogin` above is untouched and still works:
 // the SQL adding this one is additive, so it can be run against the database
 // serving the current build without breaking sign-in before the new build ships.
+// Since ticket #126 this is the one the app actually signs in with.
 //
 // `verify_login_details` answers with the signer's identity — login id, plant
 // and role — instead of yes/no. Same guarantee as the boolean version: the


### PR DESCRIPTION
Closes #126. Phase 3 of the multi-plant spec (#117), on top of #124 and #125.

Signing in as `npmd` opens the app on NPMD's data with no selector to get wrong. Signing in as `admin` opens on All Plants with the selector, exactly as #121 left it.

## One pure function decides it

`accessFor(session)` in `src/lib/calc.js` maps role + plant to `{tabs, readOnly, plantSelector, plant}`. `APP_TABS` moved there beside it — two tab lists is one too many, and `App.jsx` cannot be imported by the test suite, so a component-local list is one no test could ever check for drift.

| Tab | Admin | Plant user |
|---|---|---|
| Dashboard, Coil Tracker, Dispatch, Sales | All plants + selector | Their plant only |
| Coil Inward, Slitting, Production | All plants + selector | Their plant, pinned — only if the plant `manufactures`; Coil Inward also requires the `COIL_INWARD_PLANT_IDS` rollout list |
| SKU Master | View and **edit** | View only |
| Orders & Invoice | **Upload** and view | View, their plant |
| Reports | **Yes** | Hidden |

- **Read-only means unmounted, not disabled** — including the things a button merely triggers: the Orders upload's hidden `<input type="file">` is gated with its button, so the write path isn't one console line away. Catalogs, order book and CSV exports all stay.
- **No selector for a plant user** — `selectedPlant` is pinned with no setter, Coil Inward registers against their plant with nothing to pick, and the pipeline stages read their plant's rows only. An admin's stages keep reading the raw register, unchanged from #121.
- **Sessions** are `{loginId, plant, role, at}`, validated by `parseStoredSession`. A pre-#126 session has no `role`, so it's rejected and deleted — one fresh sign-in, no version stamp needed.

## A session can be well-formed and still grant nothing

A `plant` credential with a NULL plant column arrives as `ALL_PLANTS` — correct for an admin, meaningless for a plant login. It parses as a valid session; `accessFor` refuses it. Sign-in requires **both**, and reports the credential as misconfigured rather than opening an app with no tabs or handing a plant login the whole company.

## This is not a data boundary

Every table keeps its permissive row-level policy and the public key still reaches every plant's rows, exactly as `blueprints/manage-app-login.md` says. This hides another plant's screens from an operator with no use for them. An E2E test asserts no screen ever calls another plant's data private, hidden or secure.

## The Playwright specs had not run in a long time

`TESTING.md` recorded "Chromium can't be downloaded here" as a known blocker. A browser was available, so they ran — and **all 7 failed, none of it caused by this ticket.** They filled a `Cost Price (₹)` field that had been deleted, clicked an `Upload Dispatch Excel` button that no longer exists, drove two `SearchSelect`s as if they were `<select>`s, expected `Save Baby Coil` where the button counts, expected FIFO to allocate without clicking **Use suggestion** (the never-auto-save rule), and went straight to the app past a login gate standing there since July.

All repaired against what the app actually does, every original assertion preserved. `playwright.config.js` gains an optional `PW_CHROMIUM_PATH` so a machine that already has a browser never has to pretend it can't test. **So the criterion "existing specs pass unchanged" could not hold as written — they weren't passing at all.**

## Reviewer, please look at

- **"Reset Data" does not exist.** The ticket lists it; there is no such control in `App.jsx` and no commit in this repo's history adds or removes one. Nothing was built — `docs/ARCHITECTURE.md` was corrected to state only what's verifiable.
- **Scoping hides `Unattributed` rows from plant users.** `filterByPlant` matches the stored value exactly, so a legacy blank-plant coil is invisible to a plant user in the pipeline stages. Deliberate — a row that can't say where it sits isn't one plant's to claim — but it makes backfilling an admin-only job, now documented in `ARCHITECTURE.md` and `UI-PATTERNS.md`.
- `verifyLogin` (the boolean sign-in) is now uncalled but kept: a browser tab on the old build still needs its SQL function until it reloads. Marked legacy with the condition for deleting it.

## Verification

400 unit tests, 29 E2E tests, `npm run build` clean. Two `/code-review` rounds (Standards + Spec); the second commit takes six findings, including a real bug where the header told a plant user with a mistyped credential that they were viewing "All Plants".

Docs updated: `ARCHITECTURE.md`, `DATA-MODEL.md`, `UI-PATTERNS.md`, `CONTEXT.md`, `TESTING.md`, `blueprints/manage-app-login.md`, `LEARNINGS.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0115Jij4CxaLDQsZpQM23yLo)_