### PR TITLE
Fix: a plant user's Slitting save deletes every other plant's baby coils (follow-up to #138)

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -227,3 +227,36 @@ stored value exactly, so a legacy blank-plant row is invisible to a plant user i
 stages. That is right — a row that cannot say where it sits is not one plant's to claim — but it
 silently makes backfilling an admin-only job. Written down in both `ARCHITECTURE.md` and
 `UI-PATTERNS.md` rather than left to be discovered by a plant user who cannot find their coil.
+
+### Round two on #126 — the fix that was worse than the bug
+
+**Never hand a component a filtered copy of a store it writes back.** Scoping the pipeline stages by
+passing `pipelineBabyCoils` looked like the tidy version of "a plant user sees only their plant". It
+was a data-loss bug. `Slitting.save` builds its next array from the `babyCoils` prop and calls
+`setBabyCoils(updated)` — not `setBabyCoils(prev => …)` — so with a filtered prop `next` is a strict
+subset of `prev`, and `syncToSupabase` reads every id in prev-but-not-next as a deletion. On
+`baby_coils`, a HARD one. **One Hyderabad operator saving one baby coil would have permanently
+deleted every NPMD baby coil.** `CoilInward` and `Production` use the functional setter and were
+safe — which is exactly why the bug was easy to miss: two of the three stages tolerated it.
+
+The same blunt filtering also silently disarmed the cross-stage guards. "A baby coil consumed by
+**any** production cannot be deleted" is only true against the whole register; so are the duplicate
+`hrCoilId` check and `nextCoilNumber`. Worst case is a legacy blank-plant row, which `genHRCoilId`
+gives an `HYD-` id — precisely what a new Hyderabad coil collides with, and precisely what the
+scoped array hid. **Display scopes; state and guards do not.**
+
+**A regression test is not finished until you have watched it fail.** The first version of the
+new test passed with the defect deliberately reintroduced — twice, for two different reasons:
+1. **Route shadowing.** The recorder installed its own `page.route` before `signIn` installed the
+   stub. Playwright runs the most recently registered handler first, so the recorder never fired and
+   `writes` was always `[]` — every assertion on it was vacuously true. Fixed by passing `onRequest`
+   into `signIn` (one handler), plus an `expect(writes.length).toBeGreaterThan(0)` so a silent
+   recorder fails loudly instead of passing quietly.
+2. **Ordering.** `syncToSupabase` awaits its upsert before issuing any delete, so when the saved row
+   appears on screen the destructive half of that same sync has not been sent. Asserting there
+   passes while the bug is live. Fixed with a `settle()` that waits for the request traffic to stop.
+
+Only after reintroducing the defect a third time did the test actually go red. Two review rounds
+found this; the first round's Standards axis flagged the guard narrowing and the Spec axis found the
+delete. **Neither would have been caught by the app's own screens** — the rows destroyed are the
+ones the user cannot see, which is why the assertion had to move to the network layer.

--- a/TESTING.md
+++ b/TESTING.md
@@ -22,13 +22,30 @@ They run in Node (no DOM/Supabase needed). `db.test.js` mocks `./supabase` so im
 `db.js` doesn't try to construct a real client.
 
 ## E2E tests (Playwright)
-Three specs, 28 tests:
+Three specs, 31 tests:
 - `e2e/pipeline.spec.js` — **Coil Inward → Slitting → Production**, FIFO split across baby coils,
   the shortfall warn-don't-block policy, and a guard that the removed stages are gone.
 - `e2e/slitting-multi.spec.js` — multi-row slitting and the baby-coil search.
 - `e2e/roles.spec.js` — **which tabs each of `admin`, `hyderabad` and `npmd` renders** (ticket #126),
   the read-only SKU Master and order book, the pinned Coil Inward plant, the one-time clearing of a
-  pre-#126 session, and that no screen describes another plant's data as private or secure.
+  pre-#126 session, and that no screen describes another plant's data as private or secure. It also
+  covers the one bug in this ticket that **nothing on screen could show**: a plant user's Slitting
+  save must never delete another plant's baby coils. `signIn` takes `rows` to seed a table with data
+  that did not come from the UI, and `writeRecorder()` captures every write so the test can assert
+  on what the app did *not* send.
+
+**Two traps that make a request-level test pass while the bug is live**, both hit while writing it:
+  - **Route shadowing.** Playwright runs the most recently registered matching handler first, so a
+    recorder installed before `signIn` is shadowed by `signIn`'s own stub and records nothing — the
+    test then passes because it observed *nothing at all*. Pass `onRequest` into `signIn`; there
+    must be exactly one handler. The test also asserts `writes.length > 0` so a silent recorder
+    fails loudly.
+  - **Ordering.** `syncToSupabase` awaits its upsert *before* issuing any delete, so when a saved
+    row appears on screen the destructive half of that same sync has not been sent yet. Use
+    `settle(page)` to wait for the traffic to stop before asserting.
+
+  Both were caught by deliberately reintroducing the defect and checking the test failed. **A new
+  regression test is not finished until you have seen it fail on the bug it describes.**
 
 **Every spec signs in**, through the real form, via `e2e/signin.js`. Only the one sign-in RPC is
 stubbed — `.env.test` points at a host that does not exist, so no password could verify, and the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,13 +56,16 @@ How it is wired in `InventoryApp`:
 - `access.plantSelector` decides whether the `<select>` is rendered. When it is not, `selectedPlant`
   is pinned to `access.plant` and there is no setter — a plant user's scope is not a control they
   could move.
-- `plantPinned` (the same distinction) also switches the **pipeline** stages onto the plant-scoped
-  arrays. #121 deliberately left those reading the raw register for an admin, and that is unchanged;
-  a plant user's stages read only their plant's rows, and Coil Inward registers against their plant
-  with nothing to pick. Because `filterByPlant` matches the stored value exactly, a legacy row whose
-  plant is **blank** is `Unattributed` and so invisible to a plant user in those stages — deliberate
-  (a row that cannot say where it sits is not one plant's to claim), and it makes backfilling such
-  rows an admin's job, from the All Plants view where they still appear.
+- `plantPinned` (the same distinction) also gives the **pipeline** stages a `viewPlant`. They keep
+  receiving the RAW stores — as #121 and #124 left them — and each scopes only what it puts on
+  screen; Coil Inward additionally registers against the user's plant with nothing to pick. The
+  arrays themselves are never filtered on the way in, and that is load-bearing rather than stylistic:
+  Slitting writes by replacing the whole array (`setBabyCoils(updated)`, not the functional form), so
+  a filtered prop would have made every unseen row look deleted to `syncToSupabase` — a **hard**
+  delete on `baby_coils`; and the cross-stage guards ("consumed by *any* production", the duplicate
+  `hrCoilId`, `nextCoilNumber`) are only true against the whole register. **Display scopes; state and
+  guards do not.** A consequence: a legacy blank-plant row is `Unattributed` and so not listed for a
+  plant user, which makes backfilling an admin's job — from the All Plants view where it still shows.
 
 **This is not a data boundary.** Every table keeps its permissive row-level policy and the app's
 public key still reaches every plant's rows. It hides another plant's screens from an operator who

--- a/docs/UI-PATTERNS.md
+++ b/docs/UI-PATTERNS.md
@@ -81,16 +81,25 @@
   Reports** receive the scoped arrays; **Coil Inward, Slitting, Production and SKU Master** keep
   receiving the raw, unfiltered store arrays **for an admin** — nothing in those four components
   changed for ticket #121, because they never saw a filtered prop.
-  - **Ticket #126 splits that by who is signed in.** `plantPinned` (a plant user — no selector, the
-    plant is their login) switches the three stages onto `pipelineCoils`/`BabyCoils`/`Productions`/
-    `Dispatches`, which are the scoped arrays. An admin's stages are unchanged. **Consequence worth
-    knowing:** `filterByPlant` matches the stored value exactly, so a legacy row with a **blank**
-    plant (registered before #120, never backfilled) is `Unattributed` and therefore invisible to a
-    plant user in those stages. That is deliberate — a row that does not say where it sits cannot be
-    shown to one plant as theirs — but it means **backfilling those rows is an admin's job**, done
-    from the All Plants view where they are still visible.
-  - **Production is the one exception, added in #124.** It still receives the **raw** arrays, and it
-    receives the selector's value as `operatingPlant` so it can scope them **itself**. It has to: the scope of
+  - **Ticket #126 scopes what the stages SHOW, and nothing else.** All three keep receiving the raw
+    stores; each takes a `viewPlant` prop (null for an admin, the user's own plant when pinned to
+    their login) and filters only its own table, export and pickers. **Never filter the array you
+    hand a stage** — the first cut of #126 did, and it was wrong twice over:
+    - **Writes.** Slitting builds its next array from the `babyCoils` prop and calls
+      `setBabyCoils(updated)` outright, not `setBabyCoils(prev => …)`. A filtered prop makes `next` a
+      strict subset of `prev`, and `syncToSupabase` reads every id in prev-but-not-next as a
+      deletion — on `baby_coils`, a **hard** one. One plant user saving one baby coil would have
+      permanently deleted every other plant's. `e2e/roles.spec.js` now asserts no DELETE is ever
+      issued on that flow.
+    - **Guards.** "A baby coil consumed by **any** production cannot be deleted", the duplicate
+      `hrCoilId` check and `nextCoilNumber` are only true against the WHOLE register. The sharpest
+      case is a legacy blank-plant row: `genHRCoilId` gives it an `HYD-` id, so it is exactly what a
+      new Hyderabad coil collides with — and exactly what a scoped array hides.
+    - So: **display scopes, state and guards do not.** A prop that reaches a setter or a guard stays
+      whole. `Unattributed` rows therefore still appear to an admin, which is who backfills them.
+  - **Production was the first to work this way, in #124** — and since #126 all three stages do. It
+    receives the **raw** arrays plus the selector's value as `operatingPlant`, and scopes them
+    **itself**; `viewPlant` scopes only its Production Records table. It has to: the scope of
     a batch being edited is *that record's* plant, not the header's, so a filtered prop would hide the
     very coils the record already consumed. See the ticket #124 section below.
   - Two exceptions inside the scoped tabs, both deliberate: Orders' `replaceOrders`/
@@ -101,7 +110,11 @@
     plant, and the acceptance criterion is that scoping the header doesn't touch them.
 - The header's former hardcoded "Inventory Management — Hyderabad" now reads
   `plantFilterOptions().find(o => o.id === selectedPlant)?.name` — "All Plants", a plant's short name,
-  or "Unattributed".
+  or "Unattributed". Since #126 the **fallback** matters too: an admin's value always comes from the
+  options, but a plant user's comes from their credential row and may match no plant master row, and
+  falling back to "All Plants" there would tell someone scoped to nothing that they see everything.
+  An unmatched pinned id shows **the id itself** — wrong-looking, which it is, and it names the value
+  to correct.
 
 ### Two things a plant filter must change, because scoping changes their meaning
 A filter is a way of **looking** at data. Where scoping would make an existing figure or action mean

--- a/e2e/roles.spec.js
+++ b/e2e/roles.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { signIn, stubSignIn, LOGINS } from './signin'
+import { signIn, stubSignIn, writeRecorder, LOGINS } from './signin'
 
 // E2E for ticket #126 — role and plant decide what a user sees.
 //
@@ -157,6 +157,76 @@ test.describe('the session', () => {
     await page.getByLabel('Password').fill('wrong')
     await page.getByRole('button', { name: 'Sign in' }).click()
     await expect(page.getByText('Invalid login ID or password.')).toBeVisible()
+  })
+})
+
+test.describe('a plant user never writes over another plant', () => {
+  // The regression this exists for: the stages were briefly handed PLANT-FILTERED arrays. Slitting
+  // builds its next array from that prop and calls `setBabyCoils(updated)` outright, so every row
+  // the user could not see looked deleted to the sync — and `baby_coils` is a HARD-delete table.
+  // One plant user saving one baby coil would have permanently destroyed every other plant's.
+  //
+  // It is invisible on screen (the rows it removes are ones this user cannot see anyway), so the
+  // assertion is on the WRITES the app sends, not on the DOM.
+  const NPMD_BABY = {
+    id: 'seed-npmd-baby', baby_coil_id: 'NPM-0826-01-A', hr_coil_id: 'NPM-0826-01',
+    plant: 'npmd', date_of_conversion: '2026-08-01', width: 100, thickness: 2.5, weight: 5,
+    baby_coil_entry: 'A', deleted: false,
+  }
+  const NPMD_COIL = {
+    id: 'seed-npmd-coil', hr_coil_id: 'NPM-0826-01', hr_coil_no: 1, plant: 'npmd',
+    date_of_inward: '2026-08-01', thickness: 2.5, width: 150, actual_weight: 10, deleted: false,
+  }
+
+  test('slitting as hyderabad never deletes NPMD baby coils', async ({ page }) => {
+    const { writes, settle, onRequest } = writeRecorder()
+    await signIn(page, 'hyderabad', { rows: { baby_coils: [NPMD_BABY], coils: [NPMD_COIL] }, onRequest })
+
+    // Register a Hyderabad mother, then slit it — the exact flow that triggered the bug.
+    await tab(page, '1. Coil Inward').click()
+    await page.getByRole('button', { name: '+ Add Coil' }).click()
+    const inputFor = (label) => page.locator('label', { hasText: label }).locator('xpath=following-sibling::input[1]')
+    await inputFor('Thickness (mm)').fill('2.5')
+    await inputFor('Width (mm)').fill('150')
+    await inputFor('Actual Weight (T)').fill('10')
+    await page.getByRole('button', { name: 'Save Coil' }).click()
+
+    // NPMD's coil is not on this user's register…
+    await expect(page.getByText('NPM-0826-01', { exact: true })).toHaveCount(0)
+    const coilId = await page.locator('table tbody tr').first().locator('td').first().innerText()
+    expect(coilId).toMatch(/^HYD-/)
+
+    await tab(page, '2. Slitting').click()
+    await page.getByRole('button', { name: '+ Add Baby Coil' }).click()
+    const search = page.locator('label', { hasText: 'HR Coil ID' }).locator('xpath=following-sibling::div[1]//input')
+    await search.click()
+    await search.fill(coilId)
+    await page.getByRole('button', { name: coilId }).first().click()
+    await page.locator('label', { hasText: 'Width (mm)' }).locator('xpath=following-sibling::input[1]').first().fill('100')
+    await page.getByRole('button', { name: /Save 1 Baby Coil/ }).click()
+    await expect(page.locator('table').getByText(`${coilId}-A`, { exact: false }).first()).toBeVisible()
+
+    // Guard against a vacuous pass: if the recorder saw nothing, the assertions below prove nothing.
+    // Registering and slitting a coil must have produced writes.
+    await settle(page)
+    expect(writes.length, 'the recorder observed no writes at all — the stub is not wired up').toBeGreaterThan(0)
+
+    // …and nothing this user did may remove it. Any DELETE at all on these tables is the bug.
+    const destructive = writes.filter(w => w.method === 'DELETE' && /baby_coils|\/coils/.test(w.url))
+    expect(destructive, `unexpected deletes: ${JSON.stringify(destructive, null, 2)}`).toEqual([])
+    // Belt and braces: the seeded id must never appear in any write the app sent.
+    const mentionsNpmd = writes.filter(w => w.url.includes('seed-npmd') || w.body.includes('seed-npmd'))
+    expect(mentionsNpmd, `NPMD rows touched: ${JSON.stringify(mentionsNpmd, null, 2)}`).toEqual([])
+  })
+
+  test('the mother-coil picker offers only their own plant', async ({ page }) => {
+    await signIn(page, 'hyderabad', { rows: { coils: [NPMD_COIL] } })
+    await tab(page, '2. Slitting').click()
+    await page.getByRole('button', { name: '+ Add Baby Coil' }).click()
+    const search = page.locator('label', { hasText: 'HR Coil ID' }).locator('xpath=following-sibling::div[1]//input')
+    await search.click()
+    await search.fill('NPM')
+    await expect(page.getByRole('button', { name: /NPM-0826-01/ })).toHaveCount(0)
   })
 })
 

--- a/e2e/signin.js
+++ b/e2e/signin.js
@@ -39,17 +39,59 @@ const REST = '**/rest/v1/**'
 // Writes are answered as accepted, so nothing here re-reads the table mid-flow. That matters more
 // than it looks: a REJECTED write makes the store re-pull to stop showing rows Postgres refused,
 // and a re-pull against an empty table would throw away the very coil the test just registered.
-async function stubTables(page) {
+async function stubTables(page, { rows = {}, onRequest = null } = {}) {
   await page.route(REST, route => {
-    if (route.request().url().includes('/rpc/')) return route.fallback()
-    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    const request = route.request()
+    const url = request.url()
+    if (url.includes('/rpc/')) return route.fallback()
+    if (onRequest) onRequest(request)
+    // `rows` seeds a table by name — `{ baby_coils: [...] }` — so a test can start with data that
+    // did not come from the UI, which is the only way to have ANOTHER plant's rows present.
+    const table = url.split('/rest/v1/')[1]?.split('?')[0] || ''
+    const body = request.method() === 'GET' ? JSON.stringify(rows[table] || []) : '[]'
+    return route.fulfill({ status: 200, contentType: 'application/json', body })
   })
+}
+
+// Record every write the app sends, so a test can assert on what it did NOT do. A destructive sync
+// is invisible on screen — the row it removes is one this user could not see anyway — so the
+// request log is the only place that bug is observable.
+//
+// It deliberately does NOT install a route of its own. Playwright runs the most recently registered
+// matching handler first, so a recorder registered before `signIn` would be shadowed by the stub
+// `signIn` installs and would quietly record nothing — a test that passes because it observed
+// nothing at all. Pass the returned `onRequest` INTO `signIn` instead, so there is one handler.
+export function writeRecorder() {
+  const writes = []
+  // The sync is asynchronous and ORDERED: syncToSupabase awaits its upsert before it issues any
+  // delete. So the moment a saved row appears on screen, the destructive half of that same sync has
+  // not been sent yet — asserting there would pass while the bug is live. Wait for the traffic to
+  // stop instead.
+  const settle = async (page, quietMs = 700, timeoutMs = 6000) => {
+    const started = Date.now()
+    let seen = -1
+    let lastChange = Date.now()
+    while (Date.now() - started < timeoutMs) {
+      if (writes.length !== seen) { seen = writes.length; lastChange = Date.now() }
+      else if (Date.now() - lastChange >= quietMs) return
+      await page.waitForTimeout(100)
+    }
+  }
+  return {
+    writes,
+    settle,
+    onRequest: (req) => {
+      const method = req.method()
+      if (method === 'GET' || method === 'HEAD') return
+      writes.push({ method, url: req.url(), body: req.postData() || '' })
+    },
+  }
 }
 
 // Stand in for the sign-in RPC. `rows` decides the answer: a credential row for a correct
 // sign-in, `[]` for a wrong password.
-export async function stubSignIn(page, rows) {
-  await stubTables(page)
+export async function stubSignIn(page, rows, opts = {}) {
+  await stubTables(page, opts)
   await page.route(RPC, route => route.fulfill({
     status: 200,
     contentType: 'application/json',
@@ -59,10 +101,10 @@ export async function stubSignIn(page, rows) {
 
 // Open the app and sign in as one of the three logins. Returns once the tab bar is on screen, so
 // a caller can go straight to clicking tabs exactly as the specs did before the gate existed.
-export async function signIn(page, who = 'admin', { password = 'correct-horse' } = {}) {
+export async function signIn(page, who = 'admin', { password = 'correct-horse', ...opts } = {}) {
   const row = LOGINS[who]
   if (!row) throw new Error(`No such test login: ${who}`)
-  await stubSignIn(page, [row])   // installs the table stub too
+  await stubSignIn(page, [row], opts)   // installs the table stub too
   await page.goto('/')
   await page.getByLabel('Login ID').fill(row.login_id)
   await page.getByLabel('Password').fill(password)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -453,7 +453,13 @@ function DataTable({ columns, data, actions, onEdit, onDelete, onRowClick, highl
 // a coil arriving there is not a question to put to them. An admin passes null and keeps the picker.
 // It changes only what is OFFERED — the stored value and the "set once at inward" rule below are
 // untouched, and an edit still shows the plant already recorded.
-function CoilInward({ coils, setCoils, dispatches, productions, babyCoils, operatingPlant = null }) {
+// `viewPlant` (ticket #126) scopes what this screen SHOWS. Everything else — the duplicate-id
+// check, the next coil number, and the delete guards — deliberately keeps reading the full `coils`,
+// `babyCoils` and `productions`: a guard that cannot see the whole register is not a guard. The
+// sharpest case is a legacy row whose plant is blank, since `genHRCoilId` gives it an `HYD-` id, so
+// it is precisely what a new Hyderabad coil would collide with and precisely what a scoped array
+// would have hidden.
+function CoilInward({ coils, setCoils, dispatches, productions, babyCoils, operatingPlant = null, viewPlant = null }) {
   const emptyForm = { dateOfInward: today(), plant: operatingPlant || DEFAULT_COIL_PLANT, hrCoilNo: '', inputCoilNumber: '', coilGrade: '', heatNumber: '', thickness: '', width: '', length: '', invoiceWeight: '', actualWeight: '', poNumber: '' }
   const [form, setForm] = useState(emptyForm)
   const [editId, setEditId] = useState(null)
@@ -468,6 +474,9 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils, opera
   }, [form.dateOfInward, form.hrCoilNo, nextNo, editId, form.plant])
 
   const isDupe = useMemo(() => coils.some(c => c.hrCoilId === hrCoilId && c.id !== editId), [coils, hrCoilId, editId])
+
+  // The register as this user sees it. Display only — never fed to a guard or a setter.
+  const shownCoils = useMemo(() => (viewPlant ? filterByPlant(coils, viewPlant) : coils), [coils, viewPlant])
 
   const save = () => {
     const no = form.hrCoilNo || nextNo
@@ -528,7 +537,7 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils, opera
 
   const downloadCoilsCSV = () => {
     const header = ['HR Coil ID', 'Date', 'Plant', 'Input Coil #', 'Grade', 'Thickness (mm)', 'Width (mm)', 'Invoice Wt (T)', 'Actual Wt (T)', 'Dispatched Wt (T)']
-    downloadCSV(`coil-inward-${today()}.csv`, header, coils.filter(c => !c.deleted).map(r => {
+    downloadCSV(`coil-inward-${today()}.csv`, header, shownCoils.filter(c => !c.deleted).map(r => {
       const s = getCoilStats(r)
       return [r.hrCoilId, r.dateOfInward, plantLabel(r.plant), r.inputCoilNumber, r.coilGrade, r.thickness, r.width, fmtT3(r.invoiceWeight), fmtT3(r.actualWeight), fmtT3(s.dispatchedWt)]
     }))
@@ -582,7 +591,7 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils, opera
       )}
 
       <Section title="Registered Coils">
-        <DataTable columns={columns} data={coils} onEdit={startEdit} onDelete={softDelete} />
+        <DataTable columns={columns} data={shownCoils} onEdit={startEdit} onDelete={softDelete} />
       </Section>
     </div>
   )
@@ -591,7 +600,12 @@ function CoilInward({ coils, setCoils, dispatches, productions, babyCoils, opera
 // ═══════════════════════════════════════════════════════════════
 // STAGE 2: SLITTING — mother coil → baby coils (manual; proportional weight/cost by width)
 // ═══════════════════════════════════════════════════════════════
-function Slitting({ coils, babyCoils, setBabyCoils, productions }) {
+// `viewPlant` (ticket #126) scopes the mother-coil picker and the baby-coil table. It must NOT
+// reach `babyCoils` itself: `save` builds its next array from that prop and calls `setBabyCoils`
+// with the whole thing, so a filtered prop would make every row it could not see look deleted —
+// and `baby_coils` is hard-deleted. Same for `productions`, which answers "has any production
+// consumed this baby coil" and has to mean *any*.
+function Slitting({ coils, babyCoils, setBabyCoils, productions, viewPlant = null }) {
   const emptyForm = { dateOfConversion: today(), hrCoilId: '' }
   const [form, setForm] = useState(emptyForm)
   // Multiple baby-coil rows entered against one mother coil, saved together. Each row carries a
@@ -740,7 +754,10 @@ function Slitting({ coils, babyCoils, setBabyCoils, productions }) {
   }
 
   const coilOptions = useMemo(() => {
-    return coils.filter(c => {
+    // Scoped for display: a plant user is offered only their own plant's mothers. The eligibility
+    // rules below are unchanged and still read the full `babyCoils`, so a mother's remaining width
+    // is computed from every baby coil cut from it, not just the ones this user can see.
+    return (viewPlant ? filterByPlant(coils, viewPlant) : coils).filter(c => {
       if (c.deleted) return false
       if (editId && c.hrCoilId === form.hrCoilId) return true
       const childWidths = babyCoils
@@ -752,7 +769,7 @@ function Slitting({ coils, babyCoils, setBabyCoils, productions }) {
       value: c.hrCoilId,
       label: `${c.hrCoilId} (W:${c.width}mm, ${fmtT3(c.actualWeight)}T)`
     }))
-  }, [coils, babyCoils, editId, form.hrCoilId])
+  }, [coils, babyCoils, editId, form.hrCoilId, viewPlant])
 
   // Group display: for each parent, show width sum check
   const parentGroups = useMemo(() => {
@@ -786,8 +803,11 @@ function Slitting({ coils, babyCoils, setBabyCoils, productions }) {
       const now = new Date()
       cutoff = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`
     }
-    return babyCoils.filter(b => b.dateOfConversion >= cutoff)
-  }, [babyCoils, dateFilter, customFrom, customTo])
+    // `viewPlant` scopes what is LISTED. `babyCoils` itself stays whole for the writes and the
+    // guards above — see the note on this component.
+    const visible = viewPlant ? filterByPlant(babyCoils, viewPlant) : babyCoils
+    return visible.filter(b => b.dateOfConversion >= cutoff)
+  }, [babyCoils, dateFilter, customFrom, customTo, viewPlant])
 
   // Dedicated Baby Coil ID search, layered on top of the date filter (composes with DataTable's
   // own generic + per-column search, which run on whatever `data` we pass it).
@@ -970,7 +990,11 @@ function Slitting({ coils, babyCoils, setBabyCoils, productions }) {
 // ═══════════════════════════════════════════════════════════════
 // STAGE 3: PRODUCTION — tube production, FIFO-consumes BABY coils
 // ═══════════════════════════════════════════════════════════════
-function Production({ coils, babyCoils, productions, setProductions, dispatches, skus, operatingPlant }) {
+// `viewPlant` (ticket #126) scopes the Production Records table. The allocation pickers are NOT
+// scoped by it — they follow `targetPlant` (ticket #124), which is the batch's own plant and is the
+// stricter, better rule. `productions` stays whole so a record's edit still resolves and the guards
+// below still see every batch.
+function Production({ coils, babyCoils, productions, setProductions, dispatches, skus, operatingPlant, viewPlant = null }) {
   const emptyForm = { dateOfProduction: today(), skuCode: '', tubeCount: '' }
   const [form, setForm] = useState(emptyForm)
   const [editId, setEditId] = useState(null)
@@ -990,6 +1014,9 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
   // A record storing blank (an unallocated batch, or a legacy row) has no plant of its own to
   // keep, so it falls through too — a blank is nothing to preserve, not a third scope. Selecting
   // Unattributed IS a real scope (coils with no plant recorded) and survives.
+  // Display only — never fed to a guard, a setter, or the allocation pickers.
+  const shownProductions = useMemo(() => (viewPlant ? filterByPlant(productions, viewPlant) : productions), [productions, viewPlant])
+
   const editingProduction = useMemo(() => editId ? productions.find(p => p.id === editId) : null, [editId, productions])
   const targetPlant = editingProduction?.plant || operatingPlant
   // ALL_PLANTS is the one value that is not a plant — it would mean "offer every plant's baby
@@ -1362,7 +1389,7 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
       )}
 
       <Section title="Production Records">
-        <DataTable columns={columns} data={productions} onEdit={startEdit} onDelete={softDelete} />
+        <DataTable columns={columns} data={shownProductions} onEdit={startEdit} onDelete={softDelete} />
       </Section>
     </div>
   )
@@ -2828,7 +2855,7 @@ function RegionCell({ state, region, onCommit, disabled }) {
   )
 }
 
-function SalesDashboard({ orders, dispatches, skus, productions = [], estimates = [], setEstimates = null, stateRegions = [], setStateRegions = null, selectedPlant = ALL_PLANTS }) {
+function SalesDashboard({ orders, dispatches, skus, productions = [], estimates = [], setEstimates = null, stateRegions = [], setStateRegions = null, selectedPlant = ALL_PLANTS, canWiden = true }) {
   const skuDesc = useCallback((code) => skus.find(s => s.skuCode === code)?.description || code, [skus])
 
   // ── Best Estimate under a plant filter (ticket #121) ──────────────────────────────────────────
@@ -2847,7 +2874,10 @@ function SalesDashboard({ orders, dispatches, skus, productions = [], estimates 
   // show the gap, never paper over it with a number that looks fine and is not.
   const plantScoped = selectedPlant !== ALL_PLANTS
   const plantScopeName = plantLabel(selectedPlant)
-  const beScopeNote = `Best Estimate is company-wide (never split by plant), so it cannot be measured against ${plantScopeName}'s invoiced tonnage alone. Switch to All Plants to see achievement.`
+  // The closing sentence names a control only an admin has — a plant user cannot switch to All
+  // Plants, so telling them to is telling them to do something impossible (the same fix Dispatch's
+  // filter note carries as `canWiden`).
+  const beScopeNote = `Best Estimate is company-wide (never split by plant), so it cannot be measured against ${plantScopeName}'s invoiced tonnage alone. ${canWiden ? 'Switch to All Plants to see achievement.' : 'Achievement against it is read on the All Plants view.'}`
 
   const todayStr = today()
   const curMonth = todayStr.slice(0, 7)
@@ -3361,22 +3391,26 @@ function InventoryApp({ session, onLogout }) {
     return access.plantSelector ? 'All Plants' : selectedPlant
   }, [selectedPlant, access.plantSelector])
 
-  // ── What the PIPELINE stages read (ticket #126) ──
-  // #121 deliberately left Coil Inward / Slitting / Production reading the raw register: an admin
-  // registers and slits coils regardless of what the header selector happens to be showing, and
-  // moving the selector must not hide the coil in front of them. That stays exactly as it was.
+  // ── What the PIPELINE stages SHOW (ticket #126) ──
+  // A plant user's plant is not a view they chose, it is where they are, so the stages must not
+  // show them another plant's coils. But the stages are NOT handed filtered arrays to achieve it,
+  // and the distinction is load-bearing rather than stylistic:
   //
-  // A plant user is a different case, and not a stricter version of the same one: their plant is
-  // not a view they chose, it is where they are, and there is no selector for them to move. So the
-  // stages read their plant's rows and only those. `plantPinned` is that distinction — the plant
-  // comes from the login rather than from a control — and it is the ONE place it is decided.
+  //   * They WRITE through the store setter. Slitting builds its next array from the prop and calls
+  //     `setBabyCoils(updated)` outright, so a filtered prop makes `next` a strict subset of `prev`
+  //     — and syncToSupabase reads every id in prev-but-not-next as a deletion. `baby_coils` is a
+  //     HARD-delete table. One plant user saving one baby coil would have permanently deleted every
+  //     other plant's.
+  //   * They GUARD across stages. "A baby coil consumed by any production cannot be deleted", the
+  //     duplicate-coil-id check, and the next-coil-number all have to see the WHOLE register to be
+  //     true. Narrow the input and the guard silently stops guarding — worst for a legacy row whose
+  //     plant is blank, which is exactly the row a duplicate HYD- id would collide with.
+  //
+  // So the stages keep receiving the raw stores, exactly as #121 and #124 left them, and each one
+  // scopes only what it puts ON SCREEN. `viewPlant` is that scope: null for an admin (show the
+  // whole register), the user's own plant when it is pinned to their login.
   const plantPinned = !access.plantSelector
-  const pipelineCoils = plantPinned ? plantCoils : coils
-  const pipelineBabyCoils = plantPinned ? plantBabyCoils : babyCoils
-  const pipelineProductions = plantPinned ? plantProductions : resolvedProductions
-  // Dispatches feed Production's "already dispatched" guards; scoping them for a plant user keeps
-  // that guard reading the same set of records the rest of their app does.
-  const pipelineDispatches = plantPinned ? plantDispatches : dispatches
+  const viewPlant = plantPinned ? selectedPlant : null
 
   // Dark mode
   useEffect(() => {
@@ -3464,17 +3498,17 @@ function InventoryApp({ session, onLogout }) {
       <main className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         {tab === 'dashboard' && <Dashboard coils={plantCoils} productions={plantProductions} dispatches={plantDispatches} skus={skus} babyCoils={plantBabyCoils} orders={plantOrders} />}
         {tab === 'coilTracker' && <CoilTracker coils={plantCoils} productions={plantProductions} dispatches={plantDispatches} babyCoils={plantBabyCoils} />}
-        {tab === 'coilInward' && <CoilInward coils={pipelineCoils} setCoils={setCoils} dispatches={pipelineDispatches} productions={pipelineProductions} babyCoils={pipelineBabyCoils}
-          operatingPlant={plantPinned ? selectedPlant : null} />}
-        {tab === 'slitting' && <Slitting coils={pipelineCoils} babyCoils={pipelineBabyCoils} setBabyCoils={setBabyCoils} productions={pipelineProductions} />}
+        {tab === 'coilInward' && <CoilInward coils={coils} setCoils={setCoils} dispatches={dispatches} productions={resolvedProductions} babyCoils={babyCoils}
+          operatingPlant={plantPinned ? selectedPlant : null} viewPlant={viewPlant} />}
+        {tab === 'slitting' && <Slitting coils={coils} babyCoils={babyCoils} setBabyCoils={setBabyCoils} productions={resolvedProductions} viewPlant={viewPlant} />}
         {/* Production reads the RAW stores and scopes them itself (ticket #124): its plant filter is
             the batch's own plant — the operating plant for a new one, the record's stored plant when
             editing — so opening another plant's record never hides the coils it already consumed.
             The selector doubles as the operating plant until phase 3 puts it on the login, so it is
             passed under that name rather than as `selectedPlant`: inside Production it answers
             "which plant am I working as", not "which plant am I looking at". */}
-        {tab === 'production' && <Production coils={pipelineCoils} babyCoils={pipelineBabyCoils} productions={pipelineProductions} setProductions={setProductions} dispatches={pipelineDispatches} skus={skus}
-          operatingPlant={selectedPlant} />}
+        {tab === 'production' && <Production coils={coils} babyCoils={babyCoils} productions={resolvedProductions} setProductions={setProductions} dispatches={dispatches} skus={skus}
+          operatingPlant={selectedPlant} viewPlant={viewPlant} />}
         {tab === 'dispatch' && <Dispatch dispatches={plantDispatches} setDispatches={setDispatches} coils={plantCoils} skus={skus}
           plantScoped={selectedPlant !== ALL_PLANTS} canWiden={access.plantSelector} />}
         {tab === 'skuMaster' && <SKUMaster skus={skus} setSkus={setSkus} productions={productions} readOnly={isReadOnly('skuMaster')} />}
@@ -3491,7 +3525,7 @@ function InventoryApp({ session, onLogout }) {
         {tab === 'sales' && <SalesDashboard orders={plantOrders} dispatches={plantDispatches} skus={skus} productions={plantProductions}
           estimates={distributorEstimates} setEstimates={setDistributorEstimates}
           stateRegions={stateRegions} setStateRegions={setStateRegions}
-          selectedPlant={selectedPlant} />}
+          selectedPlant={selectedPlant} canWiden={access.plantSelector} />}
         {/* Reports follows the selector too (#121). `estimates`/`stateRegions` stay unfiltered for
             the same reason as Sales — neither carries a plant. A scoped workbook announces itself
             in its sheet titles and file name; see the Reports component. */}


### PR DESCRIPTION
Follow-up to #138, which is already merged. **This fixes a data-loss bug that #138 introduced and that is live on `main` now.**

## The bug

`#138` scoped the pipeline stages by handing them plant-**filtered** arrays. `Slitting.save` builds its next array from the `babyCoils` prop and calls `setBabyCoils(updated)` — not `setBabyCoils(prev => …)`:

```js
updated = [...babyCoils, ...newRecords]   // babyCoils = the FILTERED prop
setBabyCoils(updated)                     // replaces the whole store
```

`syncToSupabase` treats every id in `prev` but not `next` as a deletion, and `baby_coils` is in `HARD_DELETE_TABLES`:

```js
const toDelete = [...prevIdSet].filter(id => !nextIds.has(id))
await supabase.from(tableName).delete().in('id', batch)
```

**So one Hyderabad operator saving one baby coil permanently deletes every NPMD baby coil**, plus every `Unattributed` one. `CoilInward`, `Production` and `Dispatch` use the functional setter and were unaffected — which is why two of the three stages tolerated the same change and the problem stayed hidden.

The same filtering also silently disarmed the cross-stage guards: *"a baby coil consumed by **any** production cannot be deleted"*, the duplicate `hrCoilId` check, and `nextCoilNumber` are only true against the whole register. The sharpest case is a legacy blank-plant row — `genHRCoilId` gives it an `HYD-` id, so it is exactly what a new Hyderabad coil collides with, and exactly what the scoped array hid.

## The fix

The stages go back to receiving the **raw** stores, as #121 and #124 left them. Each takes a `viewPlant` that scopes only what it puts on screen — Coil Inward's register and export, Slitting's mother picker and baby-coil table, Production's records table.

**Display scopes; state and guards do not.** Production's allocation pickers keep following `targetPlant` (#124), which is stricter and better.

## The regression test took three attempts to be real

It passed with the defect deliberately reintroduced — twice — before it worked:

1. **Route shadowing.** The recorder registered its own `page.route` before `signIn` registered the stub. Playwright runs the most recently registered handler first, so the recorder never fired and `writes` was always `[]` — every assertion on it vacuously true. Now `onRequest` is passed *into* `signIn` (one handler), and the test asserts it observed writes at all.
2. **Ordering.** `syncToSupabase` awaits its upsert *before* issuing any delete, so when the saved row appears on screen the destructive half of that sync has not been sent. Added a `settle()` that waits for the traffic to stop.

Only on the third attempt did it go red on the bug. It asserts at the **network layer** because nothing on screen can show this — the rows destroyed are precisely the ones the user cannot see.

`e2e/signin.js` gains `rows` (seed a table with data that did not come from the UI — the only way to have another plant's rows present) and `writeRecorder()`.

## Also in here

- **Sales** still ended its Best Estimate note with *"Switch to All Plants to see achievement"* — the same impossible instruction `canWiden` fixed on Dispatch in #138, missed one screen over.
- Three doc corrections: `UI-PATTERNS.md` still called Production "the one exception" that takes raw arrays and still described the old header fallback; `TESTING.md` undercounted the specs.

## Verification

400 unit tests, 31 E2E tests, `npm run build` clean — all re-run after rebasing onto merged `main`.

Found by the second `/code-review` round (Spec axis found the delete, Standards axis found the guard narrowing). Neither was visible from the app's own screens.

---
_Generated by [Claude Code](https://claude.ai/code/session_0115Jij4CxaLDQsZpQM23yLo)_