### PR TITLE
Plant service areas: store which regions each plant ships to

### DIFF
--- a/.claude/skills/pb-mtd-report/SKILL.md
+++ b/.claude/skills/pb-mtd-report/SKILL.md
@@ -48,6 +48,12 @@ These figures must reproduce the app's own KPIs (`src/lib/calc.js`, `src/lib/rep
   stored `productions.total_weight`. The app does this on every view via `resolveProductionWeights`
   (`App.jsx:2758`) so a corrected master weight flows through. Summing stored `total_weight`
   overstates it whenever the master's `weightPerTube` changed after a production was saved.
+- **Physical Inventory is the COMPANY's stock and is deliberately NOT split by service area.** The
+  workbook's per-distributor **Free Stock (area)** is (ticket #129, ADR-0006): a distributor is only
+  shown the stock of the plants that serve its region — Hyderabad + Lepakshi serve South, NPMD +
+  Tapi serve West. The two are different questions and must not be reconciled against each other.
+  Today every production row is Hyderabad's, so the whole of Physical Inventory sits in South's pool
+  and every West distributor's Free Stock is blank — that is the true position, not a gap.
 
 ## Steps
 
@@ -386,3 +392,10 @@ Pending to Serve by Plant - All Plants --->	2615.4T
   ship-to state, and all three are pipeline figures this report does not break down.
 - **Never scope this report to one plant.** The All Plants totals are the headline and do not move;
   the split explains them. A per-plant edition of the workbook is explicitly out of scope (#117).
+- **Never reconcile Physical Inventory against the Distributor × SKU sheet's Free Stock.** Since
+  #129 that column is the distributor's **service area's** stock, not the company's, and a West row
+  reading blank beside a company total of 1,857 T is correct. Summing the column was already
+  forbidden (ADR-0002); comparing it to the headline is the same mistake in a new place.
+- **Never report a `?` in a stock column as zero.** It means the distributor's state carries no
+  region, so no service area can be derived — a labelling gap to fix on the Sales tab, not a fact
+  about stock.

--- a/.claude/skills/servable-orders-whatsapp/SKILL.md
+++ b/.claude/skills/servable-orders-whatsapp/SKILL.md
@@ -30,44 +30,53 @@ and the message start to disagree (ADR-0003).
 
 ## The three rules this report exists to respect
 
-**1 — There is no plant total, and there must never be one.** On-hand is the whole plant's and is
-reserved to nobody (ADR-0002). The same tonnage legitimately appears against every distributor
-waiting on that size, so the servable column does not add up. On 18-Aug-2026, `50x50x2.0 SHS` had
-39.3 T on the floor with 88.0 T queued against it across six distributors, and each read its full
-pending as servable. Per-distributor totals are real; a plant total would be fiction — the identical
-total ADR-0002 suppressed on the workbook's Distributor × SKU sheet. A `⚠️` marks a size ordered for
-more than the plant holds.
+**1 — There is no plant total, and there must never be one.** Inside a service area, on-hand is
+shared and reserved to nobody (ADR-0002). The same tonnage legitimately appears against every
+distributor in that area waiting on that size, so the servable column does not add up. On
+18-Aug-2026, `50x50x2.0 SHS` had 39.3 T on the floor with 88.0 T queued against it, and each
+distributor read its full pending as servable. Per-distributor totals are real; a plant total would
+be fiction — the identical total ADR-0002 suppressed on the workbook's Distributor × SKU sheet. A
+`⚠️` marks a size ordered for more than its area holds.
 
-**2 — The plant cannot ship everywhere.** The service area is **not in the data model**: plants are
-attributed (#118) but nothing records where each one ships, so it is a business rule that has to be
-passed in, and today it is **South only**. It is applied with `--serves South`, which filters the
-**order book before any stock maths**, so `allPending`, Free Stock and the contested flag all
-recompute against demand this plant can actually serve. Filtering the *output* instead would leave
-South sizes reading "contested" because of West orders that were never competing for this stock.
+**2 — A distributor is only offered stock from plants that serve its region (#129, ADR-0006).** This
+is now automatic and unconditional, in `salesByDistributor`, and it comes off the **plant master**:
+Hyderabad and Lepakshi serve South, NPMD and Tapi serve West. Every one of the script's figures is
+already scoped that way before you pass any flag.
 
-**3 — The message names the floor it is counting (#128).** `🏭 Stock made at: Hyderabad` in the
-header, read off the `plant` on the production rows via `plantNamesIn` — never typed, never assumed.
-Until four plants were attributed, "the plant" could go unnamed without lying; now an unnamed floor is
-a claim, and a wrong one.
+`--serves South` is a **different** control and still worth passing: it narrows the ORDER BOOK, so
+the message lists the South sales team's own distributors instead of the national book. It chooses
+the audience; the plant master chooses the stock. The tonnage it excludes is still stated (`📍 South
+only`, plus the out-of-area line) rather than dropped.
 
-It says **made at**, not *held at*, and the difference is load-bearing: on-hand is produced − invoiced
-across all plants for a size, and nothing attributes the surviving tonnage back to a floor. A plant
-that made stock and has since shipped every tonne is still named. Naming who made what this report
-counts is true; claiming to know where each tonne now sits is not.
+> Today that means a West distributor's servable tonnage is **zero**, because no plant serving West
+> has produced anything. The message says so outright — `⚠️ No stock for West — no plant serving it
+> has produced any` — because a list of zeros otherwise reads as an outage. It fills itself in the
+> day NPMD produces. Do **not** "fix" it by widening the pool.
 
-> **Known limit — several floors, one on-hand.** If the stock spans more than one plant the header
-> says so (`🏭 Stock made at: Hyderabad + NPMD — combined, not split by plant`) and a `⚠️` footer warns
-> that a size may be sitting at a different plant from the distributor waiting on it. That is a
-> **statement, not a fix**: on-hand is still summed across plants. Scoping stock and demand per plant
-> needs an answer to "which regions does NPMD serve?", which #117 deliberately left open — do not
-> invent one by adding a filter here. Today NPMD produces nothing, so the message names Hyderabad
-> alone.
+**3 — The message names each floor with the region it serves (#128, #129).** `🏭 Stock made at:
+Hyderabad (South)` in the header, read off the `plant` on the production rows — never typed, never
+assumed. Naming the plant without the region it serves is only half the fact: a reader who knows the
+stock was made at Hyderabad still cannot tell whether their distributor may have any of it.
 
-Two ways the plant can be missing, and they are **not** the same fact:
-`🏭 Stock: plant not identified — aggregated bundle carries no plant` means the bundle predates #128
-and should be rebuilt; `🏭 Stock: made at a plant nobody has labelled` means the production rows
-themselves carry no plant, which is a labelling gap to fix on the floor. Never report the second as
-the first — it sends someone off to rebuild a query that was fine.
+It says **made at**, not *held at*, and the difference is load-bearing: on-hand is produced −
+invoiced at those plants, and nothing attributes the surviving tonnage back to one floor. A plant
+that made stock and has since shipped every tonne is still named.
+
+> **Known limit — two floors, one on-hand.** Where two plants serve the SAME region their floors are
+> summed into one on-hand. Inside a service area that is intended — an order there can be filled
+> from either — but a size may still be sitting at the further of the two, so a `⚠️` footer names it
+> per region (`On-hand for South combines Hyderabad and Lepakshi`). Plants serving *different*
+> regions are never combined and the message must never say they are.
+
+`Unattributed` is not a plant (CONTEXT.md) and serves no region, so it can never be printed as one —
+and its stock is offered to nobody. A production row with a blank plant is reported on **stderr**
+(`N T of production carries no plant…`) as a labelling gap to fix on the floor, never silently
+dropped.
+
+An **aggregated bundle** (`--agg`) must carry `plant` on BOTH its `prod` and its `disp` tuples —
+on-hand is produced − invoiced *within an area*, so scoping one half and not the other compares
+different things. A bundle missing either is **refused outright**, with the tuple shapes to rebuild
+it: reporting from it would announce that nothing can be served at all.
 
 ## Steps
 
@@ -92,11 +101,13 @@ The bundle carries only plain Σs; every identity, SKU key and stock rule still 
 The script re-adds the expanded rows and refuses to report if they disagree with the bundle's own
 `checks` block, so a truncated or half-pasted payload fails loudly instead of under-reporting.
 
-The production Σs are grouped **per SKU and per plant**, which is what lets the aggregated path still
-name the floor. A bundle built before #128 carries three-element `prod` tuples: the message then says
-`🏭 Stock: plant not identified` rather than filing every tonne under `Unattributed` — rebuild it with
-the query below. A **current** bundle whose rows carry an empty plant is a different message (see
-rule 3) and needs no rebuild.
+Both the production **and** the dispatch Σs are grouped **per SKU and per plant** — on-hand is
+produced − invoiced *within a service area*, so scoping one half and not the other compares different
+things. A bundle built before #128/#129 carries three-element `prod` or `disp` tuples and the script
+**refuses to run**, naming which half is short: it cannot pool per area without them, and would
+otherwise announce that nothing can be served. Rebuild with the query below. A **current** bundle
+whose rows carry an empty plant needs no rebuild — that is a shop-floor labelling gap, reported as
+one on stderr.
 
 ```sql
 with open_o as (
@@ -124,11 +135,12 @@ select json_build_object(
   'prod', (select coalesce(json_agg(json_build_array(sku_code, tc, tw, plant) order by sku_code), '[]'::json) from (
        select sku_code, coalesce(plant,'') plant, sum(coalesce(tube_count,0)) tc, round(sum(coalesce(total_weight,0))::numeric,4) tw
        from productions where deleted is not true group by sku_code, coalesce(plant,'')) p),
-  'disp', (select coalesce(json_agg(json_build_array(c, w, pc) order by c), '[]'::json) from (
-       select be->>'skuCode' c, round(sum(coalesce((be->>'weight')::numeric,0)),4) w,
+  'disp', (select coalesce(json_agg(json_build_array(c, w, pc, plant) order by c), '[]'::json) from (
+       select be->>'skuCode' c, coalesce(be->>'plant','') plant,
+              round(sum(coalesce((be->>'weight')::numeric,0)),4) w,
               sum(coalesce((be->>'pieces')::numeric,0)) pc
        from dispatches d, lateral jsonb_array_elements(d.bundle_entries) be
-       where d.deleted is not true group by 1) q),
+       where d.deleted is not true group by 1, 2) q),
   'orders', (select coalesce(json_agg(json_build_object('code', dc, 'name', nm, 'state', st, 'lines', ls) order by nm), '[]'::json) from (
        select dc, nm, max(st) st, json_agg(json_build_array(mm, cf, nc) order by mm) ls from (
          select coalesce(nullif(trim(o.distributor_code),''),'') dc, trim(coalesce(o.customer,'')) nm,
@@ -154,9 +166,13 @@ Refuse to send, and say why, if any of these trip:
   labelling gap, not a service-area decision (`Unmapped` is never a region — CONTEXT.md). Fix it by
   mapping the state on the Sales tab, never by letting the filter swallow the row.
 - The in-scope pending total moved by more than a few percent overnight with no upload to explain it.
-- The header names a plant nobody expects, or says nobody labelled the rows, or names a second plant
-  on a day NPMD has not started producing. All three mean the production rows' `plant` is wrong, not
-  that the stock moved.
+- The header names a plant nobody expects, or says no plant serving the area has produced, or names a
+  second plant on a day NPMD has not started producing. All three mean the production rows' `plant`
+  is wrong, not that the stock moved.
+- The header names a plant against a region it should not serve (`NPMD (South)`). That is the plant
+  master, not the data — check the Masters tab before sending.
+- stderr reports production tonnage carrying no plant. That stock is offered to nobody; fix the rows
+  rather than explaining the gap in the message.
 
 Cross-checks worth keeping (they caught real errors when this was built):
 `Σ pending` across the whole book is **2,512.0 T** and the West book excluded by `--serves South` is
@@ -167,8 +183,11 @@ Cross-checks worth keeping (they caught real errors when this was built):
 2. Save it to `reports/servable-orders-whatsapp-<D>.txt`.
 3. State plainly what was excluded: the out-of-area distributors and their tonnage. That figure is
    in the message footer already — do not drop it when summarising.
-4. Say whose stock it was. The header line carries it; repeat it when summarising, because "we can
-   serve 638 T" means nothing without the floor it came off.
+4. Say whose stock it was **and whose region it serves**. The header line carries both; repeat them
+   when summarising, because "we can serve 638 T" means nothing without the floor it came off, and
+   the floor means nothing without who may be served from it.
+5. If any region in the message has no serving plant with stock, say so in your summary too — the
+   zeros are the true position, and a reader who assumes an outage will go looking for a bug.
 
 ## WhatsApp formatting
 `*bold*` single asterisks, `_italic_` underscores, `•` bullets, no markdown tables or headers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,13 @@ npm run dev                  # http://localhost:3000
 - **Never** make Production consume mother coils — it consumes **baby coils** (Stage 2 output).
 - **Never** auto-save the FIFO suggestion. It is guidance only; the operator's `manualAlloc` is what `save()` persists.
 - **Never** write production `coilAllocations` without **both** `babyCoilId` and the mother `hrCoilId` — the mother id drives costing and Coil Tracker.
+- **Never** show a distributor stock from a plant that does not serve its region. Service area is
+  stored on the **plant master** (`plants.serves` — Hyderabad + Lepakshi serve South, NPMD + Tapi
+  serve West), and `salesByDistributor` builds **one stock pool per region**. Productions,
+  dispatches, `allConfirmed` and `allPending` are scoped **together** or the numbers get worse than
+  no fix at all — an unscoped dispatch filter subtracts South's invoices from West's empty floor.
+  A region no plant serves reads **0**; an `Unmapped` distributor reads **`?`**, never 0 — unknown
+  is not empty. See `docs/adr/0006-*`.
 - **Never** let allocation cross plants. The `plant` filter runs **ahead of** every eligibility rule in `coilFifoAllocate`, and the manual coil dropdown is scoped the same way — an operator may override the spec (off-spec coils stay pickable) but never the plant, because a coil in another state is not off-spec, it is not there. Short of stock, report a shortfall; never reach into another plant.
 - **Never** let a pipeline row's `plant` be re-typed after Coil Inward. It is set once, there, and inherited — a baby coil takes its mother's, a production takes its baby coils'. Plant says where a physical object sits; a form cannot move it.
 - **Never** reintroduce the **tube**/`tubes` stage or **Bundle Formation**/`bundles`. Both removed; tables are legacy.
@@ -57,6 +64,11 @@ GitHub Issues on `PB-TMT-ai/jsw-pipes-inventory` — via the GitHub MCP tools in
 ### Triage labels
 
 The five canonical roles, each label string equal to its name: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Masters tab
+
+Three masters on one tab (SKU, Plant, Distributor) under the tab key `skuMaster` — the key is what
+`accessFor` grants, so it does not move when the label does.
 
 ### Domain docs
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -126,29 +126,48 @@ whether the plant selector is offered — one pure function, `accessFor` in `src
 _Avoid_: Permission, access level, privilege, user type, admin rights, security role
 
 **Service area**:
-The set of regions a plant will actually ship to. **South** for Hyderabad, the plant most of this
-database describes. It exists nowhere in the data — no distributor carries a plant, and only order
-and invoice lines carry one — so it is a business rule passed into a report, never a figure read
-off a row. A report that ignores it will tell the sales team it can serve a West distributor out of
-southern stock: on 18-Aug-2026 that was 275.7 T of the 638.6 T it claimed.
+The set of regions a plant will actually ship to. **Hyderabad and Lepakshi serve South; NPMD and
+Tapi serve West.** It is a commercial decision, not an ERP field — it appears in no export — so it
+is **stored on the plant master** (`plants.serves`, editable on the Masters tab) rather than passed
+into a report. It is what decides which stock a distributor is offered: the plants that serve **its**
+region, and no others. A report that ignores it tells the sales team it can serve a West distributor
+out of southern stock — on 20-Aug-2026 that was 310.6 T of Hyderabad tonnage offered across 50 West
+rows, with West's shortfall understated by 361 T.
 _Avoid_: Territory, catchment, coverage, allocation
+
+**Plant master**:
+The four plants and, per plant, the one thing about it a person decides: its **service area**.
+Everything else — Ship From Code, ERP names, coil prefix, whether it runs the pipeline — comes from
+the ERP and is read-only. Ships as a code seed (`src/data/plants.js`) with the `plants` table
+layered on top, per plant, so editing one plant cannot un-serve the other three.
+_Avoid_: Plant table, plant config, factory list
+
+**Distributor master**:
+A **region override** per distributor, and nothing else. A distributor's region normally comes from
+its ship-to state; the override exists for the exception that rule cannot express — a border depot,
+a group buying through one billing state. **Blank means "use the state's region"**, which is what
+almost every distributor stays on; blank is not a region and is not `Unmapped`.
+_Avoid_: Distributor table, customer master, account settings
 
 **Out of area**:
 Pending tonnage belonging to a distributor this plant does not ship to. It is **not** cancelled and
 not someone else's problem to hide — it stays in the order book and in the plant-wide pending total,
-and a service-area report states it rather than dropping it. 1,397 T on 18-Aug-2026, all West.
+and a service-area report states it rather than dropping it. 1,397 T on 18-Aug-2026, all West. It is
+the *audience* half of the rule: `--serves` chooses whose message this is, while the plant master
+chooses whose stock they may be shown. Those were one control by accident and are now two on purpose.
 _Avoid_: Excluded, filtered out, other region, not our orders
 
 **Servable**:
 `min(pending, on-hand)` for one distributor and one size — the part of what they are waiting on that
-is physically on the floor today. Like the On-hand it derives from, it is **shared and unreserved**:
-two distributors waiting on the same size are each shown its full tonnage, so servable figures are
-real per distributor and meaningless when summed across them. The message **names the floor** it
-counted (`Stock made at: Hyderabad`), read off the production rows' own plant: with four plants
-attributed, an unnamed floor is a claim rather than a shorthand. It says *made at* because on-hand is
-produced − invoiced across all plants for a size and nothing attributes what survives back to a
-floor — so stock made at more than one plant is said plainly and still summed, naming the limit
-rather than fixing it.
+is physically on the floor today, where "the floor" is the **plants that serve that distributor's
+region**. Inside a service area it is **shared and unreserved**: two distributors there waiting on
+the same size are each shown its full tonnage, so servable figures are real per distributor and
+meaningless when summed across them. Across service areas nothing is shared at all — a West
+distributor's servable tonnage is zero while every plant serving West produces nothing, and that
+zero is the true position, not a missing figure. The message **names each floor with the region it
+serves** (`Stock made at: Hyderabad (South)`), read off the production rows' own plant. It says
+*made at* because on-hand is produced − invoiced and nothing attributes what survives back to a
+floor; where two plants serve one region their floors are summed, which is said plainly per region.
 _Avoid_: Available to promise, ATP, allocatable, committed
 
 ## Region

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -270,3 +270,49 @@ Only after reintroducing the defect a third time did the test actually go red. T
 found this; the first round's Standards axis flagged the guard narrowing and the Spec axis found the
 delete. **Neither would have been caught by the app's own screens** — the rows destroyed are the
 ones the user cannot see, which is why the assertion had to move to the network layer.
+
+## 2026-08-20 — A rule in prose, contradicted by three captions, is not a rule
+
+**West distributors were shown South stock for as long as the sheet has existed.** `producedPool`
+summed every plant's tonnage by SKU and never read `p.plant`; `salesByDistributor` wrote that one
+number onto every distributor's row. On the 20-Aug-2026 workbook that offered 310.61 MT of Hyderabad
+tonnage across 50 West rows and printed West's shortfall as **1,755.35 MT** against a true
+**2,116 MT** — the entire West order book.
+
+The rule was not missing. It was in `CONTEXT.md` under **Service area**, and implemented once, as
+the `--serves` flag in `scripts/servable-orders.mjs` — which filters *orders*, never *stock*. What
+kept it invisible was that **three captions asserted the opposite as if it were a decision**: the
+workbook's sheet-4 note ("Free Stock is every plant's finished stock combined — the plant column is
+not applied to it, because stock is held where it was made"), and two lines of `docs/ALGORITHMS.md`
+saying the same. Every review since read those, found them coherent, and moved on.
+
+**A business rule that lives in one prose document and one CLI flag is a rule nobody enforces.** The
+fix was to make it data — a `serves` column on a plant master — so the code has to read it. Prose
+can be contradicted by a caption; a `Set` of plant ids cannot.
+
+**Scoping half of a subtraction is worse than scoping none of it.** `onhand` is produced − invoiced.
+Filtering productions to West (nothing) while leaving dispatches national would have made every West
+SKU read Hyderabad's invoiced tonnage as **negative stock** — a screen full of red where the truth is
+a blank. Four things had to move in one commit: productions, dispatches, `allConfirmed`,
+`allPending`. Two more, and less obvious: `regionOf` had to be resolved *above* the stock block (it
+ran after, which is one reason the pool could only ever be global), and the `Unmapped` case had to
+stop being coerced with `?? 0`.
+
+**"No filter" and "an empty filter" are opposite instructions, and one sentinel cannot say both.**
+`filterByPlant(rows, ALL_PLANTS)` returns everything. The new `filterByPlants(rows, new Set())` must
+return **nothing** — a region no plant serves has no stock, and falling back to "everything" there
+is precisely the bug, at the exact moment it matters most. So the set-based siblings use `null` for
+"do not filter", which cannot be confused with an empty set.
+
+**Unknown is not empty.** An `Unmapped` distributor has no derivable service area. Printing `0`
+tells a sales team "we hold nothing for you"; printing `?` tells them "nobody has mapped your
+state". Those are opposite instructions and one of them is false. `reports.js` was coercing with
+`?? 0` — one operator, three characters, a wrong answer every day.
+
+**Fixtures that carry none of the dimension under test pass for the wrong reason.** Both stock
+fixtures had no `plant` on their productions and — in `calc.test.js` — no `shipToState` either.
+Adding the service-area code turned every one of those tests green while proving nothing: with no
+plant the stock belongs to no area, so *everything* reads zero and every assertion about zero holds.
+The dimension had to be added to the fixtures **before** the assertions were flipped, and the
+over-dispatch case needed `plant` on the dispatch entry too, or the filter drops the row and the
+floor at zero is never exercised.

--- a/blueprints/add-new-sku-type.md
+++ b/blueprints/add-new-sku-type.md
@@ -1,7 +1,7 @@
 # Blueprint: Add a New SKU Product Type
 
 ## Goal
-Add a new product type (e.g., RHS, CHS, ERW) with SKU entries to the SKU Master.
+Add a new product type (e.g., RHS, CHS, ERW) with SKU entries to the SKU Master (the **Masters** tab).
 
 ## Inputs Required
 - productType: string (e.g., "RHS", "CHS", "ERW")
@@ -27,7 +27,7 @@ Add a new product type (e.g., RHS, CHS, ERW) with SKU entries to the SKU Master.
    - `totalConversion` — `weightPerTube × ladderPrice / 1000`
 4. If this is a CHS (circular) type, populate `outsideDiameter` and `nominalBore` instead of height/breadth
 5. Verify the SKU auto-generation in the SKUMaster component handles the new type
-6. Test: check SKU Master tab shows new entries, and the Bundle Formation SKU dropdown includes them
+6. Test: check the Masters tab's SKU Catalog shows new entries, and the Production SKU dropdown includes them
 
 ## Edge Cases
 - CHS uses diameter instead of height×breadth — update description format

--- a/blueprints/manage-app-login.md
+++ b/blueprints/manage-app-login.md
@@ -38,13 +38,13 @@ Read this before you promise anyone anything.
 |---|---|---|
 | Dashboard, Coil Tracker, Dispatch, Sales | All plants, plus the plant selector | Their plant only |
 | Coil Inward, Slitting, Production | All plants, plus the selector | Their plant, pinned — and only if that plant `manufactures` |
-| SKU Master | View and **edit** | View only |
+| Masters (SKU / Plant / Distributor) | View and **edit** | View only |
 | Orders & Invoice | **Upload** and view | View, their plant |
 | Reports | **Yes** | Hidden |
 
 The three admin-only powers are admin-only for a reason worth knowing before you hand anyone the
 `admin` password: the **upload** replaces the whole company's order book in one go (a second
-uploader on a stale file overwrites everyone), **SKU Master** sets `weightPerTube` and therefore
+uploader on a stale file overwrites everyone), **Masters** sets `weightPerTube` and each plant's service area and therefore
 every plant's tonnage and cost, and **Reports** builds the company-wide workbooks.
 
 A plant user gets **no plant selector** — their plant is on their login, and the header names it.

--- a/docs/ALGORITHMS.md
+++ b/docs/ALGORITHMS.md
@@ -14,8 +14,53 @@ Pure helpers live in `src/lib/calc.js`. Formulas:
 - Bundle availability (`producedPool`) per SKU = `produced − bundled`; bundling is capped at it.
 - Dispatch cost rate = `Mother Coil Cost Price / Mother Coil Actual Weight` (₹/MT), weight-weighted across each entry's `coilAllocations` (legacy fallback: single `traceHrCoilId`).
 - **A dispatch record's weight is a function of its entries, never an independent fact** (`withDispatchEntries`): `theoreticalWeight = Σ entry weight`, `selectedBundles = entries`, and `variance = vehicleWeight − theoreticalWeight` (0 when nothing was weighed — no weighbridge reading is *no measurement*, not a variance of the whole load). Anything that changes which entries a record holds goes through this one helper — the daily upload building a record (`buildDispatchRecords`) and the plant filter narrowing one (`filterDispatchesByPlant`). They previously each carried their own copy of the arithmetic in two different files, which is how the two would eventually have disagreed about what one invoice weighs. `vehicleWeight` is deliberately **not** derived: it is a whole-vehicle weighbridge figure and cannot be split when the entries are.
-- **Distributor × SKU stock** (`salesByDistributor` with `opts.productions`) — per distributor and canonical SKU: `pending = confirmed + nonConfirmed`; `onhand = max(0, producedPool.availableWeight)`; `allConfirmed` = Σ Confirmed across **every** distributor; **`freeStock = onhand − allConfirmed`** — the displayed figure, plant stock promised to nobody yet, **not floored** so an over-committed size reads negative; `allPending` = Σ pending across **every** distributor for that SKU; `shortBy = max(0, pending − onhand)` — still measured against on-hand, so a row can show no shortfall beside a negative Free Stock. `onhand` is the **whole plant's** stock and is divided between nobody, so the identical tonnage repeats on every distributor's row for that size and `shortBy` can read 0 on a size that is oversubscribed several times over (ADR-0002 — 39.3 T of `50x50x2.0` against 78 T queued across five distributors). Both the Sales tab drill-down and the PB MTD workbook's **Distributor × SKU** sheet read this one function, so screen and workbook cannot disagree; the sheet lists only live pairs (pending or invoiced MTD above zero), sorts region → distributor → pending desc, and **never totals `onhand`** — summing it reports more stock than the plant holds. Each SKU row also carries its own **`description`** — the SKU master's when it has a row for the code, else the **order line's own** description. 37 of the ERP codes on the order book have no master row at all (ordered, never produced), and for those the order line is the only place the tube's name exists; without it both the screen and the workbook printed the raw MM ID (`1140-13075-10078295`) where the description belongs. The workbook's SKU label is derived from that description in the same `size x thickness` shape the SKU Ageing sheet uses, so the two sheets still join.
+- **Distributor × SKU stock** (`salesByDistributor` with `opts.productions`) — per distributor and canonical SKU, scoped to the distributor's **service area** (ticket #129): its region → the plants whose `serves` includes it → the pool. `pending = confirmed + nonConfirmed`; `onhand = max(0, producedPool.availableWeight)` over **those plants'** productions less **those plants'** dispatch entries; `allConfirmed` = Σ Confirmed across every distributor **in that area**; **`freeStock = onhand − allConfirmed`** — the displayed figure, area stock promised to nobody yet, **not floored** so an over-committed size reads negative; `allPending` = Σ pending across every distributor **in that area** for that SKU; `shortBy = max(0, pending − onhand)` — still measured against on-hand, so a row can show no shortfall beside a negative Free Stock. All four halves move **together**: scoping only the productions would subtract South's invoices from West's empty pool and read every West SKU as negative, and would net South's Confirmed off West's zero. Inside an area the pool is still divided between nobody, so the identical tonnage repeats on every row there for that size and `shortBy` can read 0 on an oversubscribed size (ADR-0002 — 39.3 T of `50x50x2.0` against 78 T queued). **Across** areas nothing repeats: on 20-Aug-2026 every production row is Hyderabad's, so West rows read 0 Free Stock and their full pending as `Short by`, and they fill in by themselves the day NPMD produces (ADR-0006). A distributor whose region is `Unmapped` has **no known service area**, so every stock field is `null` — `?` in the workbook, an em dash on screen, **never 0**. Both the Sales tab drill-down and the PB MTD workbook's **Distributor × SKU** sheet read this one function, so screen and workbook cannot disagree; the sheet lists only live pairs (pending or invoiced MTD above zero), sorts region → distributor → pending desc, and **never totals `onhand`** — summing it reports more stock than the area holds. Each SKU row also carries its own **`description`** — the SKU master's when it has a row for the code, else the **order line's own** description. 37 of the ERP codes on the order book have no master row at all (ordered, never produced), and for those the order line is the only place the tube's name exists; without it both the screen and the workbook printed the raw MM ID (`1140-13075-10078295`) where the description belongs. The workbook's SKU label is derived from that description in the same `size x thickness` shape the SKU Ageing sheet uses, so the two sheets still join.
 - ±5% tolerance on weight validations (via the shared `tolerance()` helper — returns `ok:true` on falsy args, so cap checks guard `actualWeight>0` explicitly).
+
+## Stock is pooled per service area (ticket #129)
+
+A distributor is only ever offered the stock of the plants that serve **its** region. The chain has
+three links and every one of them is a stored fact, not a rule in prose:
+
+```
+distributor ─► region ────────────────► plants ─────────────► pool
+  its most      state → region map,      plants.serves        productions AND dispatch
+  recent line   or the distributor       (plant master)       entries at those plants
+  's state      master's override
+```
+
+`salesByDistributor` resolves `regionOf` **before** the stock block (it used to run after, which is
+one reason the pool could only ever be one global number), then builds one pool per region present:
+
+```js
+plants = plantsServingRegion(region, plantMaster(opts.plants))   // Set of plant ids
+pool   = producedPool(filterByPlants(productions, plants),
+                      filterDispatchesByPlants(dispatches, plants), null, keyOf)
+```
+
+**Four things move together, and must.** Scope only the productions and the numbers get *worse* than
+before: dispatches unscoped subtracts South's invoices from West's empty pool (every West SKU reads
+negative), `allConfirmed` unscoped nets South's Confirmed off West's zero, and `allPending` unscoped
+answers "who else is queued" with distributors these plants cannot serve.
+
+**`filterByPlants` / `filterDispatchesByPlants` are set-based siblings of `filterByPlant` /
+`filterDispatchesByPlant`, and they differ on exactly one case:**
+
+| call | result | meaning |
+|---|---|---|
+| `filterByPlant(rows, ALL_PLANTS)` | every row | no filter |
+| `filterByPlants(rows, null)` | every row | no filter |
+| `filterByPlants(rows, new Set())` | **no rows** | no plant serves here |
+
+An empty set is an **answer**, not a missing argument. A region nobody ships to shows no stock;
+falling back to "everything" there is the bug ticket #129 exists to fix, at the exact moment it
+matters most. A row with **no plant** belongs to no service area — it counts toward none, exactly as
+it counts toward neither plant under the header selector.
+
+**`Unmapped` is unknown, not empty.** A distributor whose state carries no region has no derivable
+service area, so it gets **no pool** and every stock field is `null`. That renders as `?` in the
+workbook and an em dash on screen — never `0`, because "we hold nothing for you" and "we cannot tell
+which plants serve you" are opposite instructions to whoever reads it.
 
 ## The plant filter sits ahead of the eligibility rules (ticket #124)
 
@@ -159,11 +204,12 @@ one object.
   tells the reader nothing).
 - **One decimal, format-only**, same rule as the distributor sheets: the cells hold exact values, so
   the `ALL PLANTS` row keeps tying to the (whole-number) KPI cards above it.
-- **Region, Best Estimate, Free Stock, on-hand and Short by are untouched.** They are keyed by
-  distributor, state and SKU — never by plant — and `reports.test.js` asserts that re-attributing
-  every order line to a different plant leaves all of them byte-identical. Free Stock in particular
-  stays **every plant's** finished stock combined: stock is held where it was made, and the plant
-  column is not applied to it.
+- **Region, Best Estimate, Free Stock, on-hand and Short by ignore the ORDER LINE's plant.** They
+  are keyed by distributor, state and SKU, and `reports.test.js` asserts that re-attributing every
+  order line to a different plant leaves all of them byte-identical. Since ticket #129 the stock
+  three of them DO follow a plant — the **production row's**, through the service area (ADR-0006) —
+  which is a different column on a different table. The distinction is the point: where an order was
+  booked never moves stock; where the stock was made decides who may be offered it.
 
 ## Daily report — the region split
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,7 @@ no longer consumes mother coils — it FIFO-consumes **baby coils** on thickness
 4. **Dispatch** — Uploaded from an Excel sheet (one row per dispatched line; columns matched case-insensitively). Rows are grouped into one dispatch per (date × vehicle); each entry's coil trace is inherited from **production FIFO** (`dispatchCoilTrace`), so cost reconciliation (mother-coil rate) still works. Invoice Reconciliation CSV export retained.
 
 ## Other Modules
-Plus: **SKU Master** (232-entry tube catalog — SHS/RHS/CHS, loaded from `src/data/skus.js`), **Coil Tracker** (mother-coil inventory + journey; **also a baby-coil view** — an "All Baby Coils" table with weight/used/free/% used/status when no mother is selected, and that mother's baby coils inside its journey when one is selected), **Dashboard** (KPIs, pipeline, yield, alerts), **Orders & Invoice** (ONE daily "Upload Sales Excel" of the One Helix workbook — Orders tab → `orders` with per-line Confirmed/Non-confirmed; Invoice tab → `dispatches`), and **Sales** (Confirmed / Non-confirmed / Pending to Dispatch / MTD Invoice / Total Orders KPIs + distributor-wise and month-wise tables). The distributor table also carries the **Best Estimate** — a typed monthly target per distributor, edited inline and measured against MTD Invoice; the plant-level Best Estimate in the PB MTD Dashboard report is their sum, no longer typed on the Reports tab (`docs/adr/0001-…`). Its **drill-down** shows unreserved plant on-hand stock against the distributor's pending, per SKU (`docs/adr/0002-…`). **PO Master, Open Order Backlog, and SKU Demand vs Supply were removed (July 2026).**
+Plus: **Masters** (tab key `skuMaster`) — three masters in one place: the **SKU Master** (232-entry tube catalog — SHS/RHS/CHS, loaded from `src/data/skus.js`), **Coil Tracker** (mother-coil inventory + journey; **also a baby-coil view** — an "All Baby Coils" table with weight/used/free/% used/status when no mother is selected, and that mother's baby coils inside its journey when one is selected), **Dashboard** (KPIs, pipeline, yield, alerts), **Orders & Invoice** (ONE daily "Upload Sales Excel" of the One Helix workbook — Orders tab → `orders` with per-line Confirmed/Non-confirmed; Invoice tab → `dispatches`), and **Sales** (Confirmed / Non-confirmed / Pending to Dispatch / MTD Invoice / Total Orders KPIs + distributor-wise and month-wise tables). The distributor table also carries the **Best Estimate** — a typed monthly target per distributor, edited inline and measured against MTD Invoice; the plant-level Best Estimate in the PB MTD Dashboard report is their sum, no longer typed on the Reports tab (`docs/adr/0001-…`). Its **drill-down** shows on-hand stock against the distributor's pending, per SKU — scoped to the distributor's **service area** and unreserved inside it (`docs/adr/0002-…`, `docs/adr/0006-…`). **PO Master, Open Order Backlog, and SKU Demand vs Supply were removed (July 2026).**
 
 ## Role and plant decide what you see (ticket #126)
 Who signed in decides which tabs render, which of them can be edited, and whether the plant selector
@@ -37,13 +37,13 @@ would eventually show a tab the rule had never heard of.
 |---|---|---|
 | Dashboard, Coil Tracker, Dispatch, Sales | All plants + selector | Their plant only |
 | Coil Inward, Slitting, Production | All plants + selector | Their plant, pinned — and only if their plant `manufactures`. Coil Inward additionally requires the plant to be on `COIL_INWARD_PLANT_IDS`, the separate rollout list an admin's picker already honours |
-| SKU Master | View and **edit** | View only |
+| Masters (SKU / Plant / Distributor) | View and **edit** | View only |
 | Orders & Invoice | **Upload** and view | View, their plant |
 | Reports | **Yes** | Hidden |
 
 Three restrictions carry real weight, and each is admin-only for a stated reason: the **upload**
 rebuilds the whole company's order book by superseding every live row, so a second uploader working
-from a stale file would overwrite everyone; **SKU Master** drives `weightPerTube`, which drives every
+from a stale file would overwrite everyone; **Masters** drives `weightPerTube` and each plant's service area, which drive every
 plant's tonnage and cost; **Reports** builds the company-wide workbooks.
 
 How it is wired in `InventoryApp`:
@@ -82,7 +82,7 @@ It defaults to **All Plants**, so every
 figure the app shows on load reads exactly as it did before this ticket. Switching it scopes
 **Dashboard, Coil Tracker, Dispatch, Orders, Sales and Reports** — all six follow ONE control
 (`InventoryApp` holds the `selectedPlant` state; the tabs never filter themselves). **Coil Inward,
-Slitting, Production and SKU Master are deliberately not scoped by the selector** — an operator
+Slitting, Production and Masters are deliberately not scoped by the selector** — an operator
 registers and consumes coils against the pipeline's own plant fields regardless of what the header
 happens to be showing. (For a **plant user** there is no selector and the stages are scoped to their
 plant structurally — see #126 above.) The header's former hardcoded "Inventory Management — Hyderabad" now reads the selection —

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -169,7 +169,7 @@ leave on can never silently scope a report or a screenshot days later.
 | **Applied to** | Dashboard, Coil Tracker, Dispatch, Orders, Sales, Reports — `InventoryApp` filters once and passes the scoped arrays down; no tab filters itself |
 | **Scoped exports** | A Reports workbook is read away from the screen that scoped it, so a scoped one carries its scope in the file itself: `— <Plant> only` in **every** sheet title (`opts.companyName`, which reaches all 7 title rows across the 3 workbooks) and a `-<plant>` suffix on the file name (`opts.fileSuffix`), plus an amber banner on the tab. Both asserted in `reports.test.js` |
 | **Unscoped exports** | The **unscoped** workbook is not filtered at all and never becomes so: it keeps every company-wide total and adds a `BY PLANT` block beneath the Dashboard KPIs, closed by an `ALL PLANTS` row that ties back to them (#127). Its Pending rows read the **order row's** `plant`, its Invoiced rows the **dispatch entry's** — the two columns of this table, read as a breakdown rather than a filter. See `docs/ALGORITHMS.md` |
-| **NOT applied to** | Coil Inward, Slitting, Production and SKU Master keep reading the raw, unfiltered store arrays. Orders' own upload path (`replaceOrders`/`replaceDispatches`, and the `productions` passed into `buildDispatchRecords` for the invoice coil trace) is also unfiltered — an upload made while the header is scoped to one plant must still resolve every other plant's coil trace correctly. Sales' `estimates` and `stateRegions` are unfiltered too — Best Estimate and Region stay exactly as documented above, keyed by distributor/state, not plant |
+| **NOT applied to** | Coil Inward, Slitting, Production and Masters keep reading the raw, unfiltered store arrays. Orders' own upload path (`replaceOrders`/`replaceDispatches`, and the `productions` passed into `buildDispatchRecords` for the invoice coil trace) is also unfiltered — an upload made while the header is scoped to one plant must still resolve every other plant's coil trace correctly. Sales' `estimates`, `stateRegions`, `plants` and `distributors` are unfiltered too — Best Estimate and Region stay keyed by distributor/state, not plant, and the two masters are the company's answer to who serves whom, which a header filter may not narrow |
 | **Read a second way by Production** | Production still gets the **raw** arrays, but from #124 it also gets the selector's value as `operatingPlant` and scopes them itself, because its scope is the *batch's* plant (the operating plant for a new one, the record's own when editing) rather than the header's — see below |
 | **Where scoping changes meaning** | Two things are **withheld** under a filter rather than silently recomputed, because a filter may not redefine an answer: Sales' **% of BE / Gap to BE / Plant BE achievement** (a plant-scoped actual over a company-wide plan is the four-against-one mismatch #117 exists to expose) and Dispatch's **Delete** (`deleted` is on the record — one whole invoice — while plant is on its entries, so deleting while scoped would remove lines the operator cannot see). See `docs/UI-PATTERNS.md` |
 | **Invariant** | Per-plant sums equal the All Plants total, Unattributed included — summing `filterByPlant`/`filterDispatchesByPlant` across every plant option (the four plants + `''`) reproduces the unfiltered figure exactly, the same guarantee `Unmapped` and `Unattributed` already carry elsewhere. Asserted in `calc.test.js` at the **unit level only**, over rows constructed to the #117 spec's *published* per-plant figures (761.441 / 1044.000 / 417.000 / 393.000 MT) — that proves the helpers compose, **not** that the deployed data sums to them. It has never been checked against the live database: `orders` there has no `plant` column yet (#118's `alter table` is unrun) and currently holds 0 rows. See the 2026-08-19 `LEARNINGS.md` entry |
@@ -204,10 +204,40 @@ it, which is why nothing may join to `state_regions` alone.
 | **Seed vs stored** | `stateRegionIndex(rows)` starts from the seed and layers the stored rows **on top** — not "table if non-empty, else seed". Editing one state writes one row; the other five seeded states must not silently become `Unmapped` |
 | **Un-mapping** | Clearing a region stores `region: ''` (an explicit un-mapping that overrides the seed), **not** a soft delete — a soft-deleted row would leave the seed in force |
 | **Distributor's state** | `distributorStateIndex(orders, dispatches)` derives it from that distributor's own lines, keyed by the identity `resolveDistributorIdentity` produces. Where lines disagree the **most recent** wins (undated loses to dated; an exact tie keeps the first line seen — orders before invoices). Every distinct state is kept in `states`, and `multiState` flags the distributor so it is **visible, not silently resolved** |
-| **Shared resolver** | `distributorRegionResolver(orders, dispatches, stateRegions)` → `key ⇒ { state, states, multiState, region }`. `salesByDistributor` calls it via `opts.stateRegions`; the report builders can call it directly, so a region on screen and a region in a report cannot diverge |
+| **Shared resolver** | `distributorRegionResolver(orders, dispatches, stateRegions, idx, distributors)` → `key ⇒ { state, states, multiState, region, regionOverride }`. `salesByDistributor` calls it via `opts.stateRegions` / `opts.distributors`; the report builders can call it directly, so a region on screen and a region in a report cannot diverge |
+| **Override** | The **distributor master** (below) wins over the state map for one distributor. Blank means "use the state's region" — it is not a region and not `Unmapped` |
+
+## Plant master — service area (ticket #129)
+Which regions a plant will actually ship to. It is the ONE thing about a plant a person decides:
+Ship From Code, ERP names, coil prefix and `manufactures` all come from the ERP and stay a read-only
+code constant in `src/data/plants.js`. So the table holds only what is typed.
+
+**Hyderabad + Lepakshi serve South. NPMD + Tapi serve West.**
+
+| Concern | Behaviour |
+|---|---|
+| **Table** | `plants (id uuid, plant_id text unique, serves text[], deleted, created_at)`. Store key `jsw:plants` |
+| **Arbiter** | `plant_id` — the plant's own literal id (`'hyderabad'`), the same value pipeline and order rows carry. The first edit of a seeded plant arrives under a fresh uuid, so arbitrating on `id` would collide with `unique(plant_id)` |
+| **Seed vs stored** | `plantMaster(rows)` starts from `src/data/plants.js` and layers stored rows **on top, per plant** — editing one plant cannot un-serve the other three. A stored row naming a plant the seed does not carry is **ignored**: a plant is an ERP company with a Ship From Code, and a row holding only an id and a region list is not one |
+| **Serving nowhere** | An empty array, `NULL` and a blank string all read as "serves nowhere", which is a real answer with a checkable consequence (that plant's stock appears on no distributor's row). What restores the shipped default is **deleting the row**, not blanking it — the opposite of `state_regions`, where a blank region is the explicit un-mapping |
+| **Read by** | `plantsServingRegion(region, master)` → a `Set` of plant ids, fed straight to `filterByPlants` / `filterDispatchesByPlants`. An **empty set** means "no plant serves here" and yields no rows; `null` means "no filter". See `docs/ALGORITHMS.md` |
+| **Fallback** | The React store falls back to `[]`, not to the seed — a stored row is a different shape from a seed row, and the seed is layered underneath inside `calc.js`. `scripts/servable-orders.mjs` fetches the table as **optional**, so a database whose DDL is unrun reports the shipped service areas rather than refusing to run |
+
+## Distributor master — region override (ticket #129)
+A region override per distributor and **nothing else**. Name, state, orders and invoices all arrive
+with the ERP data and are resolved from it, so anything else stored here would be a second,
+hand-typed copy of a fact the ERP already ships.
+
+| Concern | Behaviour |
+|---|---|
+| **Table** | `distributors (id uuid, distributor_key text unique, distributor_name text, region text, deleted, created_at)`. Store key `jsw:distributors` |
+| **Arbiter** | `distributor_key` — the identity `resolveDistributorIdentity` produces, the same key `distributor_estimates` uses. `distributor_name` is a label for the Masters tab and is **never joined on** |
+| **Blank** | `region: ''` (stored `NULL`) means "use the state's region". Clearing an override **writes the blank** rather than deleting the row, because a stored blank and no row at all must mean the same thing — otherwise clearing would strand the distributor instead of returning it to its state's answer |
+| **Seed** | `src/data/distributors.js`, empty on purpose. An override is a correction to the state rule; shipping one nobody asked for would be a correction to nothing |
+| **Scope** | It moves which region a distributor is reported under, and therefore which plants' stock it is offered. It never touches the distributor's **state**, which stays the ERP's own answer |
 
 ## Sync & upsert semantics
-Mutations update React state optimistically, then sync to Supabase in the background; failures broadcast a `jsw:syncError` window event **and re-read the table** so state can't keep claiming rows Postgres refused. Upserts arbitrate on `id` except **`skus`, which arbitrates on `sku_code`**, **`distributor_estimates`, which arbitrates on the composite `distributor_key,month`**, and **`state_regions`, which arbitrates on `state`** (`conflictTargetFor` in `db.js`) — that column is UNIQUE, and Postgres resolves `ON CONFLICT` against only ONE index, so a conflict on a *non-arbiter* unique column is a hard error that fails the whole batch.
+Mutations update React state optimistically, then sync to Supabase in the background; failures broadcast a `jsw:syncError` window event **and re-read the table** so state can't keep claiming rows Postgres refused. Upserts arbitrate on `id` except **`skus`, which arbitrates on `sku_code`**, **`distributor_estimates`, which arbitrates on the composite `distributor_key,month`**, **`state_regions`, which arbitrates on `state`**, **`plants`, which arbitrates on `plant_id`**, and **`distributors`, which arbitrates on `distributor_key`** (`conflictTargetFor` in `db.js`) — that column is UNIQUE, and Postgres resolves `ON CONFLICT` against only ONE index, so a conflict on a *non-arbiter* unique column is a hard error that fails the whole batch.
 
 ### Replace-all ordering — insert first, supersede after (2026-08-20)
 `orders` and `dispatches` are rebuilt wholesale by the daily Sales upload (`replaceAllRows` in
@@ -304,7 +334,7 @@ Two pure functions in `src/lib/calc.js`, kept separate because they answer diffe
 | | |
 |---|---|
 | `parseStoredSession(saved, now)` | **Is this a session?** `{loginId, plant, role, at}` or `null`. Rejects a missing/unknown role, a blank plant, a bad or missing timestamp, and anything past the 30-day window. Every session stored before #126 carries no `role`, so all of them return `null` — that *is* the one-time re-authentication, and it needs no version stamp |
-| `accessFor(session)` | **What may it do?** `{tabs, readOnly, plantSelector, plant}`. Admin ⇒ every tab, nothing read-only, the selector, starting on `ALL_PLANTS`. Plant ⇒ their plant pinned, no selector, no Reports, no manufacturing tabs unless the plant `manufactures`, and SKU Master + Orders read-only |
+| `accessFor(session)` | **What may it do?** `{tabs, readOnly, plantSelector, plant}`. Admin ⇒ every tab, nothing read-only, the selector, starting on `ALL_PLANTS`. Plant ⇒ their plant pinned, no selector, no Reports, no manufacturing tabs unless the plant `manufactures`, and Masters + Orders read-only |
 
 A credential can pass the first and fail the second, and the case is real: a `plant` role whose
 `plant` column is NULL arrives as **`ALL_PLANTS`** (that mapping is `verifyLoginDetails`'s, and

--- a/docs/UI-PATTERNS.md
+++ b/docs/UI-PATTERNS.md
@@ -30,8 +30,8 @@
 - Baby-coil-delete guard: a baby coil consumed by any production cannot be deleted (Slitting blocks it). `coilAllocations` store `{babyCoilId, hrCoilId, pieces, weight}` (baby + mother).
 
 ## Read-only tabs (ticket #126)
-- **`readOnly` withholds the writing controls; it never hides the data.** `SKUMaster` and `Orders`
-  each take a `readOnly` prop. The catalog, the order book, every figure and the CSV exports all
+- **`readOnly` withholds the writing controls; it never hides the data.** `Masters` (which passes it
+  down to all three of its sections) and `Orders` each take a `readOnly` prop. The catalog, the order book, every figure and the CSV exports all
   stay — a plant user looks SKUs up constantly. What goes is the add form, `onEdit`/`onDelete`
   (passing `undefined` drops DataTable's whole Actions column, the same move Dispatch makes above)
   and the upload button.
@@ -42,6 +42,10 @@
 - **Say why, once, where the control was.** Each read-only tab carries a short note — the SKU
   catalog is central because `weightPerTube` sets every plant's tonnage; one upload replaces every
   plant's orders. A missing button with no explanation reads as a bug.
+- **A disabled control is the right shape when the value explains the screen.** The Masters tab's
+  two newer sections (#129) render their selects and checkboxes **disabled** rather than unmounted:
+  a plant user needs to read which regions their plant serves, because that is what decides the
+  stock figures on their own Sales tab. Unmounting is for a write path with nothing to read.
 
 ## Plant across the pipeline stages (ticket #120)
 - **Coil Inward is the only place plant is typed** — and since ticket #126, only for an **admin**.
@@ -201,6 +205,42 @@ the scope is one derived value in one component and not threaded through props.
 - The write is keyed by **state, not distributor**: one edit re-maps every distributor in that state. The cell's tooltip and the paragraph under the table both say so — a per-row-looking control with cross-row effect has to announce it. A distributor with no state has nothing to key on, so the select is **disabled** rather than writing nowhere.
 - An unmapped state reads `Unmapped` and its row stays in the `DataTable` totals — never filter or merge rows on state/region.
 - The Sales CSV gains **State**, **All States** (populated only for a multi-state distributor, so the resolved single State is auditable) and **Region**.
+
+## Masters tab — three masters, one tab (ticket #129)
+- The **SKU Master** tab is now **Masters** and carries three sections: **SKU Master**, **Plant
+  Master**, **Distributor Master**. The tab **key stays `skuMaster`** — that is what `accessFor`
+  grants and what `PLANT_READ_ONLY_TABS` names, so renaming it would silently move a permission.
+  Only the label changed.
+- They sit together because they are the same kind of thing: the few facts the ERP does not ship and
+  a person therefore has to state. Order is by how often they are used — a SKU daily, a service area
+  a few times a year, an override almost never.
+- **Plant Master** shows all four plants with everything ERP-owned rendered and locked (Ship From
+  Code, coil prefix, `manufactures`). The one editable cell is **Serves** — a checkbox per region
+  (`PlantServesCell`), not a text field: the four regions are fixed, and a typed "Wesr" would
+  silently mean *serves nowhere*. Commits on every click.
+- A region **no plant serves** is called out under the table in amber, with what it means (those
+  distributors are shown no stock and their full pending as Short by). Silence there would read as
+  a bug on the distributor's screen rather than as a fact about the plant.
+- **Distributor Master** lists every distributor from the same `salesByDistributor` the Sales tab
+  reads — so the region shown here is the region the stock pool is actually built from. Columns:
+  Distributor, State, **Region in use** (highlighted when it came from an override), **Override**.
+- The override select's blank option reads **`(use state)`**, never `Unmapped`, and the inherited
+  answer is printed beside it (`→ West`) so a blank cell still says what it resolves to. Clearing
+  writes `region: ''` rather than deleting the row — a stored blank and no row must mean the same
+  thing. `Show only overridden (N)` filters the list, because the exceptions are the point.
+- `readOnly` (a plant login) withholds the writes on all three sections. The two new ones are
+  **disabled, not hidden**: a plant user reads the service areas because they explain what their own
+  screens show.
+
+## Sales drill-down — whose stock it is (ticket #129)
+- The stock columns are scoped to the open distributor's **service area**, so the tooltips and the
+  caption name it (`Hyderabad + Lepakshi (South) stock for this SKU…`) via one `areaLabel` helper.
+  "The plant's stock" is the sentence that let the workbook offer Hyderabad tonnage to West.
+- `null` renders as an em dash and **never** as `0`. Two amber sentences sit under the table and are
+  not decoration: one for a region no plant serves ("those dashes are the real position, not a
+  loading error — they fill in the day a plant that serves it produces") and one for `Unmapped`
+  ("we cannot tell which plants serve it… map the state in the Region column above"). A screen of
+  dashes with no explanation reads as an outage.
 
 ## Stage 4 Dispatch — coil split
 - Each entry's coil split is inherited from production FIFO (`dispatchCoilTrace`, carrying `{babyCoilId, hrCoilId}`), so the **persisted shape is unchanged** — `buildReconciliationRows`, the records table, and the Invoice Reconciliation CSV (one row per date × invoice × SKU) are untouched.

--- a/docs/UI-PATTERNS.md
+++ b/docs/UI-PATTERNS.md
@@ -78,7 +78,7 @@
   to All Plants.
 - `InventoryApp` filters once, with `filterByPlant`/`filterDispatchesByPlant` (`calc.js`), and passes
   the scoped arrays down as ordinary props. **Dashboard, Coil Tracker, Dispatch, Orders, Sales and
-  Reports** receive the scoped arrays; **Coil Inward, Slitting, Production and SKU Master** keep
+  Reports** receive the scoped arrays; **Coil Inward, Slitting, Production and Masters** keep
   receiving the raw, unfiltered store arrays **for an admin** — nothing in those four components
   changed for ticket #121, because they never saw a filtered prop.
   - **Ticket #126 scopes what the stages SHOW, and nothing else.** All three keep receiving the raw

--- a/docs/adr/0002-distributor-drilldown-shows-unreserved-plant-stock.md
+++ b/docs/adr/0002-distributor-drilldown-shows-unreserved-plant-stock.md
@@ -92,3 +92,33 @@ definition is written for the order book the plant is moving towards, not the on
 Whether Confirmed should instead follow the ERP's *Order Status* column (2,098 T of lines are marked
 "Confirmed" there) is a separate, larger question — it feeds the Dashboard KPIs, the Best Estimate %
 and three sheets of the workbook — and is deliberately not settled here.
+
+## Amendment 3 — the pool is a service area's, not the company's (issue #129)
+
+Everything above is about how a pool is **divided** between the distributors queued against it: it
+is not divided at all, and the sheet says so. That still holds and is unchanged.
+
+What was wrong was **whose pool a row reads**. `producedPool` summed every plant's stock into one
+number and every distributor's row read that number, whatever region the distributor was in. On
+20-Aug-2026 all 1,279 production rows were Hyderabad's — a **South** plant — and the workbook was
+offering that tonnage to West distributors: 50 of 270 West rows carried a Free Stock figure
+(310.61 MT of distinct Hyderabad tonnage), and West's `Short by` printed **1,755.35 MT** against a
+true **2,116 MT**, the whole West order book.
+
+Since #129 a distributor is shown the stock of the plants that serve **its** region and of no
+others — see ADR-0006, which records that decision and the two masters behind it. The consequences
+for this sheet:
+
+- The column is **`Free Stock (area)`**. Its caption names who serves whom and says what an empty
+  West column means, because a screen of dashes otherwise reads as a loading bug.
+- The **sharing this ADR is about is unchanged inside an area**: two South distributors waiting on
+  one size still both see its full tonnage, `Short by` still reads 0 on a size oversubscribed
+  several times over, and the column is still totalled nowhere.
+- Across areas nothing repeats. A West row and a South row for the same size are now two different
+  figures, which is the first time this sheet has held two.
+- A distributor whose region is `Unmapped` has no derivable service area, so its stock cells read
+  **`?`** — unknown, never `0`.
+
+The eleventh column this ADR declined to add is still not added. The disambiguation it would have
+provided is now partly free: much of what looked like contention was West demand competing for South
+stock, and that demand is no longer in the same pool at all.

--- a/docs/adr/0006-stock-is-offered-only-within-a-plants-service-area.md
+++ b/docs/adr/0006-stock-is-offered-only-within-a-plants-service-area.md
@@ -1,0 +1,99 @@
+# Stock is offered only within a plant's service area
+
+A distributor is shown the finished stock of the plants that ship to **its** region, and of no
+others. Service area is stored on a **plant master**, and a **distributor master** carries a
+per-distributor region override for the exception a state map cannot express.
+
+## What was happening
+
+`producedPool` (`src/lib/calc.js`) summed stock by SKU across every plant and never read `p.plant`.
+`salesByDistributor` wrote that one number onto every distributor's row, regardless of region. So
+the Sales tab drill-down, the PB MTD workbook's **Distributor × SKU** sheet, and the WhatsApp
+servable-orders message all answered "what stock is there for this size?" with the company total.
+
+On 20-Aug-2026 every one of the 1,279 production rows in the database was `plant = 'hyderabad'`, a
+**South** plant. NPMD, Lepakshi and Tapi had produced nothing. And the workbook was offering
+Hyderabad's tonnage to **West** distributors:
+
+```
+                       what the file said        what was true
+West rows w/ Free Stock   50 of 270                 0 of 270
+West Free Stock offered   310.61 MT                 0 MT
+West "Short by"           1,755.35 MT               2,116 MT  ← the whole West order book
+```
+
+The rule itself was not missing. It was written in `CONTEXT.md` under **Service area** and
+implemented once — as the `--serves` flag in `scripts/servable-orders.mjs`, which filters *orders*
+and never *stock*. Three captions stated the opposite as though it were a decision: the workbook's
+sheet-4 note, and two lines of `docs/ALGORITHMS.md` ("Free Stock stays every plant's finished stock
+combined: stock is held where it was made, and the plant column is not applied to it"). A rule that
+lives in one document and one flag, contradicted by three captions, is not a rule.
+
+## The decision
+
+**Hyderabad and Lepakshi serve South. NPMD and Tapi serve West.**
+
+That answer is now data, in two new tables built like `state_regions` — a code seed with the table
+layered on top, per row, so a half-populated table can never un-serve what shipped:
+
+| | holds | seed | editable on |
+|---|---|---|---|
+| `plants` | `serves` — the regions this plant ships to | `src/data/plants.js` | Masters tab |
+| `distributors` | a region override, blank ⇒ use the state's region | `src/data/distributors.js` (empty) | Masters tab |
+
+Everything else about a plant — Ship From Code, ERP names, coil prefix, `manufactures` — stays a
+read-only code constant. There is nothing in any of them for a person to be right about.
+
+`salesByDistributor` now builds **one pool per region** rather than one per company:
+
+```
+distributor ─► region ────────────────► plants ─────────────► pool
+  its most      state → region map,      plants.serves        productions AND dispatch
+  recent line   or the distributor       (plant master)       entries at those plants
+  's state      master's override
+```
+
+## Four things had to move together
+
+Scoping the productions alone makes the numbers **worse** than the bug:
+
+1. **Dispatches**, by the same plant set — otherwise South's invoices are subtracted from West's
+   empty pool and every West SKU reads as negative stock. Hyderabad invoices West distributors
+   today; that tonnage leaves the *South* floor.
+2. **`allConfirmed` per region** — otherwise South's Confirmed tonnage is netted off West's zero.
+3. **`allPending` per region** — "who else is queued for this size" only means something among
+   distributors the same plants can serve.
+4. **`regionOf` resolved before the stock block**, not after it. Which pool a row reads is decided
+   by its region, so the region has to exist first. That ordering is one reason the pool could only
+   ever be one global number.
+
+## Consequences
+
+- **A West distributor's row shows West plants' stock — zero today.** Blank Free Stock, and `Short
+  by` equal to the full pending. That is the true position, and it self-corrects the day NPMD
+  produces. Every surface now says so in a sentence, because a screen of dashes otherwise reads as
+  a loading bug.
+- **Every South figure is unchanged**, to the kilo. All stock is Hyderabad's, so South's pool is
+  what the global pool was. That is the proof nothing else broke.
+- **`Unmapped` is unknown, not empty.** A distributor whose state carries no region has no derivable
+  service area, so its stock fields are `null` — `?` in the workbook, an em dash on screen, never
+  `0`. "We hold nothing for you" and "we cannot tell who serves you" are opposite instructions.
+- **An unattributed production row belongs to no service area** and is offered to nobody. This is
+  the same treatment `filterByPlant` already gives a blank plant under the header selector, and it
+  is reported: the servable-orders script prints the unlabelled tonnage on stderr rather than
+  letting it disappear.
+- **ADR-0002 is untouched inside an area.** Stock stays shared and unreserved between distributors
+  in the same region; no allocation rule was introduced and none is implied.
+- **`--serves` changed meaning.** It chooses the *audience* of the WhatsApp message; the plant
+  master chooses the *stock*. Those were one control by accident and are now two on purpose.
+
+## What was deliberately left out
+
+- **No allocation rule.** ADR-0002 still stands: inside a region, nothing is reserved to anybody.
+- **No plant split on the Dashboard's Physical Inventory total.** That KPI is the company's stock
+  and stays so.
+- **No change to how orders or invoices are attributed to plants** (ADR-0004 is untouched). An
+  order line's own `plant` still moves no stock figure — a test asserts it. Stock follows the
+  **production** row's plant, which is a different column on a different table.
+- **No editing of ERP-owned plant fields.** Renaming a plant, changing its Ship From Code or its
+  coil prefix stays a code change, because those are the ERP's facts and not ours.

--- a/e2e/roles.spec.js
+++ b/e2e/roles.spec.js
@@ -13,7 +13,7 @@ import { signIn, stubSignIn, writeRecorder, LOGINS } from './signin'
 
 const tab = (page, name) => page.getByRole('button', { name, exact: true })
 const ALL_TABS = ['Dashboard', 'Coil Tracker', '1. Coil Inward', '2. Slitting', '3. Production',
-  '4. Dispatch', 'SKU Master', 'Orders & Invoice', 'Sales', 'Reports']
+  '4. Dispatch', 'Masters', 'Orders & Invoice', 'Sales', 'Reports']
 const MANUFACTURING_TABS = ['1. Coil Inward', '2. Slitting', '3. Production']
 
 test.describe('admin', () => {
@@ -28,7 +28,7 @@ test.describe('admin', () => {
 
   test('can edit the SKU master and upload the sales workbook', async ({ page }) => {
     await signIn(page, 'admin')
-    await tab(page, 'SKU Master').click()
+    await tab(page, 'Masters').click()
     await expect(page.getByRole('button', { name: '+ Add SKU' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Edit' }).first()).toBeVisible()
 
@@ -69,7 +69,7 @@ for (const [login, plantName] of [['hyderabad', 'Hyderabad'], ['npmd', 'NPMD']])
 
     test('reads the SKU master but cannot change it', async ({ page }) => {
       await signIn(page, login)
-      await tab(page, 'SKU Master').click()
+      await tab(page, 'Masters').click()
       // The catalog itself is fully there — a plant user looks SKUs up all day.
       await expect(page.getByText(/SKU Catalog \(\d+ items\)/)).toBeVisible()
       // Every control that writes is absent from the DOM, not merely disabled.

--- a/e2e/roles.spec.js
+++ b/e2e/roles.spec.js
@@ -36,6 +36,29 @@ test.describe('admin', () => {
     await expect(page.getByRole('button', { name: 'Upload Sales Excel' })).toBeVisible()
   })
 
+  // The Masters tab carries three masters since ticket #129, and the service area is the one on it
+  // that changes a number. Assert the tick boxes are real and reachable — the whole fix is unusable
+  // if the only place to set a service area does not render.
+  test('sets a plant service area on the Masters tab', async ({ page }) => {
+    await signIn(page, 'admin')
+    await tab(page, 'Masters').click()
+    await expect(page.getByRole('heading', { name: 'SKU Master' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Plant Master' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Distributor Master' })).toBeVisible()
+
+    // As shipped: Hyderabad serves South and not West.
+    await expect(page.getByLabel('Hyderabad serves South')).toBeChecked()
+    await expect(page.getByLabel('Hyderabad serves West')).not.toBeChecked()
+    await expect(page.getByLabel('NPMD serves West')).toBeChecked()
+
+    // Ticking one writes it and leaves the other plants alone — the seed is layered under the
+    // stored rows, so editing NPMD may never un-serve Hyderabad.
+    await page.getByLabel('NPMD serves South').check()
+    await expect(page.getByLabel('NPMD serves South')).toBeChecked()
+    await expect(page.getByLabel('NPMD serves West')).toBeChecked()
+    await expect(page.getByLabel('Hyderabad serves South')).toBeChecked()
+  })
+
   test('can still move the selector onto one plant', async ({ page }) => {
     await signIn(page, 'admin')
     await page.getByLabel('Plant', { exact: true }).selectOption({ label: 'NPMD' })
@@ -76,6 +99,14 @@ for (const [login, plantName] of [['hyderabad', 'Hyderabad'], ['npmd', 'NPMD']])
       await expect(page.getByRole('button', { name: '+ Add SKU' })).toHaveCount(0)
       await expect(page.getByRole('button', { name: 'Edit' })).toHaveCount(0)
       await expect(page.getByRole('button', { name: 'Del' })).toHaveCount(0)
+      // Same rule for the two masters that joined this tab (#129): a plant user reads the service
+      // areas — they explain what their own screens show — and cannot re-point them.
+      await expect(page.getByRole('heading', { name: 'Plant Master' })).toBeVisible()
+      await expect(page.getByLabel('Hyderabad serves South')).toBeChecked()
+      await expect(page.getByLabel('Hyderabad serves South')).toBeDisabled()
+      // The distributor section has no rows to assert on here — the E2E stub answers every table
+      // read with an empty set, and the list is derived from the order book.
+      await expect(page.getByRole('heading', { name: 'Distributor Master' })).toBeVisible()
     })
 
     test('reads the order book but cannot upload it', async ({ page }) => {

--- a/scripts/daily-messages.test.mjs
+++ b/scripts/daily-messages.test.mjs
@@ -68,33 +68,59 @@ describe('scripts/daily-splits.mjs — what the daily message prints (#128)', ()
   })
 })
 
-describe('scripts/servable-orders.mjs — the message names whose floor it is (#128)', () => {
+describe('scripts/servable-orders.mjs — whose floor it is, and who may have it (#128, #129)', () => {
   // Named per case, never derived from the rows: two cases hashing to one filename would silently
   // feed one test the other's book.
   const message = (name, rows) => run('servable-orders.mjs', ['--date', D, '--in', fixture(name, rows)])
   const rows = { orders, dispatches, productions, skus, babyCoils: [], stateRegions: null }
 
-  it('names the plant the stock is standing on', () => {
-    expect(message('one-floor', rows)).toContain('🏭 Stock made at: Hyderabad')
+  // PATEL STEEL is TELANGANA (South) and PUNE STEEL is MAHARASHTRA (West), so this one book spans
+  // both service areas — which is what makes the assertions below about the boundary and not about
+  // an empty report.
+  it('names the plant the stock is standing on, and the region it serves', () => {
+    expect(message('one-floor', rows)).toContain('🏭 Stock made at: Hyderabad (South)')
   })
 
-  // The message used to say "the plant" and mean it — there was only one. With two floors in the
-  // same tables an unnamed floor is a claim, and a wrong one.
-  it('names both floors, and says they are combined, once a second plant produces', () => {
+  // The heart of #129: Hyderabad's 18.5 T is South's, and PUNE STEEL is in West. It may not be
+  // offered a kilo of it, and the message has to say why rather than look like an outage.
+  it('offers Hyderabad stock to South and says plainly that West has none', () => {
+    // Enough Hyderabad production to survive the 463.5 T already invoiced off it, so South has a
+    // real floor to be served from — otherwise both distributors read zero for the same reason and
+    // the assertion would not be about the service area at all.
+    const stocked = { ...rows, productions: [{ ...productions[0], tubeCount: 40000 }] }
+    const out = message('south-only-stock', stocked)
+    expect(out).toContain('PATEL STEEL')
+    expect(out).not.toContain('PUNE STEEL')          // West: no West plant has produced
+    expect(out).toContain('No stock for West — no plant serving it has produced any')
+  })
+
+  // Two floors serving two DIFFERENT areas are not combined and must not say they are — that
+  // sentence was true when the pool was one and is the thing this ticket removed.
+  it('names two floors separately when they serve different areas — never "combined"', () => {
     const twoFloors = { ...rows, productions: [...productions, { id: 'p2', deleted: false, plant: 'npmd', dateOfProduction: '2026-08-06', skuCode: 'S1', tubeCount: 500, totalWeight: 9.25 }] }
     const out = message('two-floors', twoFloors)
-    expect(out).toContain('🏭 Stock made at: Hyderabad + NPMD — combined, not split by plant')
-    expect(out).toContain('On-hand combines Hyderabad, NPMD')
+    expect(out).toContain('🏭 Stock made at: Hyderabad (South) + NPMD (West)')
+    expect(out).not.toContain('combined, not split by plant')
+    expect(out).not.toContain('On-hand for')          // they share no region, so nothing is summed
+    expect(out).toContain('PUNE STEEL')                // West now has a floor of its own
   })
 
-  // `Unattributed` is not a plant (CONTEXT.md), so it may never be printed as one — on either path.
-  // Two causes, two sentences: a production row nobody labelled, and an aggregated bundle too old to
-  // carry the column at all.
-  it('never calls the labelling gap a plant', () => {
+  // Two floors serving the SAME area ARE summed, and that is the case the warning is for.
+  it('warns per region when two plants serving one area are summed into one on-hand', () => {
+    const sameArea = { ...rows, productions: [...productions, { id: 'p2', deleted: false, plant: 'lepakshi', dateOfProduction: '2026-08-06', skuCode: 'S1', tubeCount: 500, totalWeight: 9.25 }] }
+    const out = message('same-area', sameArea)
+    expect(out).toContain('🏭 Stock made at: Hyderabad (South) + Lepakshi (South)')
+    expect(out).toContain('On-hand for South combines Hyderabad and Lepakshi')
+  })
+
+  // `Unattributed` is not a plant (CONTEXT.md) and serves no region, so it can never be printed as
+  // one — and since #129 its tonnage is offered to nobody, which the message must state outright
+  // rather than quietly report an empty floor.
+  it('never calls the labelling gap a plant, and says its stock reaches nobody', () => {
     const unlabelled = { ...rows, productions: [{ ...productions[0], plant: '' }] }
     const out = message('no-plant-on-rows', unlabelled)
-    expect(out).toContain('🏭 Stock: made at a plant nobody has labelled')
-    expect(out).not.toContain('Unattributed plant')
+    expect(out).toContain('🏭 Stock: no plant serving South + West has produced anything')
+    expect(out).not.toContain('Unattributed')
   })
 
   // Three plants producing must not read "both floors" — the message has four to choose from.
@@ -104,25 +130,47 @@ describe('scripts/servable-orders.mjs — the message names whose floor it is (#
       { ...productions[0], id: 'p2', plant: 'npmd' },
       { ...productions[0], id: 'p3', plant: 'lepakshi' },
     ] }
-    expect(message('three-floors', three)).toContain('🏭 Stock made at: Hyderabad + NPMD + Lepakshi — combined, not split by plant')
+    expect(message('three-floors', three))
+      .toContain('🏭 Stock made at: Hyderabad (South) + NPMD (West) + Lepakshi (South)')
   })
 
-  // The aggregated path (the one an agent uses when the egress policy blocks Supabase) has two ways
-  // to have no plant, and they are not the same fact: a bundle built before #128 never carried the
-  // column, while a current bundle can carry a row nobody labelled. Reporting the second as the
-  // first sends an operator off to rebuild a query that was fine.
-  it('tells a stale bundle apart from an unlabelled production row', () => {
-    const bundle = (prod) => ({
+  // The plant master is what decides all of this, and it is a table — so re-pointing NPMD at South
+  // has to move the message, not just the app.
+  it('follows the plant master: re-point NPMD at South and West goes dark', () => {
+    const repointed = {
+      ...rows,
+      productions: [...productions, { id: 'p2', deleted: false, plant: 'npmd', dateOfProduction: '2026-08-06', skuCode: 'S1', tubeCount: 500, totalWeight: 9.25 }],
+      plants: [{ id: 'pl1', plantId: 'npmd', serves: ['South'], deleted: false }],
+    }
+    const out = message('repointed', repointed)
+    expect(out).toContain('🏭 Stock made at: Hyderabad (South) + NPMD (South)')
+    expect(out).toContain('No stock for West')
+    expect(out).not.toContain('PUNE STEEL')
+  })
+
+  // The aggregated path (the one an agent uses when the egress policy blocks Supabase) cannot pool
+  // per service area without a plant on BOTH halves of produced − invoiced. A bundle missing either
+  // is refused outright: reporting from it would announce that nothing can be served at all.
+  it('refuses an aggregated bundle that carries no plant on production or on dispatch', () => {
+    const bundle = (prod, disp) => ({
       skus: [['S1', 'SHS', 50, 50, null, 2, 6000, '4923', 18.5]],
-      prod, disp: [['S1', 10, 100]],
+      prod, disp,
       orders: [{ code: 'D1', name: 'PATEL STEEL', state: 'TELANGANA', lines: [['S1', 30, 10]] }],
       missingDesc: [],
       checks: { pendingMt: 40, producedMt: 18.5, invoicedMt: 10 },
     })
-    const agg = (name, prod) => run('servable-orders.mjs', ['--date', D, '--agg', fixture(name, bundle(prod))])
-    expect(agg('agg-old', [['S1', 1000, 18.5]])).toContain('aggregated bundle carries no plant')
-    expect(agg('agg-unlabelled', [['S1', 1000, 18.5, '']])).toContain('🏭 Stock: made at a plant nobody has labelled')
-    expect(agg('agg-current', [['S1', 1000, 18.5, 'hyderabad']])).toContain('🏭 Stock made at: Hyderabad')
+    const agg = (name, prod, disp) => {
+      try { return run('servable-orders.mjs', ['--date', D, '--agg', fixture(name, bundle(prod, disp))]) }
+      catch (e) { return String(e.stdout || '') + String(e.stderr || '') }
+    }
+    expect(agg('agg-old', [['S1', 1000, 18.5]], [['S1', 10, 100]]))
+      .toContain('carries no plant on its production tuples')
+    expect(agg('agg-old-disp', [['S1', 1000, 18.5, 'hyderabad']], [['S1', 10, 100]]))
+      .toContain('carries no plant on its dispatch tuples')
+    expect(agg('agg-unlabelled', [['S1', 1000, 18.5, '']], [['S1', 10, 100, '']]))
+      .toContain('🏭 Stock: no plant serving South has produced anything')
+    expect(agg('agg-current', [['S1', 1000, 18.5, 'hyderabad']], [['S1', 10, 100, 'hyderabad']]))
+      .toContain('🏭 Stock made at: Hyderabad (South)')
   })
 
   // Unchanged meanings are half of this ticket: the service area still filters the order book, and

--- a/scripts/servable-orders.mjs
+++ b/scripts/servable-orders.mjs
@@ -3,11 +3,15 @@
 // Answers one question, per distributor and size: "of what this distributor is waiting on, how much
 // is sitting on the floor right now?"  Servable = min(pending, plant on-hand).
 //
-// THE FIGURE IS SHARED, NOT RESERVED (docs/adr/0002-…). On-hand is the WHOLE PLANT's stock for a
-// size; nothing is earmarked for anybody. Two distributors each waiting on 40 T of a size the plant
-// holds 45 T of will BOTH read 40 T servable, though only one can actually be served. So:
-//   - every SKU line carries the plant on-hand beside the servable tonnage
-//   - a size queued for more than the plant holds is flagged as CONTESTED
+// ON-HAND IS THE SERVICE AREA'S (ticket #129, docs/adr/0006-…). A distributor is only ever offered
+// stock made at the plants that ship to its region — Hyderabad and Lepakshi serve South, NPMD and
+// Tapi serve West, and the answer is stored on the plant master, not assumed here.
+//
+// INSIDE an area THE FIGURE IS SHARED, NOT RESERVED (docs/adr/0002-…): nothing is earmarked for
+// anybody. Two distributors in the same area each waiting on 40 T of a size the area holds 45 T of
+// will BOTH read 40 T servable, though only one can actually be served. So:
+//   - every SKU line carries the area's on-hand beside the servable tonnage
+//   - a size queued for more than the area holds is flagged as CONTESTED
 //   - there is NO plant total of servable tonnage — summing shared stock is a fiction, exactly the
 //     total ADR-0002 suppressed on the Distributor x SKU sheet. Per-distributor totals are real.
 //
@@ -28,13 +32,13 @@
 //           pulling 6k dispatch rows through an MCP tool is not viable. The bundle carries
 //           per-SKU sums, which this expands back into rows so the SAME calc.js runs on them.
 //   --min   hide SKU lines below this servable tonnage (default 0.5 T) — keeps the message pasteable.
-//   --serves REGION[,REGION]  restrict the report to distributors in these regions, because THIS
-//           PLANT CANNOT SHIP EVERYWHERE. Service area is a business rule, not a column — plants are
-//           attributed (ticket #118) but nothing records where each one ships — so it has to be
-//           passed in. It filters the ORDER BOOK before any stock maths, so
-//           `allPending`, Free Stock and the contested flag all recompute over servable demand
-//           only; a size queued 40 T by a distributor this plant cannot ship is not competing for
-//           the stock and must not be shown as if it were. Omit for every region (plant-wide).
+//   --serves REGION[,REGION]  restrict the report to distributors in these regions — WHOSE message
+//           this is, not which stock they may be served from. Since ticket #129 the stock scoping is
+//           automatic and unconditional: every distributor reads only the stock of the plants that
+//           serve its own region, whether or not this flag is passed. What the flag still does is
+//           narrow the LIST, so the South sales team gets a South message; it filters the ORDER BOOK
+//           before any stock maths, so `allPending` and the contested flag are computed over the
+//           demand shown. Omit for every region — the figures do not change, only the audience.
 //   --top   at most this many SKU lines per distributor (default 5). The rest collapse into one
 //           "+N more sizes" line that still carries their tonnage, so nothing vanishes from a
 //           distributor's total. Use --top 0 for every size.
@@ -49,7 +53,8 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { salesByDistributor, resolveProductionWeights, skuKeyResolver, canonicalSkuKey, skuSizeLabel,
          distributorRegionResolver, distributorOrderIndex, resolveDistributorIdentity,
-         plantNamesIn, UNATTRIBUTED_PLANT } from '../src/lib/calc.js'
+         plantNamesIn, UNATTRIBUTED_PLANT, UNMAPPED_REGION,
+         plantMaster, plantsServingRegion, filterByPlants } from '../src/lib/calc.js'
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -111,6 +116,8 @@ const COLS = {
   skus: 'id,deleted,created_at,sku_code,description,type,height,breadth,outside_diameter,thickness,length,weight_per_tube',
   baby_coils: 'id,created_at,baby_coil_id,hr_coil_id',
   state_regions: 'id,created_at,state,region,deleted',
+  plants: 'id,created_at,plant_id,serves,deleted',
+  distributors: 'id,created_at,distributor_key,distributor_name,region,deleted',
 }
 
 async function loadRows() {
@@ -120,7 +127,8 @@ async function loadRows() {
   if (inFile) {
     const raw = JSON.parse(readFileSync(path.resolve(inFile), 'utf8'))
     return { orders: raw.orders || [], dispatches: raw.dispatches || [], productions: raw.productions || [],
-      skus: raw.skus || [], babyCoils: raw.babyCoils || [], stateRegions: raw.stateRegions ?? null }
+      skus: raw.skus || [], babyCoils: raw.babyCoils || [], stateRegions: raw.stateRegions ?? null,
+      plants: raw.plants ?? null, distributors: raw.distributors ?? null }
   }
   const { url, key } = loadEnv()
   if (!url || !key) {
@@ -129,15 +137,19 @@ async function loadRows() {
         '  get_project_url + get_publishable_keys (project ref hztblmccvvarmgxmunrp).')
   }
   const base = url.replace(/\/+$/, '')
-  const [orders, dispatches, productions, skus, babyCoils, stateRegions] = await Promise.all([
+  const [orders, dispatches, productions, skus, babyCoils, stateRegions, plants, distributors] = await Promise.all([
     fetchAll(base, key, 'orders', COLS.orders),
     fetchAll(base, key, 'dispatches', COLS.dispatches),
     fetchAll(base, key, 'productions', COLS.productions),
     fetchAll(base, key, 'skus', COLS.skus),
     fetchAll(base, key, 'baby_coils', COLS.baby_coils, { optional: true }),
     fetchAll(base, key, 'state_regions', COLS.state_regions, { optional: true }),
+    // Both optional: the two masters (ticket #129) layer over their code seeds, so a database whose
+    // DDL has not been run yet reports the shipped service areas rather than refusing to run.
+    fetchAll(base, key, 'plants', COLS.plants, { optional: true }),
+    fetchAll(base, key, 'distributors', COLS.distributors, { optional: true }),
   ])
-  return { orders, dispatches, productions, skus, babyCoils: babyCoils || [], stateRegions }
+  return { orders, dispatches, productions, skus, babyCoils: babyCoils || [], stateRegions, plants, distributors }
 }
 
 
@@ -150,7 +162,7 @@ async function loadRows() {
 // Bundle shape (all arrays of tuples):
 //   skus        [code, productType, height, breadth, nominalBore, thickness, length, isStd, weightPerTube]
 //   prod        [code, Σtube_count, Σtotal_weight, plant]   — grouped per SKU *and* plant (#128)
-//   disp        [code, Σweight, Σpieces]
+//   disp        [code, Σweight, Σpieces, plant]              — grouped per SKU *and* plant (#129)
 //   orders      [{ code, name, lines: [[mmId, Σconfirmed, Σnon_confirmed], …] }]
 //   missingDesc [mmId, description]   — only for order codes the SKU master does not carry
 //   checks      { pendingMt, producedMt, invoicedMt } — Postgres's OWN totals, computed straight off
@@ -190,10 +202,15 @@ function loadAggregated(file) {
   // salesByDistributor's month filter drops it before the per-distributor attribution — which the
   // aggregate cannot carry anyway. This report prints no invoiced figure, so nothing is lost; if one
   // is ever added here, it must come from the live path, not from --agg.
+  // Grouped per SKU AND per plant for the same reason production is (#129): on-hand is
+  // produced − invoiced *within a service area*, and the two halves have to be scoped by the same
+  // plants or the subtraction is between different things. A bundle whose tuples carry no plant is
+  // rejected outright below rather than reported on.
   const dispatches = [{
     id: 'disp-agg', deleted: false, dateOfDispatch: '1900-01-01',
-    bundleEntries: (b.disp || []).map(([code, weight, pieces]) => ({
+    bundleEntries: (b.disp || []).map(([code, weight, pieces, plant]) => ({
       skuCode: code, weight: Number(weight || 0), pieces: Number(pieces || 0),
+      ...(plant == null ? {} : { plant }),
     })),
   }]
 
@@ -210,7 +227,8 @@ function loadAggregated(file) {
   }))
 
   assertBundleTies(b.checks, { orders, productions, dispatches })
-  return { orders, dispatches, productions, skus, babyCoils: [], stateRegions: null, aggregated: true }
+  return { orders, dispatches, productions, skus, babyCoils: [], stateRegions: null,
+    plants: null, distributors: null, aggregated: true }
 }
 
 // Re-add the expanded rows and compare with the totals Postgres reported off the base tables. A
@@ -237,7 +255,10 @@ function assertBundleTies(checks, { orders, productions, dispatches }) {
 }
 
 // ── build ──
-const { orders, dispatches, productions, skus, babyCoils, stateRegions, aggregated } = await loadRows()
+// `distributorMaster`, not `distributors` — the latter is the per-distributor REPORT rows further
+// down, and two different things under one name in one module is a bug waiting to be written.
+const { orders, dispatches, productions, skus, babyCoils, stateRegions, plants,
+        distributors: distributorMaster, aggregated } = await loadRows()
 
 const dumpFile = flag('dump')
 if (dumpFile) {
@@ -255,13 +276,14 @@ const MONTH = DATE.slice(0, 7)
 // from its most recent line's ship-to state, one region per distributor even when it ships to
 // several states, and layered over the six-row state→region seed.
 //
-// The filter lands on the ORDER BOOK, before salesByDistributor — deliberately, and this is the
-// whole point. salesByDistributor derives `allPending`, Free Stock and (here) the contested flag by
-// summing across every distributor it is given. Feeding it the national book and filtering the
-// OUTPUT would leave a South size reading "contested" because of West orders this plant cannot
-// ship — demand that is not competing for this stock at all. Filtering the input makes those three
-// figures mean "against the demand this plant can actually serve".
-const regionResolver = distributorRegionResolver(orders, dispatches, stateRegions)
+// The filter lands on the ORDER BOOK, before salesByDistributor, so `allPending` and the contested
+// flag are computed over exactly the demand the message lists.
+//
+// Since #129 it is no longer what keeps West orders out of South's stock — salesByDistributor pools
+// per service area itself, so a South size can no longer read "contested" because of West demand
+// whether or not this flag is passed. The flag chooses the AUDIENCE; the plant master chooses the
+// stock. Those were one control by accident and are now two on purpose.
+const regionResolver = distributorRegionResolver(orders, dispatches, stateRegions, null, distributorMaster)
 const orderIdx = distributorOrderIndex(orders)
 const regionOfOrder = (o) => regionResolver(resolveDistributorIdentity(o, orderIdx, false).key).region || 'Unmapped'
 
@@ -302,58 +324,103 @@ if (unmappedDropped.length) {
 // NEVER a density constant: weightPerTube is the only source (CLAUDE.md non-negotiable).
 const resolvedProductions = resolveProductionWeights(productions, skus, babyCoils)
 
-// ── Whose floor this is (ticket #128) ───────────────────────────────────────────────────────────
-// The message advises what can be served from stock ON HAND, and on-hand is produced − invoiced —
-// so the plants that produced it are the plants whose stock this is. Read off the rows rather than
-// passed in: an assumed plant name is exactly the kind of thing that stays right until it isn't.
+// ── Whose floor this is (tickets #128, #129) ────────────────────────────────────────────────────
+// The message advises what can be served from stock ON HAND, and since #129 on-hand is scoped to
+// the SERVICE AREA of each distributor — the plants that ship to its region. So the header names
+// the plants that serve the regions in this report, and nothing else: naming a floor whose stock no
+// distributor here can be served from would be worse than naming none.
 //
-// Until #118 there was one unnamed "the plant" and the message could leave it unnamed without
-// lying. With four plants attributed and two of them manufacturing, an unnamed floor implies a
-// single plant that is no longer a given — so the header names it, and names BOTH if the stock
-// spans two. It does not scope the figures to one plant: what `--serves` means for NPMD is an open
-// business question (#117), and answering it by filtering here would be inventing the answer.
-const livePlantRows = (productions || []).filter(p => !p.deleted)
-const stockPlants = plantNamesIn(livePlantRows)
-const namedPlants = stockPlants.filter(n => n !== UNATTRIBUTED_PLANT)
+// Read off the rows rather than passed in: an assumed plant name is exactly the kind of thing that
+// stays right until it isn't. `Unattributed` is never called a plant (CONTEXT.md: it is not a fifth
+// plant) and belongs to no service area either, so it cannot appear here at all — a production row
+// with no plant is a labelling gap on the shop floor, and it is reported as one below.
+//
+// It says "made at", not "held at", because that is what the rows support: on-hand is produced
+// minus invoiced at those plants, and nothing attributes the surviving tonnage back to one floor. A
+// plant that made stock and has since shipped every tonne of it is still named.
+const master = plantMaster(plants)
+const regionsInScope = [...new Set(ordersInScope.map(regionOfOrder))]
+const servingPlantIds = new Set()
+regionsInScope.forEach(r => plantsServingRegion(r, master).forEach(id => servingPlantIds.add(id)))
+
+const areaLabel = regionsInScope.length ? regionsInScope.join(' + ') : 'this area'
+
+const allLivePlantRows = (productions || []).filter(p => !p.deleted)
+// The stock this report can actually offer: rows made at a plant that serves a region in scope.
+const livePlantRows = filterByPlants(allLivePlantRows, servingPlantIds)
+const stockPlantIds = new Set(livePlantRows.map(p => String(p.plant ?? '').trim()))
+
+// An aggregated bundle built before #128/#129 carries no `plant` key on its production or dispatch
+// tuples. Since #129 that is not a cosmetic gap: with no plant, stock belongs to no service area,
+// every distributor reads zero on-hand, and the message would announce that the plant can serve
+// nothing at all. Refuse, and say what to rebuild.
+const aggProdLacksPlant = Boolean(aggregated) && allLivePlantRows.length > 0 && !allLivePlantRows.some(p => 'plant' in p)
+const aggDispLacksPlant = Boolean(aggregated) && (dispatches || []).some(d =>
+  (d.bundleEntries || []).length > 0 && !(d.bundleEntries || []).some(e => 'plant' in e))
+if (aggProdLacksPlant || aggDispLacksPlant) {
+  die(`the aggregated bundle carries no plant on its ${aggProdLacksPlant ? 'production' : 'dispatch'} tuples.\n` +
+      `  Since ticket #129 stock is pooled per SERVICE AREA, so a row with no plant belongs to no\n` +
+      `  area and reads as zero on-hand everywhere — the report would claim nothing can be served.\n` +
+      `  Rebuild the bundle grouping BOTH prod and disp per SKU *and* plant:\n` +
+      `    prod [code, \u03a3tube_count, \u03a3total_weight, plant]   disp [code, \u03a3weight, \u03a3pieces, plant]`)
+}
+
+// A production row with a BLANK plant is a different fault: the query was fine, the shop floor
+// labelling is not. It belongs to no service area and so serves nobody — say so rather than let the
+// tonnage quietly disappear from the report.
+const unlabelledMt = allLivePlantRows.filter(p => !String(p.plant ?? '').trim())
+  .reduce((t, p) => t + Number(p.totalWeight || 0), 0)
+if (unlabelledMt > 0.05) {
+  console.error(`\n   ! ${unlabelledMt.toFixed(1)} T of production carries no plant, so it belongs to no service area`)
+  console.error(`     and is offered to nobody in this report. Fix the plant on those production rows.`)
+}
 
 // What the header says about the floor, decided ONCE — the header line, the footer warning and the
-// stderr summary all read it, and three sites re-deriving "how many plants is this?" is three
-// chances to tell the reader a different story about the same stock.
+// stderr summary all read it, and three sites re-deriving "whose stock is this?" is three chances
+// to tell the reader a different story about the same tonnage.
 //
-// `Unattributed` is never called a plant here (CONTEXT.md: it is not a fifth plant). Production rows
-// with no plant are a labelling gap on the shop floor, and an aggregated bundle built before #128
-// carries no plant at all — two different causes, so two different sentences, neither of which
-// invents a floor.
-//
-// It says "made at", not "held at", because that is what the rows support: on-hand is produced minus
-// invoiced across ALL plants for a size, and nothing attributes the surviving tonnage back to a
-// floor. A plant that made stock and has since shipped every tonne of it is still named. Naming the
-// plants that made what this report counts is true; claiming to know where each tonne now sits is
-// not, and per-plant stock is out of scope by #117.
-//
-// An aggregated bundle built before #128 has no `plant` KEY on its production rows at all, which is
-// a stale query; a row carrying an empty plant is a labelling gap on the shop floor. Different
-// causes, different sentences — and the second one must never be reported as the first, or an
-// operator goes off to rebuild a bundle that was fine.
-const aggBundleLacksPlant = Boolean(aggregated) && livePlantRows.length > 0 && !livePlantRows.some(p => 'plant' in p)
+// Each plant is named WITH the regions it serves in this report ("Hyderabad (South)"), because the
+// two facts are only useful together: a reader who knows the stock was made at Hyderabad still
+// cannot tell whether their distributor may have any of it. `Unattributed` cannot appear — it is
+// not a plant and serves no region, so `filterByPlants` has already dropped it.
+const inScope = (r) => regionsInScope.some(x => x.toLowerCase() === String(r).toLowerCase())
+const stockPlants = master.filter(p => stockPlantIds.has(p.id))
+  .map(p => ({ name: p.name, regions: (p.serves || []).filter(inScope) }))
+const stockPlantNames = plantNamesIn(livePlantRows)
+// Regions in this report that no plant with stock serves — every distributor there reads zero, and
+// a message that did not say so would look like an outage.
+const dryRegions = regionsInScope.filter(r => r !== UNMAPPED_REGION
+  && !stockPlants.some(p => p.regions.some(x => x.toLowerCase() === r.toLowerCase())))
+
+// A region in this report served by MORE THAN ONE plant with stock: their floors are summed into
+// one on-hand, which inside a service area is the intended behaviour — an order there can be filled
+// from either — but a size may still be sitting at the further of the two. Named per region, because
+// "combines Hyderabad, NPMD" would be false the moment those two serve different areas, which is
+// exactly what they do today.
+const sharedAreas = regionsInScope
+  .map(r => ({ region: r, names: stockPlants.filter(p => p.regions.some(x => x.toLowerCase() === r.toLowerCase())).map(p => p.name) }))
+  .filter(g => g.names.length > 1)
+
 const stockScope = () => {
-  if (!livePlantRows.length) return { header: '', footer: '' }
-  if (aggBundleLacksPlant) {
-    return { header: '🏭 Stock: plant not identified — aggregated bundle carries no plant', footer: '' }
+  if (!allLivePlantRows.length) return { header: '', footer: '' }
+  const named = stockPlants.map(p => `${p.name} (${p.regions.join(', ') || 'no region in this report'})`).join(' + ')
+  const lines = []
+  if (dryRegions.length) {
+    lines.push(`_\u26a0\ufe0f No stock for ${dryRegions.join(', ')} \u2014 no plant serving ${dryRegions.length === 1 ? 'it' : 'them'} has produced any. Those distributors show their full pending, which is the true position._`)
   }
-  if (!namedPlants.length) {
-    return { header: '🏭 Stock: made at a plant nobody has labelled', footer: '' }
+  sharedAreas.forEach(g => lines.push(
+    `_\u26a0\ufe0f On-hand for ${g.region} combines ${g.names.join(' and ')} \u2014 a size may be sitting at the further plant from the distributor waiting on it._`))
+  if (!stockPlants.length) {
+    return {
+      header: `\ud83c\udfed Stock: no plant serving ${areaLabel} has produced anything`,
+      footer: lines.join('\n') || `_\u26a0\ufe0f Nothing on this list can be served from stock: the plants that serve ${areaLabel} hold none. Check the service areas on the Masters tab if that is wrong._`,
+    }
   }
-  if (stockPlants.length === 1) return { header: `🏭 Stock made at: ${stockPlants[0]}`, footer: '' }
-  // Two or more: the floors are summed into one on-hand, which is a real limit of this report and
-  // the reader is the one who can act on it. State it where the figures are.
-  return {
-    header: `🏭 Stock made at: ${stockPlants.join(' + ')} — combined, not split by plant`,
-    footer: `_⚠️ On-hand combines ${stockPlants.join(', ')} — a size may be sitting at a different plant from the distributor waiting on it._`,
-  }
+  return { header: `\ud83c\udfed Stock made at: ${named}`, footer: lines.join('\n') }
 }
 const stock = stockScope()
-const rows = salesByDistributor(ordersInScope, dispatches, MONTH, skus, { productions: resolvedProductions, stateRegions })
+const rows = salesByDistributor(ordersInScope, dispatches, MONTH, skus,
+  { productions: resolvedProductions, stateRegions, plants, distributors: distributorMaster })
 
 const EPS = 0.005
 
@@ -448,7 +515,9 @@ const totals = {
   distributors: distributors.length,
   nothingServable,
   servesRegions: SERVES,
-  stockPlants,
+  stockPlants: stockPlantNames,
+  stockPlantAreas: stockPlants,
+  dryRegions,
   outOfScopeDistributors: outOfScope.size,
   outOfScopeMt,
   // Pending across the whole book, servable or not — this one IS additive (each distributor's own
@@ -462,7 +531,10 @@ const totals = {
 const summary = { date: DATE, month: MONTH, minMt: MIN, topPerDistributor: TOP, distributors, totals,
   outOfScope: [...outOfScope].map(([customer, e]) => ({ customer, region: e.region, pending: e.pending })),
   diagnostics: { orders: orders.length, dispatches: dispatches.length, productions: productions.length,
-    skus: skus.length, stateRegions: stateRegions == null ? 'table absent (seed only)' : stateRegions.length } }
+    skus: skus.length, stateRegions: stateRegions == null ? 'table absent (seed only)' : stateRegions.length,
+    plants: plants == null ? 'table absent (seed only)' : plants.length,
+    distributorMaster: distributorMaster == null ? 'table absent (seed only)' : distributorMaster.length,
+    servingPlants: [...servingPlantIds] } }
 
 // ── WhatsApp text ──
 function whatsapp() {
@@ -498,7 +570,7 @@ function whatsapp() {
     L.push(`_⚠️ ${unmappedDropped.length} distributor${unmappedDropped.length === 1 ? '' : 's'} (${T(mt)}) left out only because their state is not mapped to a region — map it on the Sales tab._`)
   }
   L.push('')
-  L.push('_Stock is the plant\'s and is reserved to nobody — the same tonnage can appear against two distributors, so these lines do not add up to a plant total._')
+  L.push('_Each distributor is offered only the stock of the plants that serve its region. Inside a region that stock is reserved to nobody — the same tonnage can appear against two distributors, so these lines do not add up to a plant total._')
   // More than one floor counted as one is a real limit of this report — named where the figures are,
   // not in a doc nobody has open at 8am.
   if (stock.footer) L.push(stock.footer)

--- a/scripts/servable-orders.mjs
+++ b/scripts/servable-orders.mjs
@@ -53,7 +53,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { salesByDistributor, resolveProductionWeights, skuKeyResolver, canonicalSkuKey, skuSizeLabel,
          distributorRegionResolver, distributorOrderIndex, resolveDistributorIdentity,
-         plantNamesIn, UNATTRIBUTED_PLANT, UNMAPPED_REGION,
+         plantNamesIn, UNMAPPED_REGION,
          plantMaster, plantsServingRegion, filterByPlants } from '../src/lib/calc.js'
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
@@ -345,7 +345,10 @@ regionsInScope.forEach(r => plantsServingRegion(r, master).forEach(id => serving
 
 const areaLabel = regionsInScope.length ? regionsInScope.join(' + ') : 'this area'
 
-const allLivePlantRows = (productions || []).filter(p => !p.deleted)
+// Off the LIVE-RESOLVED rows, not the stored ones — the tonnage reported below has to be the same
+// tonnage salesByDistributor pooled, or the "carries no plant" warning would quote a figure nothing
+// on screen holds (CLAUDE.md: weight comes from weightPerTube, never from a frozen total_weight).
+const allLivePlantRows = (resolvedProductions || []).filter(p => !p.deleted)
 // The stock this report can actually offer: rows made at a plant that serves a region in scope.
 const livePlantRows = filterByPlants(allLivePlantRows, servingPlantIds)
 const stockPlantIds = new Set(livePlantRows.map(p => String(p.plant ?? '').trim()))

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3097,11 +3097,19 @@ function SalesDashboard({ orders, dispatches, skus, productions = [], estimates 
   // distributor's SERVICE AREA, so the tooltips have to name it — "the plant's stock" is the
   // sentence that made the workbook offer Hyderabad tonnage to West distributors for a month.
   const selectedRegion = selected?.region || UNMAPPED_REGION
+  // The plants that serve a region, by display name. One helper, three readers (two tooltips and
+  // the caption) — three sites re-deriving "whose stock is this?" is three chances to tell the
+  // reader a different story about the same tonnage.
+  const areaPlants = useCallback((region) => region === UNMAPPED_REGION ? []
+    : [...plantsServingRegion(region, plantMaster(plants))].map(id => plantLabel(id)), [plants])
+  // The same thing said as a noun phrase, for a tooltip. Every branch has to name the AREA, because
+  // a figure whose scope is unstated is what this ticket was about: "the plant's stock" is the
+  // sentence that let the workbook offer Hyderabad tonnage to West for a month.
   const areaLabel = useCallback((region) => {
-    if (region === UNMAPPED_REGION) return 'No service area known —'
-    const names = [...plantsServingRegion(region, plantMaster(plants))].map(id => plantLabel(id))
-    return names.length ? `${names.join(' + ')} (${region})` : `No plant serves ${region} —`
-  }, [plants])
+    if (region === UNMAPPED_REGION) return 'an unknown service area (this distributor\u2019s state carries no region)'
+    const names = areaPlants(region)
+    return names.length ? `${names.join(' + ')} \u2014 the plants serving ${region}` : `${region}, which no plant serves`
+  }, [areaPlants])
   const monthRows = useMemo(() => salesByMonth(orders, dispatches), [orders, dispatches])
 
   // Filter options carry the identity id as value (matches r.id) and the short code as label.
@@ -3229,12 +3237,12 @@ function SalesDashboard({ orders, dispatches, skus, productions = [], estimates 
     { label: 'Free Stock (T)', value: r => r.freeStock ?? 0,
       render: r => r.freeStock == null
         ? <span className="text-slate-400" title={`No region mapped for this distributor's state, so we cannot tell which plants serve it. Map the state in the Region column above.`}>—</span>
-        : <span title={`${areaLabel(selectedRegion)} stock for this SKU less Confirmed orders across every distributor in that area — not reserved for this one. On-hand ${fmtT(r.onhand ?? 0)} T − Confirmed ${fmtT(r.allConfirmed ?? 0)} T`}>{redIfNeg(r.freeStock)}</span>,
+        : <span title={`Stock at ${areaLabel(selectedRegion)}, less the Confirmed orders of every distributor in that area — not reserved for this one. On-hand ${fmtT(r.onhand ?? 0)} T − Confirmed ${fmtT(r.allConfirmed ?? 0)} T`}>{redIfNeg(r.freeStock)}</span>,
       total: v => redIfNeg(v) },
     { label: 'All Distr. Pending (T)', value: r => r.allPending ?? 0,
       render: r => r.allPending == null ? <span className="text-slate-400">—</span>
         : <span className={r.onhand != null && r.allPending > r.onhand ? 'text-amber-600 dark:text-amber-400' : ''}
-            title={`Pending across every distributor this SKU could be served to from the same plants (${areaLabel(selectedRegion)})`}>{fmtT(r.allPending)}</span> },
+            title={`Pending across every distributor in ${selectedRegion} — the demand competing for this same stock. Distributors elsewhere are served from other plants and are not counted here.`}>{fmtT(r.allPending)}</span> },
     { label: 'Short by (T)', value: r => r.shortBy ?? 0,
       render: r => r.shortBy == null ? <span className="text-slate-400">—</span>
         : r.shortBy > 0
@@ -3369,7 +3377,7 @@ function SalesDashboard({ orders, dispatches, skus, productions = [], estimates 
                   without it a screen of dashes reads like a loading bug. */}
               <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
                 <strong>Free Stock</strong> = the stock of the plants that <strong>serve {selectedRegion}</strong>
-                {' '}({areaLabel(selectedRegion).replace(/ —$/, '')}) for this SKU (produced − invoiced) less the
+                {areaPlants(selectedRegion).length ? ` (${areaPlants(selectedRegion).join(' + ')})` : ''} for this SKU (produced − invoiced) less the
                 {' '}<strong>Confirmed</strong> tonnage of <strong>every</strong> distributor in that same area — what is promised to
                 nobody yet. It is <strong>not reserved</strong> for {distributorCode(selected.customer)}, and goes
                 {' '}<span className="text-red-600 dark:text-red-400">negative</span> when the size is committed beyond what is on the
@@ -3377,7 +3385,7 @@ function SalesDashboard({ orders, dispatches, skus, productions = [], estimates 
                 be served even with no <strong>Short by</strong> shown. {selectedRegion} is set from this distributor’s ship-to state,
                 and which plants serve it is set on the <strong>Masters</strong> tab.
               </p>
-              {selectedRegion !== UNMAPPED_REGION && plantsServingRegion(selectedRegion, plantMaster(plants)).size === 0 && (
+              {selectedRegion !== UNMAPPED_REGION && areaPlants(selectedRegion).length === 0 && (
                 <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
                   <strong>No plant serves {selectedRegion} yet</strong>, so every Free Stock reads 0 and every
                   {' '}<strong>Short by</strong> is this distributor’s full pending. Those dashes are the real position, not a

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import {
   UNATTRIBUTED_PLANT, plantLabel, dispatchPlantLabel, plantForErpRow, erpRowPicker,
   coilInwardPlants, DEFAULT_COIL_PLANT, babyCoilPlant, productionPlant, crossPlantAllocationRows,
   ALL_PLANTS, plantFilterOptions, filterByPlant, filterDispatchesByPlant, withDispatchEntries,
+  plantMaster, plantsServingRegion,
   accessFor, parseStoredSession,
 } from './lib/calc'
 import { loadChunk } from './lib/chunk'
@@ -1663,8 +1664,13 @@ function Dispatch({ dispatches, setDispatches, coils, skus, plantScoped = false,
 }
 
 // ═══════════════════════════════════════════════════════════════
-// SKU MASTER
+// MASTERS — SKU, Plant, Distributor
 // ═══════════════════════════════════════════════════════════════
+// One tab, three masters (ticket #129). They sit together because they are the same KIND of thing:
+// the handful of facts the ERP does not ship and a person therefore has to state — a tube's weight,
+// a plant's service area, a distributor's region when its state gets it wrong. The tab KEY is still
+// `skuMaster`, so `accessFor` grants exactly what it granted before.
+//
 // `readOnly` (ticket #126) withholds every control that WRITES — the add form, Edit and Del. The
 // catalog itself still renders in full: a plant user needs to look up a SKU's weight and price
 // constantly, and it is one company-wide catalog, so there is nothing here to scope, only to lock.
@@ -1752,7 +1758,7 @@ function SKUMaster({ skus, setSkus, productions, readOnly = false }) {
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">SKU Master</h2>
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-white">SKU Master</h3>
         {!readOnly && <Btn onClick={() => { setForm(emptySku); setEditId(null); setShowForm(!showForm) }}>{showForm ? 'Cancel' : '+ Add SKU'}</Btn>}
       </div>
 
@@ -1794,6 +1800,188 @@ function SKUMaster({ skus, setSkus, productions, readOnly = false }) {
         <DataTable columns={columns} data={skus}
           onEdit={readOnly ? undefined : startEdit} onDelete={readOnly ? undefined : deleteSku} />
       </Section>
+    </div>
+  )
+}
+
+// ── PLANT MASTER — the service area (ticket #129) ───────────────────────────────────────────────
+// One editable field on the whole section: which regions a plant ships to. Everything else on a
+// plant comes from the ERP (its Ship From Code, its coil prefix) or from the code seed (whether it
+// manufactures), so it is shown and locked — there is nothing here for a person to be right about.
+//
+// A checkbox per region rather than a text field, because the four regions are fixed and a typed
+// "Wesr" would silently mean "serves nowhere". Commits on every click; the store write is upserted
+// on `plant_id`, so the first edit of a seeded plant creates its row and every later edit updates it.
+function PlantServesCell({ plant, serves, onCommit, disabled }) {
+  const has = (r) => serves.some(x => x.toLowerCase() === r.toLowerCase())
+  return (
+    <span className="flex flex-wrap gap-2">
+      {REGIONS.map(r => (
+        <label key={r} className={`flex items-center gap-1 text-xs px-2 py-1 rounded border ${has(r)
+          ? 'border-indigo-400 bg-indigo-50 text-indigo-800 dark:border-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-200'
+          : 'border-slate-300 text-slate-500 dark:border-slate-600 dark:text-slate-400'} ${disabled ? 'opacity-50' : 'cursor-pointer'}`}>
+          <input type="checkbox" className="accent-indigo-600" checked={has(r)} disabled={disabled}
+            aria-label={`${plant.name} serves ${r}`}
+            onChange={e => onCommit(e.target.checked
+              ? [...serves.filter(x => x.toLowerCase() !== r.toLowerCase()), r]
+              : serves.filter(x => x.toLowerCase() !== r.toLowerCase()))} />
+          {r}
+        </label>
+      ))}
+    </span>
+  )
+}
+
+function PlantMaster({ plants, setPlants, readOnly = false }) {
+  const master = useMemo(() => plantMaster(plants), [plants])
+
+  // One row per plant, keyed on the plant's LITERAL id — never on the store row's uuid, which does
+  // not exist until the first edit. Writing `serves: []` is a real answer ("serves nowhere") and is
+  // stored as such; what restores the shipped default is deleting the row, which this screen does
+  // not offer, because un-typing a commercial decision is not a thing an operator should do by
+  // accident.
+  const saveServes = useCallback((plantId, serves) => {
+    if (!setPlants) return
+    setPlants(prev => {
+      const rows = prev || []
+      const i = rows.findIndex(r => String(r.plantId || '') === plantId)
+      if (i >= 0) { const next = [...rows]; next[i] = { ...next[i], serves, deleted: false }; return next }
+      return [...rows, { id: crypto.randomUUID(), plantId, serves, deleted: false }]
+    })
+  }, [setPlants])
+
+  const columns = [
+    { label: 'Plant', key: 'name' },
+    { label: 'ERP Ship From Code', value: r => r.erpCode, render: r => <span className="font-mono text-xs">{r.erpCode}</span> },
+    { label: 'Coil Prefix', key: 'coilPrefix' },
+    { label: 'Runs the pipeline', value: r => (r.manufactures ? 'Yes' : 'No'),
+      render: r => <Badge ok={r.manufactures} text={r.manufactures ? 'Yes' : 'No'} /> },
+    { label: 'Serves (regions)', value: r => (r.serves || []).join(', '),
+      render: r => <PlantServesCell plant={r} serves={r.serves || []}
+        disabled={readOnly || !setPlants} onCommit={v => saveServes(r.id, v)} /> },
+  ]
+
+  const unserved = REGIONS.filter(r => plantsServingRegion(r, master).size === 0)
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Plant Master</h3>
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        <strong>Serves</strong> is a plant’s <strong>service area</strong> — the regions it will actually ship to. It is the
+        one thing here a person sets; the ERP code, coil prefix and whether the plant runs the pipeline all come from the ERP
+        and are read-only. It decides which stock a distributor is shown on the <strong>Sales</strong> tab and in the
+        PB MTD workbook: a distributor sees the stock of the plants that serve <strong>its</strong> region and of no others.
+      </p>
+      <DataTable columns={columns} data={master} />
+      {unserved.length > 0 && (
+        <p className="text-xs text-amber-600 dark:text-amber-400">
+          No plant serves <strong>{unserved.join(', ')}</strong> — distributors there are shown no stock at all, and their
+          full pending as “Short by”. That is the true position while it holds; tick a region above the day it changes.
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ── DISTRIBUTOR MASTER — the region override (ticket #129) ──────────────────────────────────────
+// Region normally comes from the distributor's SHIP-TO STATE, which arrives with the ERP data and
+// is never typed. This section is only for the exception that rule cannot express: a distributor
+// whose state says one region but who is genuinely served as another.
+//
+// Blank is the ordinary value and means "use the state's region" — which is why clearing writes ''
+// rather than deleting the row, and why the cell shows the inherited answer beside the select.
+function DistributorRegionCell({ customer, state, inherited, override, onCommit, disabled }) {
+  return (
+    <span onClick={e => e.stopPropagation()} className="flex items-center gap-2">
+      <select value={REGIONS.includes(override) ? override : ''} disabled={disabled}
+        aria-label={`Region override for ${customer}`}
+        title={`Override ${customer}'s region. Blank uses ${state ? `${state}'s` : 'the state'} mapping (${inherited}).`}
+        onChange={e => onCommit(e.target.value)}
+        className="w-28 px-2 py-1 rounded border border-blue-300 dark:border-blue-700 text-sm bg-blue-50/60 dark:bg-blue-900/20 dark:text-slate-100 focus:ring-1 focus:ring-indigo-500 outline-none disabled:opacity-50">
+        <option value="">(use state)</option>
+        {REGIONS.map(r => <option key={r} value={r}>{r}</option>)}
+      </select>
+      {!override && <span className="text-xs text-slate-400">→ {inherited}</span>}
+    </span>
+  )
+}
+
+function DistributorMaster({ rows, distributors, setDistributors, readOnly = false }) {
+  const [onlyOverridden, setOnlyOverridden] = useState(false)
+
+  const saveOverride = useCallback((row, region) => {
+    if (!setDistributors) return
+    setDistributors(prev => {
+      const list = prev || []
+      const i = list.findIndex(r => String(r.distributorKey || '') === row.id)
+      if (i >= 0) {
+        const next = [...list]
+        next[i] = { ...next[i], distributorKey: row.id, distributorName: row.customer, region, deleted: false }
+        return next
+      }
+      return [...list, { id: crypto.randomUUID(), distributorKey: row.id, distributorName: row.customer, region, deleted: false }]
+    })
+  }, [setDistributors])
+
+  const data = useMemo(() => (onlyOverridden ? rows.filter(r => r.regionOverride) : rows), [rows, onlyOverridden])
+
+  const columns = [
+    { label: 'Distributor', value: r => r.customer, render: r => <span title={r.customer}>{distributorCode(r.customer, 3) || '—'}</span> },
+    { label: 'State', value: r => r.state || '',
+      render: r => r.state || <span className="text-slate-400" title="No state on this distributor's order or invoice lines">—</span> },
+    { label: 'Region in use', value: r => r.region,
+      render: r => <span className={r.regionOverride ? 'text-indigo-600 dark:text-indigo-400 font-medium' : ''}
+        title={r.regionOverride ? 'Set here, overriding the state map' : 'Inherited from the state map'}>{r.region}</span> },
+    { label: 'Override', value: r => r.regionOverride || '',
+      render: r => <DistributorRegionCell customer={r.customer} state={r.state}
+        inherited={r.inheritedRegion} override={r.regionOverride}
+        disabled={readOnly || !setDistributors} onCommit={v => saveOverride(r, v)} /> },
+  ]
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Distributor Master</h3>
+        <label className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+          <input type="checkbox" className="accent-indigo-600" checked={onlyOverridden}
+            onChange={e => setOnlyOverridden(e.target.checked)} />
+          Show only overridden ({rows.filter(r => r.regionOverride).length})
+        </label>
+      </div>
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        A distributor’s region comes from its <strong>ship-to state</strong>, mapped on the <strong>Sales</strong> tab —
+        map a state once and every distributor there follows it, new ones included. Set an <strong>Override</strong> here
+        only for the exception that rule cannot express. Blank means “use the state’s region”, which is what almost every
+        distributor should stay on. Region decides which plants’ stock the distributor is shown.
+      </p>
+      <DataTable columns={columns} data={data} maxHeight="60vh" />
+    </div>
+  )
+}
+
+// The tab itself: the three masters in one place, in the order they are used — a SKU is looked up
+// daily, a service area a few times a year, an override almost never.
+function Masters({ skus, setSkus, productions, orders, dispatches, stateRegions,
+                   plants, setPlants, distributors, setDistributors, readOnly = false }) {
+  // The distributor list comes from the SAME salesByDistributor the Sales tab and the workbook read,
+  // so a region shown here is the region the stock pool is actually built from. `inheritedRegion` is
+  // the second call with the overrides withheld — what the row would read if the override came off,
+  // which is the only honest thing to print beside a blank select.
+  const rows = useMemo(() => {
+    const inherited = new Map(salesByDistributor(orders, dispatches, '', [], { stateRegions })
+      .map(r => [r.id, r.region]))
+    return salesByDistributor(orders, dispatches, '', [], { stateRegions, distributors })
+      .map(r => ({ ...r, inheritedRegion: inherited.get(r.id) || UNMAPPED_REGION }))
+      .sort((a, b) => a.customer.localeCompare(b.customer))
+  }, [orders, dispatches, stateRegions, distributors])
+
+  return (
+    <div className="space-y-8">
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Masters</h2>
+      <SKUMaster skus={skus} setSkus={setSkus} productions={productions} readOnly={readOnly} />
+      <PlantMaster plants={plants} setPlants={readOnly ? null : setPlants} readOnly={readOnly} />
+      <DistributorMaster rows={rows} distributors={distributors}
+        setDistributors={readOnly ? null : setDistributors} readOnly={readOnly} />
     </div>
   )
 }
@@ -2855,7 +3043,7 @@ function RegionCell({ state, region, onCommit, disabled }) {
   )
 }
 
-function SalesDashboard({ orders, dispatches, skus, productions = [], estimates = [], setEstimates = null, stateRegions = [], setStateRegions = null, selectedPlant = ALL_PLANTS, canWiden = true }) {
+function SalesDashboard({ orders, dispatches, skus, productions = [], estimates = [], setEstimates = null, stateRegions = [], setStateRegions = null, plants = [], distributors = [], selectedPlant = ALL_PLANTS, canWiden = true }) {
   const skuDesc = useCallback((code) => skus.find(s => s.skuCode === code)?.description || code, [skus])
 
   // ── Best Estimate under a plant filter (ticket #121) ──────────────────────────────────────────
@@ -2900,10 +3088,20 @@ function SalesDashboard({ orders, dispatches, skus, productions = [], estimates 
   }, [orders, dispatches, curMonth])
 
   const kpis = useMemo(() => salesKpis(orders, dispatches, month), [orders, dispatches, month])
-  const allRows = useMemo(() => salesByDistributor(orders, dispatches, month, skus, { estimates, productions, stateRegions }),
-    [orders, dispatches, month, skus, estimates, productions, stateRegions])
+  const allRows = useMemo(() => salesByDistributor(orders, dispatches, month, skus, { estimates, productions, stateRegions, plants, distributors }),
+    [orders, dispatches, month, skus, estimates, productions, stateRegions, plants, distributors])
   const rows = useMemo(() => distributor ? allRows.filter(r => r.id === distributor) : allRows, [allRows, distributor])
   const selected = useMemo(() => allRows.find(r => r.id === selectedCustomer) || null, [allRows, selectedCustomer])
+
+  // Whose stock the drill-down is showing (ticket #129). The stock columns are scoped to the open
+  // distributor's SERVICE AREA, so the tooltips have to name it — "the plant's stock" is the
+  // sentence that made the workbook offer Hyderabad tonnage to West distributors for a month.
+  const selectedRegion = selected?.region || UNMAPPED_REGION
+  const areaLabel = useCallback((region) => {
+    if (region === UNMAPPED_REGION) return 'No service area known —'
+    const names = [...plantsServingRegion(region, plantMaster(plants))].map(id => plantLabel(id))
+    return names.length ? `${names.join(' + ')} (${region})` : `No plant serves ${region} —`
+  }, [plants])
   const monthRows = useMemo(() => salesByMonth(orders, dispatches), [orders, dispatches])
 
   // Filter options carry the identity id as value (matches r.id) and the short code as label.
@@ -3021,20 +3219,24 @@ function SalesDashboard({ orders, dispatches, skus, productions = [], estimates 
     { label: 'Pending to Dispatch (T)', value: r => r.pending, render: r => fmtT(r.pending), total: v => fmtT(v) },
     { label: 'MTD Invoice (T)', value: r => r.mtdInvoice, render: r => fmtT(r.mtdInvoice), total: v => fmtT(v) },
     { label: 'Total Orders (T)', value: r => r.totalOrders, render: r => fmtT(r.totalOrders), total: v => fmtT(v) },
-    // ── Inventory against the orders. Free Stock is the PLANT's stock for the SKU less the Confirmed
-    // tonnage of every distributor — unreserved, so the same figure shows under every distributor
-    // waiting on that size (ADR-0002). "All Distr. Pending" is what makes the sharing visible: stock
-    // below it means the size is oversubscribed even where this distributor alone looks covered. ──
+    // ── Inventory against the orders, scoped to this distributor's SERVICE AREA (ticket #129). Free
+    // Stock is the stock of the plants that serve its region, less the Confirmed tonnage of every
+    // distributor in that same area — unreserved there, so the same figure shows under every
+    // distributor in the area waiting on that size (ADR-0002). "All Distr. Pending" is what makes
+    // that sharing visible: stock below it means the size is oversubscribed even where this
+    // distributor alone looks covered. A null (an `Unmapped` distributor — no known service area)
+    // renders as an em dash, never as 0. ──
     { label: 'Free Stock (T)', value: r => r.freeStock ?? 0,
-      render: r => r.freeStock == null ? '—'
-        : <span title={`Plant stock for this SKU less Confirmed orders across all distributors — not reserved for this one. On-hand ${fmtT(r.onhand ?? 0)} T − Confirmed ${fmtT(r.allConfirmed ?? 0)} T`}>{redIfNeg(r.freeStock)}</span>,
+      render: r => r.freeStock == null
+        ? <span className="text-slate-400" title={`No region mapped for this distributor's state, so we cannot tell which plants serve it. Map the state in the Region column above.`}>—</span>
+        : <span title={`${areaLabel(selectedRegion)} stock for this SKU less Confirmed orders across every distributor in that area — not reserved for this one. On-hand ${fmtT(r.onhand ?? 0)} T − Confirmed ${fmtT(r.allConfirmed ?? 0)} T`}>{redIfNeg(r.freeStock)}</span>,
       total: v => redIfNeg(v) },
     { label: 'All Distr. Pending (T)', value: r => r.allPending ?? 0,
-      render: r => r.allPending == null ? '—'
+      render: r => r.allPending == null ? <span className="text-slate-400">—</span>
         : <span className={r.onhand != null && r.allPending > r.onhand ? 'text-amber-600 dark:text-amber-400' : ''}
-            title="Pending across every distributor for this SKU">{fmtT(r.allPending)}</span> },
+            title={`Pending across every distributor this SKU could be served to from the same plants (${areaLabel(selectedRegion)})`}>{fmtT(r.allPending)}</span> },
     { label: 'Short by (T)', value: r => r.shortBy ?? 0,
-      render: r => r.shortBy == null ? '—'
+      render: r => r.shortBy == null ? <span className="text-slate-400">—</span>
         : r.shortBy > 0
           ? <span className="text-red-600 dark:text-red-400 font-medium">{fmtT(r.shortBy)}</span>
           : <span className="text-emerald-600 dark:text-emerald-400">—</span>,
@@ -3161,15 +3363,34 @@ function SalesDashboard({ orders, dispatches, skus, productions = [], estimates 
           {selected.skuRows.length ? (
             <>
               <DataTable columns={skuCols} data={selected.skuRows} filters={skuBreakdownFilters} exportRef={skuBreakdownExportRef} excel maxHeight="60vh" totalsLabel="TOTAL" />
-              {/* ADR-0002 — the stock shown here is the plant's and is not reserved, so two
-                  distributors waiting on one size are both shown covered by the same tonnage. */}
+              {/* Ticket #129 — the stock shown here is the SERVICE AREA's, and ADR-0002 still holds
+                  inside it: two distributors in the same area waiting on one size are both shown
+                  covered by the same tonnage. The empty-area sentence below is not decoration —
+                  without it a screen of dashes reads like a loading bug. */}
               <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
-                <strong>Free Stock</strong> = the <strong>plant's</strong> stock for the SKU (produced − invoiced) less the
-                {' '}<strong>Confirmed</strong> tonnage of <strong>every</strong> distributor — what is promised to nobody yet. It is
-                {' '}<strong>not reserved</strong> for {distributorCode(selected.customer)}, and goes <span className="text-red-600 dark:text-red-400">negative</span> when
-                the size is committed beyond what is on the floor. Where <strong>All Distr. Pending</strong> exceeds it, the size is
-                oversubscribed and this distributor may not be served even with no <strong>Short by</strong> shown.
+                <strong>Free Stock</strong> = the stock of the plants that <strong>serve {selectedRegion}</strong>
+                {' '}({areaLabel(selectedRegion).replace(/ —$/, '')}) for this SKU (produced − invoiced) less the
+                {' '}<strong>Confirmed</strong> tonnage of <strong>every</strong> distributor in that same area — what is promised to
+                nobody yet. It is <strong>not reserved</strong> for {distributorCode(selected.customer)}, and goes
+                {' '}<span className="text-red-600 dark:text-red-400">negative</span> when the size is committed beyond what is on the
+                floor. Where <strong>All Distr. Pending</strong> exceeds it, the size is oversubscribed and this distributor may not
+                be served even with no <strong>Short by</strong> shown. {selectedRegion} is set from this distributor’s ship-to state,
+                and which plants serve it is set on the <strong>Masters</strong> tab.
               </p>
+              {selectedRegion !== UNMAPPED_REGION && plantsServingRegion(selectedRegion, plantMaster(plants)).size === 0 && (
+                <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                  <strong>No plant serves {selectedRegion} yet</strong>, so every Free Stock reads 0 and every
+                  {' '}<strong>Short by</strong> is this distributor’s full pending. Those dashes are the real position, not a
+                  loading error — they fill in by themselves the day a plant that serves {selectedRegion} produces.
+                </p>
+              )}
+              {selectedRegion === UNMAPPED_REGION && (
+                <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                  <strong>This distributor’s state carries no region</strong>, so we cannot tell which plants serve it and the
+                  stock columns read “—” rather than 0 — unknown, not empty. Map the state in the <strong>Region</strong> column of
+                  the table above and the figures appear.
+                </p>
+              )}
             </>
           ) : <p className="text-sm text-slate-400 py-8 text-center">No SKU rows for this distributor</p>}
         </Section>
@@ -3199,6 +3420,8 @@ const TABLE_LABELS = {
   dispatches: 'Dispatches',
   skus: 'SKU Master',
   orders: 'Orders',
+  plants: 'Plant Master',
+  distributors: 'Distributor Master',
 }
 
 function SyncErrorBanner() {
@@ -3240,7 +3463,7 @@ function SyncErrorBanner() {
 // The lazy import goes through loadChunk (lib/chunk.js): a tab left open across a deploy asks for a
 // hashed chunk Vercel no longer serves ("Failed to fetch dynamically imported module"), so it
 // reloads once instead of showing that to the operator. ──
-function Reports({ skus, productions, dispatches, coils, babyCoils, orders, estimates = [], stateRegions = [], selectedPlant = ALL_PLANTS }) {
+function Reports({ skus, productions, dispatches, coils, babyCoils, orders, estimates = [], stateRegions = [], plants = [], distributors = [], selectedPlant = ALL_PLANTS }) {
   const [busy, setBusy] = useState(null)   // 'finished' | 'raw' | 'dashboard' | null
   const [err, setErr] = useState(null)
 
@@ -3274,7 +3497,7 @@ function Reports({ skus, productions, dispatches, coils, babyCoils, orders, esti
       // estimates for the report month (ADR-0001), so it can't drift from what the Sales tab shows.
       // The state → region master rides along for the same reason: the workbook's Region column and
       // the Sales tab's are one mapping, not two.
-      else await R.generateMtdDashboardReport(orders, dispatches, productions, skus, { estimates, stateRegions, ...reportOpts })
+      else await R.generateMtdDashboardReport(orders, dispatches, productions, skus, { estimates, stateRegions, plants, distributors, ...reportOpts })
     } catch (e) {
       setErr(String(e?.message || e))
     } finally {
@@ -3304,9 +3527,9 @@ function Reports({ skus, productions, dispatches, coils, babyCoils, orders, esti
           <p><span className="font-medium text-slate-600 dark:text-slate-300">PB MTD Dashboard</span> — the monthly order/invoice/inventory dashboard (as on today): headline KPIs, Order Status Summary, Order Pipeline — MTD, and Inventory &amp; Production, plus a second sheet of every SKU holding more than 2 MT with FIFO ageing. Numbers reconcile with the Sales &amp; Dashboard KPIs.</p>
           <p><span className="font-medium text-slate-600 dark:text-slate-300">Best Estimate</span> is no longer typed here — it is the sum of the per-distributor targets set on the <span className="font-medium">Sales</span> tab for this month. Set none and <span className="font-medium">% of BE</span> / <span className="font-medium">Daily Run Rate</span> show N/A.</p>
           <p><span className="font-medium text-slate-600 dark:text-slate-300">Distributor by Region</span> — a third sheet reading Plan, Total Orders and Invoiced MTD per distributor, in region blocks with a total per region and a grand total. Regions come from the state map on the <span className="font-medium">Sales</span> tab; a state nobody has mapped groups under <span className="font-medium">Unmapped</span> and still counts in the grand total.</p>
-          {/* Sheet 4 repeats one plant-wide on-hand tonnage on every distributor's row for that size
-              (nothing is reserved), so it is totalled nowhere — say so here, not just on the sheet. */}
-          <p><span className="font-medium text-slate-600 dark:text-slate-300">Distributor × SKU</span> — a fourth sheet: per distributor and size, what is pending, what was invoiced this month, and the plant's stock of that size. Same figures as the <span className="font-medium">Sales</span> tab drill-down. <span className="font-medium">Free Stock is plant-wide and unreserved</span> — it repeats on every distributor waiting on that size, so the sheet carries no totals.</p>
+          {/* Sheet 4 repeats one service area's on-hand tonnage on every row in that area (nothing
+              is reserved there), so it is totalled nowhere — say so here, not just on the sheet. */}
+          <p><span className="font-medium text-slate-600 dark:text-slate-300">Distributor × SKU</span> — a fourth sheet: per distributor and size, what is pending, what was invoiced this month, and the stock of that size <span className="font-medium">at the plants that serve that distributor</span>. Same figures as the <span className="font-medium">Sales</span> tab drill-down. <span className="font-medium">Free Stock is area-wide and unreserved</span> — it repeats on every distributor in the area waiting on that size, so the sheet carries no totals. Service areas are set on the <span className="font-medium">Masters</span> tab; a region no plant serves reads no stock, and a distributor whose state carries no region reads “?”.</p>
         </div>
       </Section>
 
@@ -3364,6 +3587,14 @@ function InventoryApp({ session, onLogout }) {
   // SKU master falls back to DEFAULT_SKUS; the seed is ALSO layered under the stored rows inside
   // stateRegionIndex, so a table holding one edited state cannot un-map the other five.
   const [stateRegions, setStateRegions] = useSupabaseStore('jsw:stateRegions', DEFAULT_STATE_REGIONS)
+  // Plant + distributor masters (ticket #129). Both fall back to an EMPTY array rather than to their
+  // code seed, because unlike state_regions the stored row is not the same shape as the seed: a
+  // plants row holds a plant id and a service area, not an ERP code and a coil prefix. The seeds are
+  // layered underneath inside calc.js (plantMaster / distributorRegionIndex), which is the only
+  // place either shape is known — so an empty table reads as "nothing overridden", never as
+  // "nothing serves anywhere".
+  const [plants, setPlants] = useSupabaseStore('jsw:plants', [])
+  const [distributors, setDistributors] = useSupabaseStore('jsw:distributors', [])
 
   const loading = coilsLoading || babyCoilsLoading || productionsLoading || dispatchesLoading || skusLoading || ordersLoading
 
@@ -3517,7 +3748,10 @@ function InventoryApp({ session, onLogout }) {
           operatingPlant={selectedPlant} viewPlant={viewPlant} />}
         {tab === 'dispatch' && <Dispatch dispatches={plantDispatches} setDispatches={setDispatches} coils={plantCoils} skus={skus}
           plantScoped={selectedPlant !== ALL_PLANTS} canWiden={access.plantSelector} />}
-        {tab === 'skuMaster' && <SKUMaster skus={skus} setSkus={setSkus} productions={productions} readOnly={isReadOnly('skuMaster')} />}
+        {tab === 'skuMaster' && <Masters skus={skus} setSkus={setSkus} productions={productions}
+          orders={orders} dispatches={dispatches} stateRegions={stateRegions}
+          plants={plants} setPlants={setPlants} distributors={distributors} setDistributors={setDistributors}
+          readOnly={isReadOnly('skuMaster')} />}
         {/* `productions` stays the FULL unfiltered set here — it feeds the upload's coil trace
             (buildDispatchRecords), which must resolve against every plant's coils regardless of
             what the header selector shows, or an upload made while filtered to one plant would
@@ -3531,12 +3765,14 @@ function InventoryApp({ session, onLogout }) {
         {tab === 'sales' && <SalesDashboard orders={plantOrders} dispatches={plantDispatches} skus={skus} productions={plantProductions}
           estimates={distributorEstimates} setEstimates={setDistributorEstimates}
           stateRegions={stateRegions} setStateRegions={setStateRegions}
+          plants={plants} distributors={distributors}
           selectedPlant={selectedPlant} canWiden={access.plantSelector} />}
         {/* Reports follows the selector too (#121). `estimates`/`stateRegions` stay unfiltered for
             the same reason as Sales — neither carries a plant. A scoped workbook announces itself
             in its sheet titles and file name; see the Reports component. */}
         {tab === 'reports' && <Reports skus={skus} productions={plantProductions} dispatches={plantDispatches} coils={plantCoils} babyCoils={plantBabyCoils} orders={plantOrders}
-          estimates={distributorEstimates} stateRegions={stateRegions} selectedPlant={selectedPlant} />}
+          estimates={distributorEstimates} stateRegions={stateRegions}
+          plants={plants} distributors={distributors} selectedPlant={selectedPlant} />}
       </main>
 
       {/* Footer */}

--- a/src/data/distributors.js
+++ b/src/data/distributors.js
@@ -1,0 +1,27 @@
+// ── DISTRIBUTOR MASTER (static seed) ────────────────────────────────────────────────────────────
+// One thing only: a REGION OVERRIDE per distributor (ticket #129). Nothing else belongs here — a
+// distributor's name, state, order book and invoices all arrive with the ERP data and are resolved
+// from it (`distributorStateIndex`, `resolveDistributorIdentity`), so anything else this table held
+// would be a second, hand-typed copy of a fact the ERP already ships, free to drift from it.
+//
+// Region normally comes from the distributor's STATE, via the state → region master: map a state
+// once and every distributor shipping there inherits it. That is right for almost everybody and is
+// the reason the state master is keyed by state rather than by distributor.
+//
+// The override exists for the exception the state rule cannot express: a distributor whose state
+// says one region but who is genuinely served as another (a border depot, a group buying through a
+// single billing state). It is per distributor and it WINS over the state's answer.
+//
+// **Blank means "use the state's region"** — it is not a region, and it is not `Unmapped`. That is
+// why the Masters tab writes `region: ''` to clear an override instead of deleting the row: blank
+// is the ordinary state, and a stored blank and no row at all mean exactly the same thing.
+//
+// The seed ships EMPTY on purpose. An override is a correction to the state rule, and shipping one
+// nobody asked for would be a correction to nothing. It exists as a seed at all so the table
+// follows the same layered shape as the state → region and plant masters — seed underneath,
+// stored rows on top (`distributorRegionIndex` in calc.js) — and so a future well-known exception
+// has an obvious place to live.
+
+const DEFAULT_DISTRIBUTORS = []
+
+export default DEFAULT_DISTRIBUTORS

--- a/src/data/plants.js
+++ b/src/data/plants.js
@@ -1,11 +1,16 @@
-// ── PLANT MASTER (static constant) ──────────────────────────────────────────────────────────────
+// ── PLANT MASTER (static seed) ──────────────────────────────────────────────────────────────────
 // Four manufacturing companies appear in the One Helix workbook's Orders sheet. Until ticket #118
 // the app had no column to put them in, so all four were counted as Hyderabad's.
 //
-// Unlike the state → region master (38 possible states, continuously hand-mapped, so it lives in a
-// `state_regions` table), plants are four, change rarely, and every identifier here comes from the
-// ERP rather than from human judgement. There is nothing for an operator to type and therefore
-// nothing to store — so this is a code constant, not a table.
+// Everything here EXCEPT `serves` comes from the ERP and is read-only: an id, a Ship From Code, the
+// ERP's own name strings, a coil prefix. There is nothing for an operator to type in any of them.
+//
+// `serves` is the exception and the reason a `plants` TABLE now exists beside this file (ticket
+// #129). Which regions a plant will ship to is a commercial decision, not an ERP field — it appears
+// in no export and can be changed by a person on a Tuesday — so it follows the state → region
+// master exactly: these rows ship as the static default, and whatever the `plants` table holds is
+// layered ON TOP of them (`plantMaster` in calc.js). A half-populated table can therefore never
+// make a seeded plant serve nowhere by accident.
 //
 // Each plant carries:
 //   id           fixed literal, stored on the row (orders.plant). Never derived from a label, so
@@ -20,6 +25,11 @@
 //   manufactures whether the plant runs Coil Inward / Slitting / Production. Lepakshi and Tapi
 //                carry orders and have never produced or invoiced, so they exist for attribution
 //                only. Reclassifying one is a one-line change to this flag.
+//   serves       the regions this plant will ship to — its SERVICE AREA (CONTEXT.md). A
+//                distributor is offered stock from the plants that serve ITS region and from no
+//                other, because a coil in another state is not far away, it is not there. An empty
+//                list means the plant serves nowhere, which is a real answer and not a fallback:
+//                its stock then appears on no distributor's row. EDITABLE — see above.
 //
 // Order matters: it is the order plants are listed in on screen, biggest first.
 
@@ -31,6 +41,7 @@ const DEFAULT_PLANTS = [
     name: 'Hyderabad',
     coilPrefix: 'HYD',
     manufactures: true,
+    serves: ['South'],
   },
   {
     id: 'npmd',
@@ -39,6 +50,7 @@ const DEFAULT_PLANTS = [
     name: 'NPMD',
     coilPrefix: 'NPM',
     manufactures: true,
+    serves: ['West'],
   },
   {
     id: 'lepakshi',
@@ -47,6 +59,7 @@ const DEFAULT_PLANTS = [
     name: 'Lepakshi',
     coilPrefix: 'LEP',
     manufactures: false,
+    serves: ['South'],
   },
   {
     id: 'tapi',
@@ -55,6 +68,7 @@ const DEFAULT_PLANTS = [
     name: 'Tapi',
     coilPrefix: 'TAP',
     manufactures: false,
+    serves: ['West'],
   },
 ]
 

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -11,6 +11,9 @@ import DEFAULT_STATE_REGIONS from '../data/stateRegions.js'
 // Static plant master — the four companies the ERP ships the order book under. Same shape of
 // dependency as the state→region seed above, and the same load-bearing `.js` extension.
 import DEFAULT_PLANTS from '../data/plants.js'
+// Static distributor master — region overrides only, and empty as shipped. Same dependency shape
+// and the same load-bearing `.js` extension as the two seeds above.
+import DEFAULT_DISTRIBUTORS from '../data/distributors.js'
 
 // ── Formatting ──
 export const fmtT = (v) => v != null ? Number(v).toFixed(1) : '—'
@@ -938,6 +941,82 @@ export function plantLabel(id, master = DEFAULT_PLANTS) {
   return plantById(id, master)?.name || UNATTRIBUTED_PLANT
 }
 
+// ── SERVICE AREA — which regions a plant ships to (ticket #129) ─────────────────────────────────
+// The rule was written in CONTEXT.md and implemented nowhere: `producedPool` summed every plant's
+// stock into one number and `salesByDistributor` wrote that number onto every distributor's row,
+// so on 20-Aug-2026 the workbook offered West distributors 310.6 T of Hyderabad stock and printed
+// their shortfall as 1,755 T instead of the true 2,116 T. Service area is now a stored fact.
+//
+// It is the ONE editable field on the plant master, so it follows the state → region master
+// exactly: the shipped answers live in src/data/plants.js and the `plants` table is layered ON TOP
+// of them, per plant. A table holding one edited plant therefore cannot un-serve the other three.
+//
+// Region names are compared case-insensitively and with internal whitespace collapsed — the same
+// shape `REGIONS` and the state master store them in — so 'south' typed into the table and 'South'
+// shipped in the seed are one region.
+export const normRegionName = (r) => String(r ?? '').replace(/\s+/g, ' ').trim()
+const regionKey = (r) => normRegionName(r).toLowerCase()
+
+// A stored row's service area as a list. NULL, absent, a blank string and an empty array all read
+// as the EMPTY list, because "serves nowhere" is a real answer here and not a fallback: a plant
+// whose service area was cleared and one that never had one are the same fact. Restoring the
+// shipped default means deleting the row, not blanking it — which is the opposite of the state
+// master, where a blank region is an explicit un-mapping. The difference is deliberate: an
+// un-mapped STATE still carries its tonnage into every total under `Unmapped`, whereas a plant
+// serving nowhere has a concrete, checkable consequence (its stock shows on no distributor's row).
+const servesList = (v) => {
+  if (Array.isArray(v)) return v.map(normRegionName).filter(Boolean)
+  const s = normRegionName(v)
+  return s ? s.split(',').map(normRegionName).filter(Boolean) : []
+}
+
+// The plant master as the app should read it: the code seed with the stored rows layered on top,
+// in the seed's order, every field but `serves` untouched. A stored row for a plant the seed does
+// not carry is IGNORED rather than appended — a plant is an ERP company with a Ship From Code and a
+// coil prefix, and a row holding only an id and a region list is not one; inventing a fifth plant
+// from it would give it no way to ever match an ERP line.
+export function plantMaster(rows = null, seed = DEFAULT_PLANTS) {
+  const stored = new Map()
+  ;(rows || []).filter(r => !r?.deleted).forEach(r => {
+    const id = String(r?.plantId ?? '').trim()
+    if (id) stored.set(id, servesList(r?.serves))
+  })
+  return (seed || []).map(p => ({
+    ...p,
+    serves: stored.has(p.id) ? stored.get(p.id) : servesList(p?.serves),
+  }))
+}
+
+// The plants that serve one region, as a Set of stored plant ids — exactly the shape
+// `filterByPlants` takes. An EMPTY set is a real answer and means what it says: nobody ships there,
+// so that region's distributors are shown no stock at all. It must never be read as "no filter" —
+// that is the bug this ticket exists to fix, and why the set-based filters below treat an empty set
+// and a missing one as opposite instructions.
+//
+// `Unmapped` is not a region (CONTEXT.md), so no plant can serve it and this returns the empty set
+// for it. Callers do NOT use that emptiness: an unmapped distributor's service area is UNKNOWN, not
+// empty, and its stock columns must read `?` rather than 0. `salesByDistributor` checks for
+// `UNMAPPED_REGION` before it ever gets here.
+export function plantsServingRegion(region, master = DEFAULT_PLANTS) {
+  const want = regionKey(region)
+  const out = new Set()
+  if (!want) return out
+  ;(master || []).forEach(p => {
+    if ((p?.serves || []).some(r => regionKey(r) === want)) out.add(p.id)
+  })
+  return out
+}
+
+// The regions that have at least one plant shipping to them — the answer to "where can we serve
+// from stock at all today". In REGIONS order, then any off-list region a stored row names.
+export function servedRegions(master = DEFAULT_PLANTS) {
+  const seen = new Set()
+  ;(master || []).forEach(p => (p?.serves || []).forEach(r => { const n = normRegionName(r); if (n) seen.add(n) }))
+  const known = REGIONS.filter(r => [...seen].some(s => regionKey(s) === regionKey(r)))
+  const extra = [...seen].filter(s => !REGIONS.some(r => regionKey(r) === regionKey(s))).sort()
+  return [...known, ...extra]
+}
+
 // ── Reading a plant off a RAW ERP row ───────────────────────────────────────────────────────────
 // `erpRowPicker` is the header-matching the two row mappers in App.jsx both do: lower-case the
 // header, drop `.` `_` and spaces, then take the first alias that holds a non-blank cell.
@@ -1109,6 +1188,32 @@ export function filterByPlant(rows, selected = ALL_PLANTS) {
   return (rows || []).filter(r => storedPlant(r) === selected)
 }
 
+// ── SET-BASED SIBLINGS (ticket #129) ───────────────────────────────────────────────────────────
+// `filterByPlant` answers "the one plant a person picked in the header". A SERVICE AREA is not one
+// plant — South is Hyderabad and Lepakshi, and it grows the day a plant is re-pointed — so the
+// stock pool behind a distributor's row needs "these plants", not "this plant".
+//
+// The two differ on one case, and it is the whole reason this is a separate function rather than a
+// looser `filterByPlant`:
+//
+//   filterByPlant(rows, ALL_PLANTS)  → every row      "no filter"
+//   filterByPlants(rows, null)       → every row      "no filter"
+//   filterByPlants(rows, new Set())  → NO rows        "no plant serves here"
+//
+// An empty set is an ANSWER, not a missing argument. A region nobody ships to must show no stock;
+// falling back to "everything" there is exactly the bug this ticket fixes, at the exact moment it
+// matters most. So the sentinel for "do not filter" is `null`, which cannot be confused with a set
+// that happens to be empty.
+//
+// Comparison is against the STORED value via the same `storedPlant` normalisation `filterByPlant`
+// uses, so a row with no plant (a legacy row never backfilled) belongs to NO service area — it
+// counts toward neither, exactly as it counts toward neither plant under the header selector.
+export function filterByPlants(rows, plants = null) {
+  if (plants == null) return rows || []
+  const want = plants instanceof Set ? plants : new Set(plants)
+  return (rows || []).filter(r => want.has(storedPlant(r)))
+}
+
 // The allocation rows that reference a baby coil which is NOT at `plant` — the guard that makes
 // "allocation never crosses plants" true of what is SAVED, not only of what was offered.
 //
@@ -1165,6 +1270,24 @@ export function filterDispatchesByPlant(dispatches, selected = ALL_PLANTS) {
     .filter(Boolean)
 }
 
+// The set-based sibling, same contract as `filterByPlants` above: `null` means no filter, an EMPTY
+// set means no plant — so a region nobody ships to subtracts NO invoices, rather than every plant's.
+//
+// This one is load-bearing in a way that is easy to miss. Stock is `produced − invoiced`, and the
+// two halves have to be scoped by the SAME plants or the subtraction is between different things.
+// Filter productions to West (nothing) and leave dispatches national and every West SKU reads
+// Hyderabad's invoiced tonnage as negative stock — a screen full of red where the truth is a blank.
+export function filterDispatchesByPlants(dispatches, plants = null) {
+  if (plants == null) return dispatches || []
+  const want = plants instanceof Set ? plants : new Set(plants)
+  return (dispatches || [])
+    .map(d => {
+      const bundleEntries = (d.bundleEntries || []).filter(e => want.has(storedPlant(e)))
+      return bundleEntries.length ? withDispatchEntries(d, bundleEntries) : null
+    })
+    .filter(Boolean)
+}
+
 // ── A distributor's own state, derived from its order and invoice lines ──
 // Keyed by the SAME identity resolveDistributorIdentity produces, so the answer lands on the
 // distributor's sales row. Where a distributor's lines disagree, the MOST RECENT line wins (ISO
@@ -1202,13 +1325,40 @@ export function distributorStateIndex(orders, dispatches, idx = null) {
 // Built once, called per row. Used by the Sales tab (through salesByDistributor) and available to
 // the report builders, so a region shown on screen and a region in a report cannot diverge.
 // An unknown key resolves to a blank state and `Unmapped` rather than throwing.
-export function distributorRegionResolver(orders, dispatches, stateRegions = null, idx = null) {
+export function distributorRegionResolver(orders, dispatches, stateRegions = null, idx = null, distributors = null) {
   const states = distributorStateIndex(orders, dispatches, idx)
   const regions = stateRegionIndex(stateRegions)
+  const overrides = distributorRegionIndex(distributors)
   return (key) => {
-    const e = states.get(String(key ?? '').trim()) || { state: '', states: [], multiState: false }
-    return { ...e, region: regionForState(e.state, regions) }
+    const k = String(key ?? '').trim()
+    const e = states.get(k) || { state: '', states: [], multiState: false }
+    const override = overrides.get(k) || ''
+    return {
+      ...e,
+      region: override || regionForState(e.state, regions),
+      regionOverride: override,
+    }
   }
+}
+
+// ── DISTRIBUTOR MASTER — the region override (ticket #129) ─────────────────────────────────────
+// Distributor identity key → the region typed against it, '' when none. Same layered shape as the
+// state master: a static seed (empty today) with the stored rows on top, so the two masters are
+// read the same way and neither can be half-applied.
+//
+// A BLANK override is not `Unmapped` and not a region — it means "use the state's region", which is
+// what almost every distributor does. That is why the Masters tab writes `region: ''` to clear one
+// rather than deleting the row: a stored blank and no row at all have to mean the same thing, or
+// clearing an override would strand the distributor instead of returning it to its state's answer.
+export function distributorRegionIndex(rows = null, seed = DEFAULT_DISTRIBUTORS) {
+  const out = new Map()
+  const put = (r) => {
+    const key = String(r?.distributorKey ?? '').trim()
+    if (key) out.set(key, normRegionName(r?.region))
+  }
+  ;(seed || []).filter(r => !r?.deleted).forEach(put)
+  ;(rows || []).filter(r => !r?.deleted).forEach(put)
+  return out
 }
 
 // ── SKU-wise inventory / booked / free rows for the dashboard. Union of SKUs with
@@ -1640,12 +1790,20 @@ export function plantBestEstimate(estimates, month = '') {
 // (BE − mtdInvoice). A distributor holding an estimate but no orders/invoices still gets a row, with
 // zeroed actuals, so a total that was completely missed cannot vanish off the screen.
 //
-// `opts.productions` adds unreserved plant stock to each SKU drill-down row: `onhand` (plant on-hand
-// for that SKU, produced − invoiced, floored at 0), `allConfirmed` (Confirmed across EVERY
-// distributor), `freeStock` (onhand − allConfirmed — the displayed figure, negative when the size is
-// over-committed), `allPending` (pending across EVERY distributor for that SKU) and `shortBy`
-// (max(0, pending − onhand)). The stock is the plant's, not this distributor's — nothing is reserved
-// to anyone, so two distributors can both be shown covered by one tonnage. See ADR-0002.
+// `opts.productions` adds unreserved stock to each SKU drill-down row, scoped to the distributor's
+// SERVICE AREA (ticket #129): `onhand` (produced − invoiced across the plants that serve this
+// distributor's region, floored at 0), `allConfirmed` (Confirmed across every distributor IN THAT
+// AREA), `freeStock` (onhand − allConfirmed — the displayed figure, negative when the size is
+// over-committed), `allPending` (pending across every distributor in that area for that SKU) and
+// `shortBy` (max(0, pending − onhand)). Inside an area the stock is still shared and reserved to
+// nobody, so two distributors there can both be shown covered by one tonnage (ADR-0002); across
+// areas it is not shared at all, because a coil at another plant is not stock this distributor can
+// be served from. A distributor whose region is `Unmapped` has no known service area, so every one
+// of these reads `null` — "?" on screen and in the workbook, never 0.
+//
+// `opts.plants` are the stored plant-master rows (service area per plant); `opts.distributors` the
+// stored region overrides. Both are layered over their code seeds, so omitting them is the shipped
+// answer rather than a blank one.
 //
 // `opts.stateRegions` adds `state`, `states`, `multiState` and `region` to every row via the shared
 // distributorRegionResolver. Rows are never filtered or merged on either — an unmapped state reads
@@ -1698,49 +1856,92 @@ export function salesByDistributor(orders, dispatches, month = '', skus = [], op
   const estIdx = distributorEstimateIndex(opts.estimates, month)
   estIdx.forEach(({ name }, key) => { row(key, name) })
 
-  // Unreserved plant stock per canonical SKU, plus the pending every distributor has on it. Both are
-  // plant-wide: the same on-hand tonnage appears under every distributor waiting on that size.
-  const pool = opts.productions ? producedPool(opts.productions, dispatches, null, keyOf) : null
-  const pendingBySku = {}, confirmedBySku = {}
-  if (pool) {
-    Object.values(map).forEach(r => Object.values(r._sku).forEach(s => {
-      pendingBySku[s.id] = (pendingBySku[s.id] || 0) + s.confirmed + s.nonConfirmed
-      confirmedBySku[s.id] = (confirmedBySku[s.id] || 0) + s.confirmed
-    }))
+  // ── State/region per distributor, resolved BEFORE the stock block ────────────────────────────
+  // The order is load-bearing, not tidiness. Which stock a distributor may be shown is decided by
+  // its region, so the region has to exist before the pool is built. It used to be resolved after,
+  // which is one reason the pool could only ever be one global number.
+  // Derived, never typed: state comes from the distributor's own lines, region from the state
+  // master — unless the distributor master carries an explicit override, which wins.
+  const regionOf = distributorRegionResolver(orders, dispatches, opts.stateRegions, idx, opts.distributors)
+  const regionByKey = new Map(Object.keys(map).map(k => [k, regionOf(k).region]))
+
+  // ── Stock per SERVICE AREA, not one pool for the company (ticket #129) ────────────────────────
+  // A distributor is shown the stock of the plants that serve ITS region and of no others. On
+  // 20-Aug-2026 every one of the 1,279 production rows was Hyderabad's — a South plant — and this
+  // function was handing that tonnage to West distributors: 310.6 T of Free Stock printed against
+  // rows no Hyderabad lorry was ever going to fill, and West's shortfall understated by 361 T.
+  //
+  // FOUR things move together here, and they have to. Scope the productions alone and the numbers
+  // get WORSE than they were:
+  //   • productions — the stock itself, from the serving plants only.
+  //   • dispatches  — the same plants, or South's invoices are subtracted from West's empty pool
+  //                   and every West SKU reads as negative stock.
+  //   • allConfirmed — per region, or South's Confirmed tonnage is netted off West's zero.
+  //   • allPending   — per region, because "who else is queued for this size" only means anything
+  //                    among distributors the same plants can actually serve.
+  //
+  // Within a region the pool is still SHARED and reserved to nobody (ADR-0002 is unchanged): two
+  // South distributors waiting on one size are both shown its full tonnage. This ticket narrows
+  // WHOSE pool a row reads, never how the pool is divided.
+  const master = plantMaster(opts.plants)
+  const poolByRegion = new Map(), pendingByRegion = new Map(), confirmedByRegion = new Map()
+  if (opts.productions) {
+    new Set(regionByKey.values()).forEach(region => {
+      // An `Unmapped` distributor has no known service area — UNKNOWN, not empty. It gets no pool,
+      // and its stock columns read `?` below rather than 0: telling a sales team a distributor has
+      // no stock because nobody mapped its state is a wrong answer, where "?" is a true one.
+      if (region === UNMAPPED_REGION) return
+      const plants = plantsServingRegion(region, master)
+      poolByRegion.set(region, producedPool(
+        filterByPlants(opts.productions, plants),
+        filterDispatchesByPlants(dispatches, plants), null, keyOf))
+      pendingByRegion.set(region, {}); confirmedByRegion.set(region, {})
+    })
+    Object.entries(map).forEach(([key, r]) => {
+      const pend = pendingByRegion.get(regionByKey.get(key)), conf = confirmedByRegion.get(regionByKey.get(key))
+      if (!pend) return                       // Unmapped — counted in no region's demand
+      Object.values(r._sku).forEach(s => {
+        pend[s.id] = (pend[s.id] || 0) + s.confirmed + s.nonConfirmed
+        conf[s.id] = (conf[s.id] || 0) + s.confirmed
+      })
+    })
   }
-  const withStock = (s) => {
-    if (!pool) return s
+  const withStock = (region) => (s) => {
+    if (!opts.productions) return s
+    const pool = poolByRegion.get(region)
+    // No pool ⇒ no service area known. Every stock column is null, which every surface renders as
+    // "?" or "—" — never as a figure.
+    if (!pool) return { ...s, onhand: null, allPending: null, allConfirmed: null, freeStock: null, shortBy: null }
     // A SKU can't hold negative stock — over-dispatched sizes floor to 0 here (the tonnage is
     // accounted for plant-wide by unmatchedDispatch, which has no place on a per-distributor row).
     const onhand = Math.max(0, Number(pool[s.id]?.availableWeight || 0))
-    const allPending = pendingBySku[s.id] || 0
-    // FREE STOCK — what the plant holds that is promised to nobody yet: on-hand less the Confirmed
-    // (released, not yet invoiced) tonnage of EVERY distributor, not just this one. Both terms are
-    // plant-wide, so the pair stays coherent: netting only this row's Confirmed against a shared
-    // pool would show a different "free" figure per distributor for the same physical stock.
-    // Goes NEGATIVE when a size is committed beyond what is on the floor — that is the signal, so
-    // it is not floored. Same shape as the Dashboard's Free FG (Inventory − Reserved), where
-    // Reserved is that identical released-not-invoiced tonnage.
-    const allConfirmed = confirmedBySku[s.id] || 0
+    const allPending = pendingByRegion.get(region)[s.id] || 0
+    // FREE STOCK — what the serving plants hold that is promised to nobody yet: on-hand less the
+    // Confirmed (released, not yet invoiced) tonnage of every distributor IN THIS SERVICE AREA, not
+    // just this one. Both terms are area-wide, so the pair stays coherent: netting only this row's
+    // Confirmed against a shared pool would show a different "free" figure per distributor for the
+    // same physical stock. Goes NEGATIVE when a size is committed beyond what is on the floor —
+    // that is the signal, so it is not floored. Same shape as the Dashboard's Free FG.
+    const allConfirmed = confirmedByRegion.get(region)[s.id] || 0
     return { ...s, onhand, allPending, allConfirmed, freeStock: onhand - allConfirmed,
       shortBy: Math.max(0, s.pending - onhand) }
   }
 
-  // State/region per distributor. Derived, never typed: state comes from the distributor's own
-  // lines, region from the state master.
-  const regionOf = distributorRegionResolver(orders, dispatches, opts.stateRegions, idx)
-
   const finish = (o) => ({ ...o, pending: o.confirmed + o.nonConfirmed, totalOrders: o.mtdInvoice + o.confirmed + o.nonConfirmed })
   return Object.values(map).map(r => {
     const { _sku, ...rest } = r
-    const skuRows = Object.values(_sku).map(finish).map(withStock).sort((a, b) => b.totalOrders - a.totalOrders)
+    const { state, states, multiState, region } = regionOf(r.id)
+    const skuRows = Object.values(_sku).map(finish).map(withStock(region)).sort((a, b) => b.totalOrders - a.totalOrders)
     const base = finish(rest)
     const bestEstimate = estIdx.get(r.id)?.estimate ?? null
-    const { state, states, multiState, region } = regionOf(r.id)
+    const { regionOverride } = regionOf(r.id)
     return {
       ...base,
       customer: rest.customer || '—',
-      state, states, multiState, region,
+      // `region` is the answer; `regionOverride` is whether a person typed it. The Masters tab needs
+      // both to show "South (from MAHARASHTRA)" against "South (override)" without re-deriving one
+      // of them itself — which is how a screen and a report start disagreeing.
+      state, states, multiState, region, regionOverride,
       bestEstimate,
       // Measured against invoiced only (decision 5) — Confirmed / Non-confirmed are an all-time
       // order-book snapshot, so comparing a month's target to them would not be like-for-like.
@@ -1932,7 +2133,10 @@ export const APP_TABS = [
   { key: 'slitting', label: '2. Slitting' },
   { key: 'production', label: '3. Production' },
   { key: 'dispatch', label: '4. Dispatch' },
-  { key: 'skuMaster', label: 'SKU Master' },
+  // The KEY stays `skuMaster` while the LABEL says Masters (ticket #129): the tab now holds three
+  // masters (SKU, Plant, Distributor), but the key is what `accessFor` grants and what
+  // PLANT_READ_ONLY_TABS names, so renaming it would silently move a permission.
+  { key: 'skuMaster', label: 'Masters' },
   { key: 'orders', label: 'Orders & Invoice' },
   { key: 'sales', label: 'Sales' },
   { key: 'reports', label: 'Reports' },

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -16,7 +16,8 @@ import {
   coilInwardPlants, DEFAULT_COIL_PLANT, babyCoilPlant, productionPlant,
   ALL_PLANTS, plantFilterOptions, plantKeysIn, plantNamesIn, filterByPlant, filterDispatchesByPlant, withDispatchEntries,
   crossPlantAllocationRows,
-  distributorStateIndex, distributorRegionResolver,
+  plantMaster, plantsServingRegion, servedRegions, filterByPlants, filterDispatchesByPlants,
+  distributorStateIndex, distributorRegionResolver, distributorRegionIndex,
   salesKpis, salesByDistributor, salesByMonth,
   estimateNum, distributorEstimateIndex, plantBestEstimate,
   APP_TABS, accessFor, parseStoredSession, ROLE_ADMIN, ROLE_PLANT, SESSION_TTL_MS,
@@ -2760,15 +2761,20 @@ describe('salesByDistributor — Best Estimate columns', () => {
   })
 })
 
-describe('salesByDistributor — unreserved plant stock in the drill-down (ADR-0002)', () => {
+// Both distributors ship to TELANGANA and the stock is made at Hyderabad, so all three sit in ONE
+// service area — which is what makes this block about sharing WITHIN an area (ADR-0002) and not
+// about the area boundary (ticket #129, the block below). Without the state and the plant every
+// test here would pass for the wrong reason: an unmapped distributor reads null stock, and
+// unattributed stock belongs to no area at all.
+describe('salesByDistributor — unreserved stock inside one service area (ADR-0002)', () => {
   const skus = [{ skuCode: 'S1', productType: 'SHS', height: 50, breadth: 50, thickness: 2, length: 6000 }]
   const orders = [
-    { deleted: false, mmId: 'S1', distributorCode: 'D1', customer: 'PATEL', orderStatus: 'Confirmed', confirmed: 40, nonConfirmed: 0 },
-    { deleted: false, mmId: 'S1', distributorCode: 'D2', customer: 'SHREE', orderStatus: 'Confirmed', confirmed: 30, nonConfirmed: 0 },
+    { deleted: false, mmId: 'S1', distributorCode: 'D1', customer: 'PATEL', shipToState: 'TELANGANA', orderStatus: 'Confirmed', confirmed: 40, nonConfirmed: 0 },
+    { deleted: false, mmId: 'S1', distributorCode: 'D2', customer: 'SHREE', shipToState: 'TELANGANA', orderStatus: 'Confirmed', confirmed: 30, nonConfirmed: 0 },
   ]
-  const productions = [{ deleted: false, skuCode: 'S1', dateOfProduction: '2026-08-01', tubeCount: 100, totalWeight: 45 }]
+  const productions = [{ deleted: false, skuCode: 'S1', plant: 'hyderabad', dateOfProduction: '2026-08-01', tubeCount: 100, totalWeight: 45 }]
 
-  it('shows the SAME plant on-hand to every distributor waiting on the SKU — nothing is reserved', () => {
+  it('shows the SAME on-hand to every distributor in the area waiting on the SKU — nothing is reserved', () => {
     const rows = salesByDistributor(orders, [], '2026-08', skus, { productions })
     const patel = rows.find(r => r.id === 'D1').skuRows[0]
     const shree = rows.find(r => r.id === 'D2').skuRows[0]
@@ -2786,13 +2792,16 @@ describe('salesByDistributor — unreserved plant stock in the drill-down (ADR-0
 
   it('shortBy is this distributor’s uncovered pending, floored at zero', () => {
     const rows = salesByDistributor(
-      [{ deleted: false, mmId: 'S1', distributorCode: 'D1', orderStatus: 'Confirmed', confirmed: 60, nonConfirmed: 0 }],
+      [{ deleted: false, mmId: 'S1', distributorCode: 'D1', shipToState: 'TELANGANA', orderStatus: 'Confirmed', confirmed: 60, nonConfirmed: 0 }],
       [], '2026-08', skus, { productions })
     expect(rows[0].skuRows[0].shortBy).toBeCloseTo(15)  // 60 pending − 45 on hand
   })
 
   it('floors an over-dispatched SKU at zero on-hand rather than showing negative stock', () => {
-    const overDispatched = [{ deleted: false, dateOfDispatch: '2026-08-05', bundleEntries: [{ skuCode: 'S1', weight: 60 }] }]
+    // The entry carries `plant` for the same reason the productions do: the dispatch filter drops
+    // an unattributed entry, and without it the 60 T never reaches the pool and the floor is never
+    // exercised — the test would pass on 45 T of untouched stock.
+    const overDispatched = [{ deleted: false, dateOfDispatch: '2026-08-05', bundleEntries: [{ skuCode: 'S1', plant: 'hyderabad', weight: 60 }] }]
     const rows = salesByDistributor(orders, overDispatched, '2026-08', skus, { productions })
     const patel = rows.find(r => r.id === 'D1').skuRows[0]
     expect(patel.onhand).toBe(0)                // 45 produced − 60 invoiced = −15, floored
@@ -2813,7 +2822,7 @@ describe('salesByDistributor — unreserved plant stock in the drill-down (ADR-0
     const rows = salesByDistributor(orders, [], '2026-08', skus, { productions })
     const patel = rows.find(r => r.id === 'D1').skuRows[0]
     const shree = rows.find(r => r.id === 'D2').skuRows[0]
-    expect(patel.allConfirmed).toBeCloseTo(70)   // 40 (Patel) + 30 (Shree)
+    expect(patel.allConfirmed).toBeCloseTo(70)   // 40 (Patel) + 30 (Shree) — both South
     expect(patel.freeStock).toBeCloseTo(-25)     // 45 on hand − 70 confirmed
     expect(shree.freeStock).toBeCloseTo(-25)     // identical on both rows — the pool is shared
     expect(patel.onhand).toBeCloseTo(45)         // on-hand itself is untouched, still floored at 0
@@ -2833,6 +2842,207 @@ describe('salesByDistributor — unreserved plant stock in the drill-down (ADR-0
     expect(row.allConfirmed).toBe(0)
     expect(row.freeStock).toBeCloseTo(45)
     expect(row.freeStock).toBeCloseTo(row.onhand)
+  })
+})
+
+// ── SERVICE AREA: a distributor is only shown the stock of plants that serve its region (#129) ──
+// The bug this replaces, on live 20-Aug-2026 data: every one of the 1,279 production rows was
+// Hyderabad's (South), and the workbook still offered 310.6 T of it to West distributors, printing
+// West's shortfall as 1,755.35 MT against a true 2,116 MT.
+describe('plantMaster / plantsServingRegion — the service area master', () => {
+  it('ships Hyderabad + Lepakshi serving South, NPMD + Tapi serving West', () => {
+    expect([...plantsServingRegion('South')].sort()).toEqual(['hyderabad', 'lepakshi'])
+    expect([...plantsServingRegion('West')].sort()).toEqual(['npmd', 'tapi'])
+    expect(servedRegions()).toEqual(['South', 'West'])
+  })
+
+  it('matches a region case-insensitively, so a hand-typed "south" is the seeded South', () => {
+    expect([...plantsServingRegion('  south ')].sort()).toEqual(['hyderabad', 'lepakshi'])
+  })
+
+  it('returns the EMPTY set for a region nobody ships to — an answer, not a missing filter', () => {
+    expect(plantsServingRegion('North').size).toBe(0)
+    expect(plantsServingRegion(UNMAPPED_REGION).size).toBe(0)   // Unmapped is not a region
+    expect(plantsServingRegion('').size).toBe(0)
+  })
+
+  it('layers a stored row over the seed, per plant, leaving the other three alone', () => {
+    const master = plantMaster([{ plantId: 'npmd', serves: ['South'] }])
+    expect([...plantsServingRegion('South', master)].sort()).toEqual(['hyderabad', 'lepakshi', 'npmd'])
+    expect([...plantsServingRegion('West', master)]).toEqual(['tapi'])          // Hyderabad untouched
+    expect(master.find(p => p.id === 'npmd').erpCode).toBe('V1865-2222-JODL-4081') // ERP fields read-only
+  })
+
+  it('reads an empty / null / blank stored service area as "serves nowhere", not as the seed', () => {
+    ;[[], null, ''].forEach(serves => {
+      const master = plantMaster([{ plantId: 'hyderabad', serves }])
+      expect([...plantsServingRegion('South', master)]).toEqual(['lepakshi'])
+    })
+  })
+
+  it('ignores a soft-deleted row, and a row naming a plant the seed does not carry', () => {
+    const master = plantMaster([
+      { plantId: 'hyderabad', serves: ['West'], deleted: true },
+      { plantId: 'ghaziabad', serves: ['North'] },
+    ])
+    expect([...plantsServingRegion('South', master)].sort()).toEqual(['hyderabad', 'lepakshi'])
+    expect(plantsServingRegion('North', master).size).toBe(0)
+    expect(master).toHaveLength(4)
+  })
+})
+
+describe('filterByPlants / filterDispatchesByPlants — an empty set is not "no filter"', () => {
+  const rows = [{ id: 'a', plant: 'hyderabad' }, { id: 'b', plant: 'npmd' }, { id: 'c' }]
+  const disp = [
+    { id: 'd1', bundleEntries: [{ skuCode: 'S1', plant: 'hyderabad', weight: 10 }, { skuCode: 'S1', plant: 'npmd', weight: 4 }] },
+    { id: 'd2', bundleEntries: [{ skuCode: 'S1', weight: 3 }] },
+  ]
+
+  it('keeps only the named plants', () => {
+    expect(filterByPlants(rows, new Set(['hyderabad', 'lepakshi'])).map(r => r.id)).toEqual(['a'])
+    expect(filterByPlants(rows, ['hyderabad', 'npmd']).map(r => r.id)).toEqual(['a', 'b'])
+  })
+
+  it('returns NO rows for an empty set and EVERY row for null — opposite instructions', () => {
+    expect(filterByPlants(rows, new Set())).toEqual([])
+    expect(filterByPlants(rows, null)).toHaveLength(3)
+    expect(filterDispatchesByPlants(disp, new Set())).toEqual([])
+    expect(filterDispatchesByPlants(disp, null)).toHaveLength(2)
+  })
+
+  it('drops an unattributed row from every service area — it belongs to none', () => {
+    expect(filterByPlants(rows, new Set(['hyderabad', 'npmd', 'lepakshi', 'tapi'])).map(r => r.id)).toEqual(['a', 'b'])
+  })
+
+  it('re-derives a filtered dispatch record\u2019s weight from the entries that survived', () => {
+    const [rec] = filterDispatchesByPlants(disp, new Set(['hyderabad']))
+    expect(rec.id).toBe('d1')
+    expect(rec.bundleEntries).toHaveLength(1)
+    expect(rec.theoreticalWeight).toBeCloseTo(10)     // not 14 — the NPMD line is not South's
+  })
+})
+
+describe('distributorRegionIndex — the distributor master overrides the state\u2019s region', () => {
+  it('is empty as shipped, so every distributor follows its state', () => {
+    expect(distributorRegionIndex().size).toBe(0)
+  })
+
+  it('lets a stored override beat the state map, and a blank fall back to it', () => {
+    const orders = [{ deleted: false, distributorCode: 'D1', customer: 'BORDER DEPOT', shipToState: 'MAHARASHTRA', orderDate: '2026-08-01' }]
+    const plain = distributorRegionResolver(orders, [])('D1')
+    expect(plain.region).toBe('West')                                   // MAHARASHTRA → West
+
+    const overridden = distributorRegionResolver(orders, [], null, null, [{ distributorKey: 'D1', region: 'South' }])('D1')
+    expect(overridden.region).toBe('South')
+    expect(overridden.state).toBe('MAHARASHTRA')                        // the state itself never moves
+    expect(overridden.regionOverride).toBe('South')
+
+    const cleared = distributorRegionResolver(orders, [], null, null, [{ distributorKey: 'D1', region: '' }])('D1')
+    expect(cleared.region).toBe('West')                                 // blank ⇒ use the state
+    expect(cleared.regionOverride).toBe('')
+  })
+
+  it('can pull a distributor OUT of Unmapped when its lines carry no state at all', () => {
+    const orders = [{ deleted: false, distributorCode: 'D9', customer: 'NO STATE', shipToState: '', orderDate: '2026-08-01' }]
+    expect(distributorRegionResolver(orders, [])('D9').region).toBe(UNMAPPED_REGION)
+    expect(distributorRegionResolver(orders, [], null, null, [{ distributorKey: 'D9', region: 'South' }])('D9').region).toBe('South')
+  })
+})
+
+describe('salesByDistributor — stock is pooled per service area (ticket #129)', () => {
+  const skus = [{ skuCode: 'S1', productType: 'SHS', height: 50, breadth: 50, thickness: 2, length: 6000 }]
+  // The live shape on 20-Aug-2026: one South plant holding everything, a West order book holding
+  // nothing but demand, and one distributor whose state nobody has mapped.
+  const orders = [
+    { deleted: false, mmId: 'S1', distributorCode: 'S', customer: 'ARIHANT', shipToState: 'KARNATAKA', orderStatus: 'Confirmed', confirmed: 10, nonConfirmed: 0 },
+    { deleted: false, mmId: 'S1', distributorCode: 'W', customer: 'VORA', shipToState: 'MAHARASHTRA', orderStatus: 'Confirmed', confirmed: 40, nonConfirmed: 0 },
+    { deleted: false, mmId: 'S1', distributorCode: 'U', customer: 'MAHENDRA', shipToState: '', orderStatus: 'Confirmed', confirmed: 8, nonConfirmed: 0 },
+  ]
+  const hyd = [{ deleted: false, skuCode: 'S1', plant: 'hyderabad', dateOfProduction: '2026-08-01', tubeCount: 100, totalWeight: 45 }]
+  const skuOf = (rows, id) => rows.find(r => r.id === id).skuRows[0]
+
+  it('shows West nothing while Hyderabad holds 45 T — the bug this ticket exists for', () => {
+    const rows = salesByDistributor(orders, [], '2026-08', skus, { productions: hyd })
+    expect(skuOf(rows, 'S').onhand).toBeCloseTo(45)
+    expect(skuOf(rows, 'W').onhand).toBe(0)
+    expect(skuOf(rows, 'W').freeStock).toBeCloseTo(-40)   // 0 on hand − West's own 40 T Confirmed
+  })
+
+  it('gives a West distributor its FULL pending as Short by, not a South-cushioned figure', () => {
+    const rows = salesByDistributor(orders, [], '2026-08', skus, { productions: hyd })
+    expect(skuOf(rows, 'W').shortBy).toBeCloseTo(40)      // the whole order book, not 0
+    expect(skuOf(rows, 'S').shortBy).toBe(0)              // 10 T against 45 T on the floor
+  })
+
+  it('nets Confirmed and pending PER AREA — South\u2019s demand is not charged to West', () => {
+    const rows = salesByDistributor(orders, [], '2026-08', skus, { productions: hyd })
+    expect(skuOf(rows, 'S').allConfirmed).toBeCloseTo(10) // South sees only ARIHANT's 10 T…
+    expect(skuOf(rows, 'W').allConfirmed).toBeCloseTo(40) // …and West only VORA's 40 T
+    expect(skuOf(rows, 'S').allPending).toBeCloseTo(10)
+    expect(skuOf(rows, 'W').allPending).toBeCloseTo(40)
+  })
+
+  it('does not let a South invoice push West negative', () => {
+    // Hyderabad invoices a West distributor — which is what actually happens today. The tonnage
+    // leaves the SOUTH floor; West's empty pool must not be reduced by it.
+    const southInvoice = [{ deleted: false, dateOfDispatch: '2026-08-05',
+      bundleEntries: [{ skuCode: 'S1', plant: 'hyderabad', weight: 6, distributorCode: 'W', customer: 'VORA', shipToState: 'MAHARASHTRA' }] }]
+    const rows = salesByDistributor(orders, southInvoice, '2026-08', skus, { productions: hyd })
+    expect(skuOf(rows, 'S').onhand).toBeCloseTo(39)       // 45 − 6, off the floor it left
+    expect(skuOf(rows, 'W').onhand).toBe(0)               // floored, and never −6
+    expect(skuOf(rows, 'W').freeStock).toBeCloseTo(-40)   // still just West's own Confirmed
+  })
+
+  it('reads "?" — null, never 0 — for a distributor with no known service area', () => {
+    const rows = salesByDistributor(orders, [], '2026-08', skus, { productions: hyd })
+    const unmapped = skuOf(rows, 'U')
+    expect(rows.find(r => r.id === 'U').region).toBe(UNMAPPED_REGION)
+    ;['onhand', 'freeStock', 'allPending', 'allConfirmed', 'shortBy'].forEach(f =>
+      expect(unmapped[f]).toBeNull())
+  })
+
+  it('fills West the day an NPMD row appears, and leaves South exactly where it was', () => {
+    const before = salesByDistributor(orders, [], '2026-08', skus, { productions: hyd })
+    const after = salesByDistributor(orders, [], '2026-08', skus, {
+      productions: [...hyd, { deleted: false, skuCode: 'S1', plant: 'npmd', dateOfProduction: '2026-08-10', tubeCount: 100, totalWeight: 50 }],
+    })
+    expect(skuOf(after, 'W').onhand).toBeCloseTo(50)
+    expect(skuOf(after, 'W').shortBy).toBe(0)
+    expect(skuOf(after, 'S')).toEqual(skuOf(before, 'S'))   // not by a kilo
+  })
+
+  it('follows the plant master: re-point NPMD at South and West goes dark again', () => {
+    const productions = [...hyd, { deleted: false, skuCode: 'S1', plant: 'npmd', dateOfProduction: '2026-08-10', tubeCount: 100, totalWeight: 50 }]
+    const rows = salesByDistributor(orders, [], '2026-08', skus,
+      { productions, plants: [{ plantId: 'npmd', serves: ['South'] }] })
+    expect(skuOf(rows, 'S').onhand).toBeCloseTo(95)   // 45 Hyderabad + 50 NPMD, one area now
+    expect(skuOf(rows, 'W').onhand).toBe(0)
+  })
+
+  it('follows the distributor master: an override moves which pool a row reads', () => {
+    const rows = salesByDistributor(orders, [], '2026-08', skus,
+      { productions: hyd, distributors: [{ distributorKey: 'W', region: 'South' }] })
+    expect(rows.find(r => r.id === 'W').region).toBe('South')
+    expect(skuOf(rows, 'W').onhand).toBeCloseTo(45)
+    expect(skuOf(rows, 'W').allConfirmed).toBeCloseTo(50)  // now sharing South's pool with ARIHANT
+    expect(skuOf(rows, 'S').allConfirmed).toBeCloseTo(50)
+  })
+
+  it('shows a region nobody serves NO stock — never every plant\u2019s', () => {
+    const north = [{ deleted: false, mmId: 'S1', distributorCode: 'N', customer: 'DELHI TUBES', shipToState: 'DELHI', orderStatus: 'Confirmed', confirmed: 20, nonConfirmed: 0 }]
+    const rows = salesByDistributor([...orders, ...north], [], '2026-08', skus,
+      { productions: hyd, stateRegions: [{ state: 'DELHI', region: 'North' }] })
+    expect(rows.find(r => r.id === 'N').region).toBe('North')
+    expect(skuOf(rows, 'N').onhand).toBe(0)          // not 45 — no plant serves North
+    expect(skuOf(rows, 'N').shortBy).toBeCloseTo(20)
+  })
+
+  it('leaves every existing caller untouched when no productions are passed', () => {
+    const rows = salesByDistributor(orders, [], '2026-08', skus)
+    rows.forEach(r => r.skuRows.forEach(s => {
+      ;['onhand', 'freeStock', 'allPending', 'allConfirmed', 'shortBy'].forEach(f =>
+        expect(s[f]).toBeUndefined())
+    }))
   })
 })
 

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -64,6 +64,8 @@ const TABLE_MAP = {
   'jsw:orders': 'orders',
   'jsw:distributorEstimates': 'distributor_estimates',
   'jsw:stateRegions': 'state_regions',
+  'jsw:plants': 'plants',
+  'jsw:distributors': 'distributors',
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -80,10 +82,17 @@ const TABLE_MAP = {
 // `state_regions` holds one row per state, so `state` is its arbiter: the first edit of a SEEDED
 // state arrives under the seed's literal id, and any later re-map of the same state must UPDATE that
 // row rather than collide with unique(state).
+// `plants` and `distributors` (ticket #129) are the same shape as `state_regions`: one row per
+// real-world thing, layered over a code seed, so the arbiter is the thing itself — the plant's
+// literal id, the distributor's resolved identity key — and never the surrogate uuid. The first
+// edit of a plant that has only ever existed in the seed arrives under a fresh id, and every later
+// edit of that plant must UPDATE that row rather than collide with unique(plant_id).
 export const CONFLICT_TARGET = {
   skus: 'sku_code',
   distributor_estimates: 'distributor_key,month',
   state_regions: 'state',
+  plants: 'plant_id',
+  distributors: 'distributor_key',
 }
 export const conflictTargetFor = (tableName) => CONFLICT_TARGET[tableName] || 'id'
 

--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -571,7 +571,7 @@ export function buildPlantMtdSummary(orders, dispatches, { date = today(), maste
   }
 }
 
-export function buildMtdDashboardData(orders, dispatches, productions, skus, { date = today(), estimates = [], stateRegions = null } = {}) {
+export function buildMtdDashboardData(orders, dispatches, productions, skus, { date = today(), estimates = [], stateRegions = null, plants = null, distributors = null } = {}) {
   const D = date, D1 = dashShift(D, -1), D2 = dashShift(D, -2)
   const MONTH = dashMonthKey(D), PREV = dashPrevMonth(D), DAY = dashDay(D)
   // The plant Best Estimate is DERIVED — Σ of the month's distributor estimates, never typed
@@ -647,8 +647,12 @@ export function buildMtdDashboardData(orders, dispatches, productions, skus, { d
 
   // ── Distributor sheets. ONE call to salesByDistributor — the same function (and the same options)
   // the Sales tab drill-down uses — feeds both, so the screen and the workbook cannot disagree.
-  // `productions` adds unreserved plant stock to every SKU row; `stateRegions` adds state + region.
-  const distRowsAll = salesByDistributor(orders, dispatches, MONTH, skus, { estimates, productions, stateRegions })
+  // `productions` adds stock to every SKU row, scoped to the distributor's SERVICE AREA;
+  // `stateRegions` adds state + region; `plants` and `distributors` are the two masters that decide
+  // which area a row reads its stock from (ticket #129). All four are pass-through — every rule
+  // lives in calc.js, so the workbook cannot answer the question differently from the screen.
+  const distRowsAll = salesByDistributor(orders, dispatches, MONTH, skus,
+    { estimates, productions, stateRegions, plants, distributors })
 
   // Sheet 3 — the month's orders and invoicing, grouped by region then distributor. It stays
   // inventory-free — every one of its columns is totalled, and an unreserved stock column cannot be
@@ -660,11 +664,13 @@ export function buildMtdDashboardData(orders, dispatches, productions, skus, { d
   // zero) — not every possible pair. Region → distributor → pending desc, with the SKU label as a
   // stable tiebreak.
   //
-  // `freeStock` (on-hand less the Confirmed tonnage of EVERY distributor) is the WHOLE PLANT's and
-  // is reserved to nobody, so the identical tonnage repeats on every distributor's row for that size
+  // `freeStock` is the SERVICE AREA's (ticket #129): on-hand at the plants that serve this
+  // distributor's region, less the Confirmed tonnage of every distributor in that same area. Inside
+  // an area it is reserved to nobody, so the identical tonnage repeats on every row for that size
   // and `shortBy` can read 0 on a row whose size is oversubscribed several times over. That is why
   // the rendered sheet carries no total on it — in fact no total row at all — and a caption naming
-  // the sharing (ADR-0002).
+  // the sharing (ADR-0002). ACROSS areas nothing repeats: a West row reads West plants' stock, and
+  // today that is zero while Hyderabad holds the lot.
   const distSkuRows = []
   distRowsAll.forEach(r => {
     ;(r.skuRows || []).forEach(s => {
@@ -673,8 +679,12 @@ export function buildMtdDashboardData(orders, dispatches, productions, skus, { d
         region: r.region, state: r.state || '', customer: r.customer,
         skuKey: s.id, sku: skuLabel(skuByKey.get(s.id), s.description || s.id),
         invoicedMtd: s.mtdInvoice, confirmed: s.confirmed, nonConfirmed: s.nonConfirmed,
-        pending: s.pending, onhand: s.onhand ?? 0, freeStock: s.freeStock ?? 0,
-        allConfirmed: s.allConfirmed ?? 0, shortBy: s.shortBy ?? 0,
+        // NOT `?? 0`. A distributor with no known service area (`Unmapped`) gets null from
+        // salesByDistributor, and coercing that to 0 prints "no stock" where the truth is "we
+        // cannot tell" — a sales team reads the first as a fact and the second as a job to do.
+        // The renderer prints "?" for null; App.jsx already renders it as an em dash.
+        pending: s.pending, onhand: s.onhand ?? null, freeStock: s.freeStock ?? null,
+        allConfirmed: s.allConfirmed ?? null, shortBy: s.shortBy ?? null,
       })
     })
   })
@@ -939,7 +949,8 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   const date = opts.date || today()
   const company = opts.companyName || 'JSW One Pipes & Tubes'
   const data = buildMtdDashboardData(orders, dispatches, productions, skus,
-    { date, estimates: opts.estimates ?? [], stateRegions: opts.stateRegions ?? null })
+    { date, estimates: opts.estimates ?? [], stateRegions: opts.stateRegions ?? null,
+      plants: opts.plants ?? null, distributors: opts.distributors ?? null })
   const ExcelJS = await loadExcelJS()
   const wb = new ExcelJS.Workbook()
   const cL = (n) => String.fromCharCode(64 + n)
@@ -1266,17 +1277,21 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
     { width: 13 }, { width: 12 }, { width: 12 }, { width: 12 }, { width: 17 }, { width: 11 }]
   writeTitle(ws4, 10, `${company} — DISTRIBUTOR × SKU — PENDING vs INVOICED vs PLANT STOCK — ${monthLabel}`, date)
   styleHeaderRow(ws4.addRow(['Region', 'State', 'Distributor', 'SKU',
-    `Invoiced MTD${invScope}`, 'Confirmed', 'Non-Conf', 'Pending', 'Free Stock (plant)', 'Short by']))
+    `Invoiced MTD${invScope}`, 'Confirmed', 'Non-Conf', 'Pending', 'Free Stock (area)', 'Short by']))
   const dsk = data.distributorSku
   const ds4HeaderRow = ws4.lastRow.number
   if (!dsk.rows.length) {
     const r = ws4.addRow(['No distributor has pending or month-to-date invoiced tonnage', '', '', '', '', '', '', '', '', ''])
     r.eachCell(c => { c.border = ALL_BORDERS })
   }
+  // A stock cell the app cannot answer prints "?" — never a "-" and never 0. `dash` renders a real
+  // 0.0 as "-", so without this an Unmapped distributor's row would be indistinguishable from one
+  // whose area genuinely holds nothing, which are opposite instructions to whoever reads the sheet.
+  const stockCell = (v) => (v == null ? '?' : dash(v))
   dsk.rows.forEach(row => {
     const r = ws4.addRow([row.region, row.state || '—', row.customer, row.sku,
       dash(row.invoicedMtd), dash(row.confirmed), dash(row.nonConfirmed), dash(row.pending),
-      dash(row.freeStock), dash(row.shortBy)])
+      stockCell(row.freeStock), stockCell(row.shortBy)])
     ;[5, 6, 7, 8, 9, 10].forEach(i => numCell(r, i, MT1))
     r.eachCell(c => { c.border = ALL_BORDERS })
   })
@@ -1284,7 +1299,7 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
     ws4.autoFilter = { from: { row: ds4HeaderRow, column: 1 }, to: { row: ws4.lastRow.number, column: 10 } }
   }
   ws4.addRow([])
-  const note4 = ws4.addRow([`Free Stock (plant) is the WHOLE PLANT's stock of that size — produced minus invoiced — LESS the Confirmed tonnage of every distributor, i.e. what is promised to nobody yet. A NEGATIVE figure means the size is committed beyond what is on the floor. It is NOT reserved for anyone, so the same tonnage is repeated on every distributor's row waiting on that size, and it is deliberately NOT totalled anywhere on this sheet: adding the column up would report more stock than the plant holds. For the same reason "Short by" (Pending − on-hand, floored at zero) can read "-" on a row whose size several distributors are queued against — it says the plant has the tonnage, not that this distributor will get it. Rows are the live pairs only (Pending or Invoiced MTD above zero), sorted Region → Distributor → Pending. A distributor whose state carries no region mapping reads ${UNMAPPED_REGION}. Free Stock is every plant's finished stock combined — the plant column is not applied to it, because stock is held where it was made and an order is served from wherever the tonnage is.${ps.invoicing.note ? ' ' + ps.invoicing.note : ''}`])
+  const note4 = ws4.addRow([`Free Stock (area) is the stock of the plants that SERVE THIS DISTRIBUTOR'S REGION — produced minus invoiced at those plants — LESS the Confirmed tonnage of every distributor in that same service area, i.e. what is promised to nobody yet. Hyderabad and Lepakshi serve South; NPMD and Tapi serve West (Masters tab). A distributor is never offered stock from a plant that does not serve it: today every production row is Hyderabad's, so West rows correctly show no Free Stock and their full pending as "Short by" — that is the true position, not a missing figure, and it fills itself in the day NPMD produces. Inside one service area the stock is NOT reserved to anyone, so the same tonnage is repeated on every distributor's row there waiting on that size, and it is deliberately NOT totalled anywhere on this sheet: adding the column up would report more stock than the plants hold. For the same reason "Short by" (Pending − on-hand in the area, floored at zero) can read "-" on a row whose size several distributors are queued against — it says the area has the tonnage, not that this distributor will get it. A "?" means the distributor's service area is unknown, not that it has no stock: its state carries no region mapping (${UNMAPPED_REGION}), so map the state on the Sales tab. Rows are the live pairs only (Pending or Invoiced MTD above zero), sorted Region → Distributor → Pending.${ps.invoicing.note ? ' ' + ps.invoicing.note : ''}`])
   ws4.mergeCells(`A${note4.number}:J${note4.number}`)
   note4.getCell(1).font = { italic: true, size: 9, color: { argb: 'FF6B7280' } }
   note4.getCell(1).alignment = { wrapText: true, vertical: 'top' }

--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -16,7 +16,8 @@
 // script without breaking a single test — see src/lib/module-resolution.test.js.
 import { producedPool, unmatchedDispatch, coilConsumption, skuSizeLabel, skuKeyResolver, canonicalSkuKey, skuAgeing, salesKpis,
   plantBestEstimate, salesByDistributor, distributorRegionResolver, distributorCode, REGIONS, UNMAPPED_REGION,
-  PLANTS, plantById, plantLabel, plantKeysIn, filterByPlant, filterDispatchesByPlant, UNATTRIBUTED_PLANT } from './calc.js'
+  PLANTS, plantById, plantLabel, plantKeysIn, filterByPlant, filterDispatchesByPlant, UNATTRIBUTED_PLANT,
+  plantMaster, plantsServingRegion } from './calc.js'
 
 const EPS = 0.0005 // MT — treat anything below as zero (rounding noise)
 
@@ -1275,7 +1276,7 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   })
   ws4.columns = [{ width: 11 }, { width: 20 }, { width: 34 }, { width: 18 },
     { width: 13 }, { width: 12 }, { width: 12 }, { width: 12 }, { width: 17 }, { width: 11 }]
-  writeTitle(ws4, 10, `${company} — DISTRIBUTOR × SKU — PENDING vs INVOICED vs PLANT STOCK — ${monthLabel}`, date)
+  writeTitle(ws4, 10, `${company} — DISTRIBUTOR × SKU — PENDING vs INVOICED vs SERVICE-AREA STOCK — ${monthLabel}`, date)
   styleHeaderRow(ws4.addRow(['Region', 'State', 'Distributor', 'SKU',
     `Invoiced MTD${invScope}`, 'Confirmed', 'Non-Conf', 'Pending', 'Free Stock (area)', 'Short by']))
   const dsk = data.distributorSku
@@ -1299,7 +1300,17 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
     ws4.autoFilter = { from: { row: ds4HeaderRow, column: 1 }, to: { row: ws4.lastRow.number, column: 10 } }
   }
   ws4.addRow([])
-  const note4 = ws4.addRow([`Free Stock (area) is the stock of the plants that SERVE THIS DISTRIBUTOR'S REGION — produced minus invoiced at those plants — LESS the Confirmed tonnage of every distributor in that same service area, i.e. what is promised to nobody yet. Hyderabad and Lepakshi serve South; NPMD and Tapi serve West (Masters tab). A distributor is never offered stock from a plant that does not serve it: today every production row is Hyderabad's, so West rows correctly show no Free Stock and their full pending as "Short by" — that is the true position, not a missing figure, and it fills itself in the day NPMD produces. Inside one service area the stock is NOT reserved to anyone, so the same tonnage is repeated on every distributor's row there waiting on that size, and it is deliberately NOT totalled anywhere on this sheet: adding the column up would report more stock than the plants hold. For the same reason "Short by" (Pending − on-hand in the area, floored at zero) can read "-" on a row whose size several distributors are queued against — it says the area has the tonnage, not that this distributor will get it. A "?" means the distributor's service area is unknown, not that it has no stock: its state carries no region mapping (${UNMAPPED_REGION}), so map the state on the Sales tab. Rows are the live pairs only (Pending or Invoiced MTD above zero), sorted Region → Distributor → Pending.${ps.invoicing.note ? ' ' + ps.invoicing.note : ''}`])
+  // Who serves whom is READ OFF THE MASTER, never spelled out here. A caption that states a rule as
+  // a literal is exactly what let this sheet claim "Free Stock is every plant's stock combined" for
+  // a month after the opposite had been decided (ADR-0006) — so the sentence has to come from the
+  // same data the figures came from, and go stale only when they do.
+  const areaMaster = plantMaster(opts.plants ?? null)
+  const servedBy = REGIONS.map(r => {
+    const names = [...plantsServingRegion(r, areaMaster)].map(id => plantLabel(id, areaMaster))
+    const list = names.length > 1 ? `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}` : names[0]
+    return names.length ? `${list} serve${names.length === 1 ? 's' : ''} ${r}` : ''
+  }).filter(Boolean).join('; ')
+  const note4 = ws4.addRow([`Free Stock (area) is the stock of the plants that SERVE THIS DISTRIBUTOR'S REGION — produced minus invoiced at those plants — LESS the Confirmed tonnage of every distributor in that same service area, i.e. what is promised to nobody yet. ${servedBy || 'No plant has a service area set'} (Masters tab). A distributor is never offered stock from a plant that does not serve it. A region whose plants have produced nothing therefore shows no Free Stock at all and its distributors' full pending as "Short by" — that is the true position, not a missing figure, and it fills itself in the day one of those plants produces. Inside one service area the stock is NOT reserved to anyone, so the same tonnage is repeated on every distributor's row there waiting on that size, and it is deliberately NOT totalled anywhere on this sheet: adding the column up would report more stock than the plants hold. For the same reason "Short by" (Pending − on-hand in the area, floored at zero) can read "-" on a row whose size several distributors are queued against — it says the area has the tonnage, not that this distributor will get it. A "?" means the distributor's service area is unknown, not that it has no stock: its state carries no region mapping (${UNMAPPED_REGION}), so map the state on the Sales tab. Rows are the live pairs only (Pending or Invoiced MTD above zero), sorted Region → Distributor → Pending.${ps.invoicing.note ? ' ' + ps.invoicing.note : ''}`])
   ws4.mergeCells(`A${note4.number}:J${note4.number}`)
   note4.getCell(1).font = { italic: true, size: 9, color: { argb: 'FF6B7280' } }
   note4.getCell(1).alignment = { wrapText: true, vertical: 'top' }

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -711,16 +711,21 @@ describe('distributor sheet — rendered layout (issue #104)', () => {
   })
 })
 
-// ── Distributor × SKU sheet (issue #105) ────────────────────────────────────────────────────────
-// Fixture reproducing the oversubscription the ticket documents from live data: SKU 50x50 x 2 SHS,
-// plant holding 39.3 T, five distributors queued against it for 78 T in total.
+// ── Distributor × SKU sheet (issues #105, #129) ─────────────────────────────────────────────────
+// The live shape on 20-Aug-2026: every tonne of stock made at Hyderabad, a South plant, and most of
+// the queue for it standing in West. SKU 50x50 x 2 SHS, 39.3 T on the Hyderabad floor, five
+// distributors queued against it for 78 T in total.
 //
-//   produced 45.3 − invoiced 6.0 (VORA)  = 39.3 T on hand, plant-wide, reserved to nobody
-//   NEW PASHCHIM MAHARASHTRA  pending 40.0   ← the only row that shows a shortfall (0.7)
-//   VORA & CO                 pending 10.0   ← reads "covered", though 78 T is queued against 39.3
-//   S G ENTERPRISES           pending 10.0
-//   ARIHANT STEEL POINT       pending 10.0
-//   MAHENDRA ISPAT            pending  8.0   ← no ship-to state → Unmapped
+//   produced 45.3 − invoiced 6.0 (VORA)  = 39.3 T on hand IN SOUTH, shared there, reserved to nobody
+//   NEW PASHCHIM MAHARASHTRA  pending 40.0   MAHARASHTRA → West → no West plant produces → short 40.0
+//   VORA & CO                 pending 10.0   MAHARASHTRA → West → short 10.0
+//   S G ENTERPRISES           pending 10.0   GUJARAT     → West → short 10.0
+//   ARIHANT STEEL POINT       pending 10.0   KARNATAKA   → South → covered out of the 39.3 T
+//   MAHENDRA ISPAT            pending  8.0   ← no ship-to state → Unmapped → stock reads "?"
+//
+// `plant` on the productions and on every dispatch entry is what makes this fixture mean anything:
+// without it the stock belongs to no service area, every row reads zero, and each assertion below
+// passes for the wrong reason.
 //
 // A second SKU (40x40 x 2.5) carries the two edge cases: KIRTI TUBES has an invoice but no pending
 // (must still appear), and VORA has an order line with neither (must NOT appear).
@@ -729,12 +734,14 @@ const dsSkus = [
   { skuCode: 'X2', productType: 'SHS', height: 40, breadth: 40, thickness: 2.5, length: 6000, weightPerTube: 8 },
 ]
 const dsProductions = [
-  { skuCode: 'X1', dateOfProduction: '2026-07-05', tubeCount: 100, totalWeight: 45.3 },
-  { skuCode: 'X2', dateOfProduction: '2026-07-05', tubeCount: 50, totalWeight: 12 },
+  { skuCode: 'X1', plant: 'hyderabad', dateOfProduction: '2026-07-05', tubeCount: 100, totalWeight: 45.3 },
+  { skuCode: 'X2', plant: 'hyderabad', dateOfProduction: '2026-07-05', tubeCount: 50, totalWeight: 12 },
 ]
+// Both invoices ship OUT OF HYDERABAD — including the one to a West distributor, which is exactly
+// what happens today. The tonnage comes off the South floor it left, and off no other.
 const dsDispatches = [
-  { dateOfDispatch: '2026-07-12', bundleEntries: [{ skuCode: 'X1', weight: 6, customer: 'VORA & CO', shipToState: 'MAHARASHTRA' }] },
-  { dateOfDispatch: '2026-07-13', bundleEntries: [{ skuCode: 'X2', weight: 3, customer: 'KIRTI TUBES', shipToState: 'TAMIL NADU' }] },
+  { dateOfDispatch: '2026-07-12', bundleEntries: [{ skuCode: 'X1', plant: 'hyderabad', weight: 6, customer: 'VORA & CO', shipToState: 'MAHARASHTRA' }] },
+  { dateOfDispatch: '2026-07-13', bundleEntries: [{ skuCode: 'X2', plant: 'hyderabad', weight: 3, customer: 'KIRTI TUBES', shipToState: 'TAMIL NADU' }] },
 ]
 const dsOrders = [
   { orderDate: '2026-07-01', customer: 'NEW PASHCHIM MAHARASHTRA', shipToState: 'MAHARASHTRA', mmId: 'X1', quantity: 40, confirmed: 40, nonConfirmed: 0, orderStatus: '' },
@@ -823,20 +830,80 @@ describe('buildMtdDashboardData — distributor × SKU rows', () => {
     expect(rows.find(r => r.customer === 'S G ENTERPRISES').region).toBe('West') // Gujarat, untouched
   })
 
-  it('repeats ONE plant-wide on-hand tonnage identically on every distributor waiting on that size', () => {
-    const x1 = rowsOf().filter(r => r.sku === '50x50 x 2')
-    expect(x1).toHaveLength(5)
-    x1.forEach(r => expect(r.onhand).toBeCloseTo(39.3, 6)) // 45.3 produced − 6.0 invoiced, undivided
-    // …and that is exactly why the column is never summed: 78 T is queued against those 39.3 T.
-    expect(x1.reduce((t, r) => t + r.pending, 0)).toBeCloseTo(78, 6)
-    expect(x1.reduce((t, r) => t + r.onhand, 0)).toBeCloseTo(196.5, 6) // 5 × 39.3 — a fiction
+  it('offers Hyderabad stock to South only — West reads zero while 39.3 T sits on the floor', () => {
+    const x1 = Object.fromEntries(rowsOf().filter(r => r.sku === '50x50 x 2').map(r => [r.customer, r]))
+    expect(Object.keys(x1)).toHaveLength(5)
+    expect(x1['ARIHANT STEEL POINT'].onhand).toBeCloseTo(39.3, 6)  // 45.3 produced − 6.0 invoiced
+    ;['NEW PASHCHIM MAHARASHTRA', 'VORA & CO', 'S G ENTERPRISES']
+      .forEach(w => expect(x1[w].onhand).toBe(0))                  // West: no West plant produces
+    expect(x1['MAHENDRA ISPAT'].onhand).toBeNull()                 // Unmapped: unknown, not zero
   })
 
-  it('Short by is Pending − On-hand floored at zero, so an oversubscribed size can read covered', () => {
+  it('still shares one tonnage between distributors INSIDE a service area (ADR-0002 unchanged)', () => {
+    // A second South distributor queued on the same size reads the identical 39.3 T — the sharing
+    // this sheet has always carried a caption about. Narrowing WHOSE pool a row reads did not
+    // divide the pool.
+    const orders = [...dsOrders,
+      { orderDate: '2026-07-09', customer: 'KIRTI TUBES', shipToState: 'TAMIL NADU', mmId: 'X1', quantity: 30, confirmed: 30, nonConfirmed: 0, orderStatus: '' }]
+    const south = buildMtdDashboardData(orders, dsDispatches, dsProductions, dsSkus, dsOpts)
+      .distributorSku.rows.filter(r => r.sku === '50x50 x 2' && r.region === 'South')
+    expect(south).toHaveLength(2)
+    south.forEach(r => expect(r.onhand).toBeCloseTo(39.3, 6))
+    // …and that is still why the column is never summed: 40 T is queued against those 39.3 T.
+    expect(south.reduce((t, r) => t + r.pending, 0)).toBeCloseTo(40, 6)
+    expect(south.reduce((t, r) => t + r.onhand, 0)).toBeCloseTo(78.6, 6) // 2 × 39.3 — a fiction
+  })
+
+  it('Short by is Pending − On-hand in the DISTRIBUTOR\u2019S OWN area, floored at zero', () => {
     const by = Object.fromEntries(rowsOf().map(r => [r.customer, r]))
-    expect(by['NEW PASHCHIM MAHARASHTRA'].shortBy).toBeCloseTo(0.7, 6) // 40 − 39.3
-    expect(by['VORA & CO'].shortBy).toBe(0)          // 10 ≤ 39.3 — the ambiguity ADR-0002 accepts
-    expect(by['MAHENDRA ISPAT'].shortBy).toBe(0)
+    expect(by['NEW PASHCHIM MAHARASHTRA'].shortBy).toBeCloseTo(40, 6) // the whole order book, not 0.7
+    expect(by['VORA & CO'].shortBy).toBeCloseTo(10, 6)                // West too — not "covered"
+    expect(by['ARIHANT STEEL POINT'].shortBy).toBe(0)  // 10 ≤ 39.3 in South — ADR-0002's ambiguity
+    expect(by['MAHENDRA ISPAT'].shortBy).toBeNull()    // unknown area ⇒ unknown shortfall
+  })
+
+  it('never subtracts a South invoice from West\u2019s empty stock', () => {
+    // VORA is a West distributor invoiced 6.0 T out of Hyderabad. That tonnage left the SOUTH floor.
+    // Charging it to West would read as −6 T, floored to 0 and every West free-stock figure wrong.
+    const by = Object.fromEntries(rowsOf().map(r => [r.customer, r]))
+    expect(by['VORA & CO'].invoicedMtd).toBeCloseTo(6, 6)
+    expect(by['VORA & CO'].onhand).toBe(0)
+    expect(by['ARIHANT STEEL POINT'].onhand).toBeCloseTo(39.3, 6)     // 45.3 − 6.0, in South
+  })
+
+  it('nets Confirmed and pending per area, so South is not charged with West\u2019s queue', () => {
+    const by = Object.fromEntries(rowsOf().map(r => [r.customer, r]))
+    expect(by['ARIHANT STEEL POINT'].allConfirmed).toBeCloseTo(10, 6)  // ARIHANT alone
+    expect(by['ARIHANT STEEL POINT'].freeStock).toBeCloseTo(29.3, 6)   // 39.3 − 10
+    expect(by['NEW PASHCHIM MAHARASHTRA'].allConfirmed).toBeCloseTo(56, 6) // 40 + 6 + 10, West only
+    expect(by['NEW PASHCHIM MAHARASHTRA'].freeStock).toBeCloseTo(-56, 6)
+  })
+
+  it('fills West the day an NPMD row appears, and moves South by not one kilo', () => {
+    const withNpmd = [...dsProductions,
+      { skuCode: 'X1', plant: 'npmd', dateOfProduction: '2026-07-14', tubeCount: 100, totalWeight: 60 }]
+    const after = Object.fromEntries(buildMtdDashboardData(dsOrders, dsDispatches, withNpmd, dsSkus, dsOpts)
+      .distributorSku.rows.map(r => [r.customer, r]))
+    const before = Object.fromEntries(rowsOf().map(r => [r.customer, r]))
+    expect(after['NEW PASHCHIM MAHARASHTRA'].onhand).toBeCloseTo(60, 6)
+    expect(after['NEW PASHCHIM MAHARASHTRA'].shortBy).toBe(0)
+    expect(after['ARIHANT STEEL POINT']).toEqual(before['ARIHANT STEEL POINT'])
+    expect(after['KIRTI TUBES']).toEqual(before['KIRTI TUBES'])
+  })
+
+  it('follows the plant master — re-point Hyderabad at West and the two swap', () => {
+    const rows = rowsOf({ ...dsOpts, plants: [{ plantId: 'hyderabad', serves: ['West'] }] })
+    const by = Object.fromEntries(rows.map(r => [r.customer, r]))
+    expect(by['NEW PASHCHIM MAHARASHTRA'].onhand).toBeCloseTo(39.3, 6)
+    expect(by['ARIHANT STEEL POINT'].onhand).toBe(0)   // Lepakshi still serves South and produces nothing
+  })
+
+  it('follows the distributor master — an override moves one row\u2019s pool without moving its state', () => {
+    const rows = rowsOf({ ...dsOpts, distributors: [{ distributorKey: 'VORA & CO', region: 'South' }] })
+    const vora = rows.find(r => r.customer === 'VORA & CO')
+    expect(vora.region).toBe('South')
+    expect(vora.state).toBe('MAHARASHTRA')             // the ERP's own answer, never overwritten
+    expect(vora.onhand).toBeCloseTo(39.3, 6)
   })
 
   it('carries the order-book split and the month’s invoiced tonnage per pair', () => {
@@ -870,8 +937,10 @@ describe('Distributor × SKU sheet — rendering', () => {
     expect(wb.worksheets.map(w => w.name))
       .toEqual(['Dashboard', 'SKU Ageing (>2 MT)', 'Distributor by Region', 'Distributor × SKU'])
     const ws = wb.getWorksheet('Distributor × SKU')
+    // The Invoiced header carries the #127 scope label: every invoice in this fixture is now
+    // attributed to Hyderabad (it has to be, or the stock filter has nothing to read).
     expect(ws.getRow(3).values.slice(1)).toEqual(['Region', 'State', 'Distributor', 'SKU',
-      'Invoiced MTD', 'Confirmed', 'Non-Conf', 'Pending', 'Free Stock (plant)', 'Short by'])
+      'Invoiced MTD · Hyderabad only', 'Confirmed', 'Non-Conf', 'Pending', 'Free Stock (area)', 'Short by'])
     expect(ws.getRow(4).values.slice(1, 5))
       .toEqual(['South', 'KARNATAKA', 'ARIHANT STEEL POINT', '50x50 x 2'])
     expect(ws.getRow(9).values.slice(1, 4)).toEqual(['Unmapped', '—', 'MAHENDRA ISPAT'])
@@ -882,11 +951,21 @@ describe('Distributor × SKU sheet — rendering', () => {
     const ws = wb.getWorksheet('Distributor × SKU')
     ;[5, 6, 7, 8, 9, 10].forEach(c => expect(ws.getCell(4, c).numFmt).toBe('#,##0.0'))
     const npm = rowStartingWith(ws, 'West') // first West row = NEW PASHCHIM MAHARASHTRA
-    // Free Stock = 39.3 on-hand − 74.0 Confirmed across all five distributors = −34.7. Negative is
-    // the point: 50x50x2.0 is committed twice over. Short by still measures against on-hand (0.7).
-    expect(Number(ws.getCell(npm, 9).value)).toBeCloseTo(-34.7, 6) // not -34, not 39.3
-    expect(Number(ws.getCell(npm, 10).value)).toBeCloseTo(0.7, 6)  // not 1
+    // West holds nothing, so Free Stock = 0 on-hand − 56.0 Confirmed across the three WEST
+    // distributors = −56.0, and Short by is the full 40 T pending. Neither figure is softened by
+    // the 39.3 T sitting in Hyderabad, which no West lorry is going to load.
+    expect(Number(ws.getCell(npm, 9).value)).toBeCloseTo(-56, 6)   // not -34.7, not 39.3
+    expect(Number(ws.getCell(npm, 10).value)).toBeCloseTo(40, 6)   // not 0.7
     expect(ws.getCell(npm, 5).value).toBe('-')                     // nothing invoiced → dashed, not 0.0
+  })
+
+  it('prints "?" — not "-" and not 0 — where the service area is unknown', async () => {
+    const { wb } = await renderMtdWorkbook(dsOrders, dsDispatches, dsProductions, dsSkus, dsOpts)
+    const ws = wb.getWorksheet('Distributor × SKU')
+    const un = rowStartingWith(ws, 'Unmapped')     // MAHENDRA ISPAT — no ship-to state
+    expect(ws.getCell(un, 9).value).toBe('?')      // Free Stock
+    expect(ws.getCell(un, 10).value).toBe('?')     // Short by
+    expect(Number(ws.getCell(un, 8).value)).toBeCloseTo(8, 6)  // its pending is a fact and still prints
   })
 
   it('never totals Free Stock — no total row of any kind sits on the sheet', async () => {
@@ -894,26 +973,34 @@ describe('Distributor × SKU sheet — rendering', () => {
     const ws = wb.getWorksheet('Distributor × SKU')
     // No totals/subtotals label anywhere in the body (the closing caption is checked separately,
     // and does mention the word — to say the column is deliberately NOT totalled).
-    labelsOf(ws).filter(v => !v.includes('WHOLE PLANT'))
+    labelsOf(ws).filter(v => !v.includes('SERVE THIS DISTRIBUTOR'))
       .forEach(v => expect(v).not.toMatch(/total/i))
     // …and no cell in the Free Stock column holds a sum of it — not the whole column, and not the
-    // per-region West subtotal (3 × −34.7) either.
+    // per-region West subtotal (3 × −56) either.
     const free = ws.getColumn(9).values.filter(v => typeof v === 'number')
-    expect(free).toHaveLength(6) // exactly the six data rows, nothing more
+    expect(free).toHaveLength(5) // the five data rows that HAVE an area; MAHENDRA's cell is "?"
     const colSum = free.reduce((t, v) => t + v, 0)
-    ;[colSum, 3 * -34.7].forEach(sum => free.forEach(v => expect(Math.abs(v - sum)).toBeGreaterThan(0.05)))
+    ;[colSum, 3 * -56].forEach(sum => free.forEach(v => expect(Math.abs(v - sum)).toBeGreaterThan(0.05)))
   })
 
-  it('captions the sheet: plant-wide, unreserved, repeated across distributors', async () => {
+  it('captions the sheet: service-area scoped, unreserved inside an area, repeated there', async () => {
     const { wb } = await renderMtdWorkbook(dsOrders, dsDispatches, dsProductions, dsSkus, dsOpts)
-    const caption = labelsOf(wb.getWorksheet('Distributor × SKU')).find(v => v.includes('WHOLE PLANT'))
+    const captions = labelsOf(wb.getWorksheet('Distributor × SKU'))
+    const caption = captions.find(v => v.includes('SERVE THIS DISTRIBUTOR'))
     expect(caption).toBeTruthy()
     expect(caption).toMatch(/NOT reserved/)
     expect(caption).toMatch(/repeated on every distributor/)
     expect(caption).toMatch(/NOT totalled/)
-    // Free Stock nets Confirmed off, so the caption has to say what was netted and what a negative means.
-    expect(caption).toMatch(/LESS the Confirmed tonnage of every distributor/)
-    expect(caption).toMatch(/NEGATIVE figure means the size is committed beyond/)
+    expect(caption).toMatch(/LESS the Confirmed tonnage of every distributor in that same service area/)
+    // It has to name who serves whom, and say what an empty West column and a "?" each mean —
+    // a screen of blanks otherwise reads as a loading bug.
+    expect(caption).toMatch(/Hyderabad and Lepakshi serve South/)
+    expect(caption).toMatch(/West rows correctly show no Free Stock/)
+    expect(caption).toMatch(/"\?" means the distributor's service area is unknown/)
+    // The old sentence said the opposite of the rule and must be gone from the whole sheet.
+    captions.forEach(v => expect(v).not.toMatch(/WHOLE PLANT/))
+    captions.forEach(v => expect(v).not.toMatch(/every plant's finished stock combined/))
+    captions.forEach(v => expect(v).not.toMatch(/the plant column is not applied to it/))
   })
 
   it('renders an empty sheet without throwing when nothing is live', async () => {
@@ -1127,8 +1214,10 @@ describe('buildPlantMtdSummary — the per-plant split (#127)', () => {
 describe('the split changes nothing else about the workbook (#127)', () => {
   const opts = { date: pD, estimates: [{ distributorKey: 'D1', distributorName: 'PATEL STEEL', month: '2026-08', bestEstimate: 900 }] }
   // The same order book with every line re-attributed to a different plant. Region, Best Estimate,
-  // Free Stock, On-hand and Short by are keyed by distributor, state and SKU — never by plant — so
-  // moving every line to another plant may not move ONE of these figures.
+  // Free Stock, On-hand and Short by are keyed by distributor, state and SKU — never by the ORDER
+  // LINE's plant — so moving every line to another plant may not move ONE of these figures.
+  // (Since #129 stock IS keyed by plant — the PRODUCTION row's, through the service area. That is a
+  // different column on a different table, and this test is what keeps the two from being confused.)
   const reattributed = pOrders.map(o => ({ ...o, plant: o.plant === 'hyderabad' ? 'tapi' : 'hyderabad' }))
 
   it('keeps the company KPIs exactly where they were', () => {
@@ -1146,15 +1235,23 @@ describe('the split changes nothing else about the workbook (#127)', () => {
     expect(b).toEqual(a)
   })
 
-  it('keeps Free Stock, On-hand and Short by plant-wide and unreserved', () => {
+  it('keeps stock deaf to the ORDER LINE\u2019s plant — it follows the service area instead', () => {
     const skus = [{ skuCode: 'S1', productType: 'SHS', height: 50, breadth: 50, thickness: 2, length: 6000, weightPerTube: 10 }]
-    const prods = [{ skuCode: 'S1', dateOfProduction: '2026-08-01', tubeCount: 100, totalWeight: 500 }]
-    const withSku = pOrders.map(o => ({ ...o, skuCode: 'S1' }))
+    const prods = [{ skuCode: 'S1', plant: 'hyderabad', dateOfProduction: '2026-08-01', tubeCount: 180, totalWeight: 900 }]
+    const withSku = pOrders.map(o => ({ ...o, mmId: 'S1' }))
     const a = buildMtdDashboardData(withSku, pDispatches, prods, skus, opts).distributorSku.rows
     const b = buildMtdDashboardData(withSku.map(o => ({ ...o, plant: 'tapi' })), pDispatches, prods, skus, opts).distributorSku.rows
-    expect(a).toEqual(b)
-    // The whole plant's stock, reserved to nobody, so the identical figure repeats on every row.
-    expect(new Set(a.map(r => r.freeStock)).size).toBe(1)
+    expect(a).toEqual(b)   // re-attributing every order line moves nothing — still true
+
+    // …but the figure itself is no longer one number for everybody. The 900 T was made at
+    // Hyderabad, less 602.5 T invoiced off that same floor, so South reads 297.5 T and West — which
+    // has no producing plant — reads zero and its full pending as Short by.
+    const by = Object.fromEntries(a.map(r => [r.customer, r]))
+    expect(by['PATEL STEEL'].onhand).toBeCloseTo(297.5, 6)      // TELANGANA → South
+    expect(by['LEPAKSHI DIST'].onhand).toBeCloseTo(297.5, 6)    // KARNATAKA → South, the same tonnage
+    expect(by['PUNE STEEL'].onhand).toBe(0)                     // MAHARASHTRA → West
+    expect(by['PUNE STEEL'].shortBy).toBeCloseTo(1044, 6)
+    expect(new Set(a.map(r => r.freeStock)).size).toBeGreaterThan(1)
   })
 
   it('keeps the region split tying to the company totals', () => {

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -994,13 +994,22 @@ describe('Distributor × SKU sheet — rendering', () => {
     expect(caption).toMatch(/LESS the Confirmed tonnage of every distributor in that same service area/)
     // It has to name who serves whom, and say what an empty West column and a "?" each mean —
     // a screen of blanks otherwise reads as a loading bug.
-    expect(caption).toMatch(/Hyderabad and Lepakshi serve South/)
-    expect(caption).toMatch(/West rows correctly show no Free Stock/)
+    // Who serves whom is read off the plant master, not spelled out in the caption — a literal here
+    // is what let the old sentence outlive the rule it described.
+    expect(caption).toMatch(/Hyderabad and Lepakshi serve South; NPMD and Tapi serve West/)
+    expect(caption).toMatch(/A region whose plants have produced nothing therefore shows no Free Stock/)
     expect(caption).toMatch(/"\?" means the distributor's service area is unknown/)
     // The old sentence said the opposite of the rule and must be gone from the whole sheet.
     captions.forEach(v => expect(v).not.toMatch(/WHOLE PLANT/))
     captions.forEach(v => expect(v).not.toMatch(/every plant's finished stock combined/))
     captions.forEach(v => expect(v).not.toMatch(/the plant column is not applied to it/))
+  })
+
+  it('follows the plant master into the caption, so the sentence cannot outlive the rule', async () => {
+    const { wb } = await renderMtdWorkbook(dsOrders, dsDispatches, dsProductions, dsSkus,
+      { ...dsOpts, plants: [{ plantId: 'npmd', serves: ['South'] }] })
+    const caption = labelsOf(wb.getWorksheet('Distributor × SKU')).find(v => v.includes('SERVE THIS DISTRIBUTOR'))
+    expect(caption).toMatch(/Hyderabad, NPMD and Lepakshi serve South; Tapi serves West/)
   })
 
   it('renders an empty sheet without throwing when nothing is live', async () => {

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -274,6 +274,63 @@ alter table state_regions enable row level security;
 drop policy if exists "Allow all access" on state_regions;
 create policy "Allow all access" on state_regions for all using (true) with check (true);
 
+-- ── PLANT MASTER (ticket #129) ────────────────────────────────────────────────────────────────
+-- The SERVICE AREA of each plant: which regions it will actually ship to. Everything else about a
+-- plant (its ERP Ship From Code, its ERP name strings, its coil prefix, whether it manufactures)
+-- comes from the ERP and stays a read-only code constant in src/data/plants.js — there is nothing
+-- for an operator to type in any of them, so there is nothing to store.
+--
+-- `plant_id` is the plant's fixed literal id ('hyderabad', 'npmd', …) — the same value the pipeline
+-- and order rows carry in their own `plant` column — and is the UNIQUE upsert arbiter, so re-saving
+-- a plant's service area UPDATES its row rather than colliding.
+--
+-- `serves` is a Postgres text[] of region names ('{South}'). It is NOT nullable-means-blank the way
+-- state_regions.region is: an EMPTY array is a real answer ("this plant serves nowhere, so its
+-- stock appears on no distributor's row") and NULL reads the same, because a plant that serves
+-- nowhere and a plant whose service area was cleared are the same fact. What restores the shipped
+-- default is deleting the row, not blanking it.
+--
+-- The table starts EMPTY: the shipped service areas live in src/data/plants.js and are layered
+-- under whatever this table holds (plantMaster in calc.js), so editing one plant cannot silently
+-- un-serve the other three.
+create table if not exists plants (
+  id uuid primary key default gen_random_uuid(),
+  plant_id text not null,
+  serves text[],
+  deleted boolean default false,
+  created_at timestamptz default now(),
+  unique (plant_id)
+);
+alter table plants enable row level security;
+drop policy if exists "Allow all access" on plants;
+create policy "Allow all access" on plants for all using (true) with check (true);
+
+-- ── DISTRIBUTOR MASTER (ticket #129) ──────────────────────────────────────────────────────────
+-- A REGION OVERRIDE per distributor, and nothing else. Region normally comes from the
+-- distributor's ship-to state through state_regions; this table is for the exception that rule
+-- cannot express — a distributor whose state says one region but who is genuinely served as
+-- another. Name, state, orders and invoices all arrive with the ERP data and are never stored here.
+--
+-- `distributor_key` is the resolved distributor identity (resolveDistributorIdentity in calc.js) —
+-- the same key distributor_estimates uses — and is the UNIQUE upsert arbiter.
+-- `distributor_name` is a label so the Masters tab can show a readable row; it is never joined on.
+--
+-- A BLANK `region` (stored NULL by toSnake) means "use the state's region". It is not a region and
+-- not Unmapped: blank is the ordinary state, which is why clearing an override writes '' instead of
+-- deleting the row — the two mean the same thing and both must read as "fall through to the state".
+create table if not exists distributors (
+  id uuid primary key default gen_random_uuid(),
+  distributor_key text not null,
+  distributor_name text,
+  region text,
+  deleted boolean default false,
+  created_at timestamptz default now(),
+  unique (distributor_key)
+);
+alter table distributors enable row level security;
+drop policy if exists "Allow all access" on distributors;
+create policy "Allow all access" on distributors for all using (true) with check (true);
+
 -- SKU Master
 create table if not exists skus (
   id text primary key,


### PR DESCRIPTION
## Summary
Implements ticket #129: plants now have a **service area** — the regions they actually ship to — stored on a new `plants` table and editable on a new Masters tab. Distributors are shown only the stock of plants serving their region, fixing a bug where West distributors were offered South stock.

## Key changes

**Data model**
- New `plants` table (Supabase + seed in `src/data/plants.js`): stores `plant_id` and `serves` (array of region names)
- New `distributors` table (Supabase + seed in `src/data/distributors.js`): stores per-distributor region overrides for exceptions the state map cannot express
- Both follow the state→region pattern: code seed + table layered on top, so edits never un-serve what shipped

**Calculation layer** (`src/lib/calc.js`)
- `plantMaster(rows)`: merges stored rows with the seed, returning the master in seed order
- `plantsServingRegion(region)`: returns the Set of plant IDs serving a region (empty set = real answer, not "no filter")
- `servedRegions(master)`: lists regions that have at least one plant shipping to them
- `filterByPlants(rows, selected)`: set-based sibling to `filterByPlant`; distinguishes `new Set()` (no plants serve here) from `null` (no filter)
- `filterDispatchesByPlants(rows, selected)`: dispatch equivalent
- Region names normalized case-insensitively with whitespace collapsed (matching `REGIONS` and state master)

**UI** (`src/App.jsx`)
- Renamed "SKU Master" tab to "Masters" — now holds three sections: SKU, Plant, and Distributor
- `PlantMaster` component: read-only ERP fields (Ship From Code, coil prefix, manufactures) + editable checkboxes per region for service area
- `DistributorMaster` component: region override per distributor (blank = use state's region)
- `PlantServesCell`: checkbox UI for region selection, commits on every click
- Both masters respect `readOnly` prop (ticket #126)

**Stock scoping** (`src/lib/reports.js`, `scripts/servable-orders.mjs`)
- `salesByDistributor` now filters stock by `plantsServingRegion(distributor.region)` before calculating on-hand
- Distributor × SKU sheet and servable-orders message now show only stock from plants serving that distributor's region
- West distributors no longer see Hyderabad (South) stock

**Tests**
- New test block in `calc.test.js`: service area boundary cases (distributor reads zero when no plant serves its region)
- Updated existing tests to include `plant` on productions and dispatches (required for stock attribution)
- Updated `reports.test.js` fixture: 20-Aug-2026 live shape (Hyderabad stock, West demand, service area boundary)
- Updated `daily-messages.test.mjs`: servable-orders message now names the region alongside the plant

**Documentation**
- New ADR-0006: "Stock is offered only within a plant's service area"
- Updated `CONTEXT.md`: service area now stored, not passed into reports
- Updated `ALGORITHMS.md`: distributor × SKU stock scoped per service area
- Updated `LEARNINGS.md`: why a rule in prose, contradicted by three captions, is not a rule

## Notable implementation details

- **Empty set is an answer**: `filterByPlants(rows, new Set())` returns no rows (region has no plants); `filterByPlants(rows, null)` returns all rows (no filter). This distinction fixes the bug.
- **No deletion UI**: clearing a plant's service area writes `serves: []` (real answer: serves nowhere). Restoring the shipped default requires deleting the row, which the Masters tab does not offer — un-typing a commercial decision should not happen by accident.
- **Upsert on plant_id**: first edit of a seeded plant creates its row; later edits update it. Stored rows for plants the seed does not carry are ignored (a plant is an

https://claude.ai/code/session_01KypmNwQc4S6UJupg3BHkS4