### PR TITLE
Collect changes on staging, and correct the deploy notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,11 @@ cp .env.example .env.local   # VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY
 npm run dev                  # http://localhost:3000
 ```
 
+## Deploying
+Work collects on **`staging`**, never straight on `main`. Open every PR against `staging`; `main` is
+the live site and moves only when `staging` is merged into it, one batch at a time. Each branch has
+its own Vercel preview — see "Deploys (Vercel)" in `docs/ARCHITECTURE.md`.
+
 ## Non-negotiables
 - **Never** derive tube weight from a density constant — use `SKU.weightPerTube`.
 - **Never** make Production consume mother coils — it consumes **baby coils** (Stage 2 output).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,24 +163,21 @@ node node_modules/vite/bin/vite.js
 Dev server runs on http://localhost:3000. Without valid Supabase env vars the client cannot reach the backend (reads error out → empty pipeline data, SKUs still fall back to `DEFAULT_SKUS`).
 
 ## Deploys (Vercel)
-Two kinds of deployment, decided by the branch a commit lands on:
+Every branch already deploys — `git.deploymentEnabled` in `vercel.json` names only `main`, but **an
+unnamed branch defaults to enabled**, so that entry restricts nothing. Don't read it as a whitelist.
 
 | Branch | URL | Changes when |
 |---|---|---|
-| `main` | production URL (what operators use) | a PR is **merged** — never on a feature-branch push |
-| any other branch | `…-git-<branch>-<team>.vercel.app` (stable per branch) | that branch is pushed |
+| `main` | production URL (what operators use) | a PR is **merged** |
+| any other branch | `jsw-pipes-inventory-git-<branch>-pb-tmt-ais-projects.vercel.app` | that branch is pushed |
 
-`vercel.json` sets `git.deploymentEnabled: true`, so **every** branch builds a preview. It was
-`{ "main": true }` before, which meant feature branches built nothing and the only way to see a
-change was to merge it into production.
+The branch URL is stable per branch, but long names are shortened and hashed
+(`claude/handoff-implementation-7lowne` → `…-git-claude-hando-ad3bbe-…`), so take the link from the
+**Preview** column of the `vercel[bot]` comment on the PR rather than constructing it.
 
-Review flow: push to a branch → open its preview URL → merge the PR when it looks right → production
-picks it up. Nothing on a feature branch touches the production URL.
-
-Caveat: previews read the **same Supabase project** as production (`VITE_SUPABASE_URL` is one
-project-wide env var). A preview is isolated in code, not in data — anything saved there is saved for
-real. Point Vercel's *Preview* environment at a separate Supabase project/branch if you need data
-isolation too.
+Previews run against the **live** Supabase project (`Pipes and Tubes Inventory System`) — it is the
+only one, with no branches, and `VITE_SUPABASE_URL` is not scoped per environment. A preview is
+isolated in code, never in data: anything saved there is saved for real.
 
 ## Error Protocol
 1. Stop and read the full error

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -162,6 +162,26 @@ node node_modules/vite/bin/vite.js
 ```
 Dev server runs on http://localhost:3000. Without valid Supabase env vars the client cannot reach the backend (reads error out → empty pipeline data, SKUs still fall back to `DEFAULT_SKUS`).
 
+## Deploys (Vercel)
+Two kinds of deployment, decided by the branch a commit lands on:
+
+| Branch | URL | Changes when |
+|---|---|---|
+| `main` | production URL (what operators use) | a PR is **merged** — never on a feature-branch push |
+| any other branch | `…-git-<branch>-<team>.vercel.app` (stable per branch) | that branch is pushed |
+
+`vercel.json` sets `git.deploymentEnabled: true`, so **every** branch builds a preview. It was
+`{ "main": true }` before, which meant feature branches built nothing and the only way to see a
+change was to merge it into production.
+
+Review flow: push to a branch → open its preview URL → merge the PR when it looks right → production
+picks it up. Nothing on a feature branch touches the production URL.
+
+Caveat: previews read the **same Supabase project** as production (`VITE_SUPABASE_URL` is one
+project-wide env var). A preview is isolated in code, not in data — anything saved there is saved for
+real. Point Vercel's *Preview* environment at a separate Supabase project/branch if you need data
+isolation too.
+
 ## Error Protocol
 1. Stop and read the full error
 2. Isolate - which component/stage failed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,8 +168,13 @@ unnamed branch defaults to enabled**, so that entry restricts nothing. Don't rea
 
 | Branch | URL | Changes when |
 |---|---|---|
-| `main` | production URL (what operators use) | a PR is **merged** |
-| any other branch | `jsw-pipes-inventory-git-<branch>-pb-tmt-ais-projects.vercel.app` | that branch is pushed |
+| `main` | production URL (what operators use) | **`staging` is merged in** — a batch at a time, on the operator's say-so |
+| `staging` | `jsw-pipes-inventory-git-staging-pb-tmt-ais-projects.vercel.app` | any PR is merged into it |
+| any work branch | `jsw-pipes-inventory-git-<branch>-pb-tmt-ais-projects.vercel.app` | that branch is pushed |
+
+**Every PR targets `staging`.** Changes pile up there and are reviewed together on the one fixed
+staging URL; merging `staging` → `main` is what puts them all live at once. A PR straight into
+`main` skips that gate and ships alone.
 
 The branch URL is stable per branch, but long names are shortened and hashed
 (`claude/handoff-implementation-7lowne` → `…-git-claude-hando-ad3bbe-…`), so take the link from the

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,9 @@
   "buildCommand": "vite build",
   "outputDirectory": "dist",
   "git": {
-    "deploymentEnabled": true
+    "deploymentEnabled": {
+      "main": true
+    }
   },
   "rewrites": [
     { "source": "/((?!assets/).*)", "destination": "/index.html" }

--- a/vercel.json
+++ b/vercel.json
@@ -3,9 +3,7 @@
   "buildCommand": "vite build",
   "outputDirectory": "dist",
   "git": {
-    "deploymentEnabled": {
-      "main": true
-    }
+    "deploymentEnabled": true
   },
   "rewrites": [
     { "source": "/((?!assets/).*)", "destination": "/index.html" }


### PR DESCRIPTION
Sets up the staging release flow and records how deploys actually work. Docs only — no application code changes.

## What changes

- **`staging` is now the collecting branch.** It was created off `main` at `da97464`. PRs target `staging`; `main` moves only when `staging` is merged into it, so a batch of changes goes live in one act instead of one at a time.
- **`CLAUDE.md`** gains a `## Deploying` section, so future sessions aim at `staging` without being told.
- **`docs/ARCHITECTURE.md`** gains a `## Deploys (Vercel)` section: which branch produces which URL, and when each one moves.

## A correction inside this branch

The first commit here (`9e7165a`) claimed `git.deploymentEnabled: {"main": true}` stopped feature branches from deploying, and changed it to `true`. That was wrong on both counts:

- Vercel defaults an **unnamed** branch to enabled, so naming only `main` restricted nothing.
- PRs #144 and #145 already carried `vercel[bot]` Preview links, e.g. `jsw-pipes-inventory-git-claude-hando-ad3bbe-pb-tmt-ais-projects.vercel.app`.

`342a3ac` reverts `vercel.json` to its original content. **The net diff on `vercel.json` is zero** — no config change was needed, and the misleading `{"main": true}` entry is now called out in the docs so it doesn't fool the next reader.

## Also recorded

- Preview URLs shorten and hash long branch names, so the link should be taken from the PR's `vercel[bot]` comment rather than constructed by hand.
- Previews run against the **live** Supabase project — verified as the only project on the account, with no branches, and `VITE_SUPABASE_URL` is not scoped per environment. A preview is isolated in code, never in data.

## Testing

Not run: `node_modules` is not installed in this container, and no application code is touched. `vercel.json` was checked as valid JSON after the revert.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky4WZSfM4SLneh28Rc4iYB)_