### PR TITLE
Branch work off staging, not main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,11 @@ npm run dev                  # http://localhost:3000
 ```
 
 ## Deploying
-Work collects on **`staging`**, never straight on `main`. Open every PR against `staging`; `main` is
-the live site and moves only when `staging` is merged into it, one batch at a time. Each branch has
-its own Vercel preview — see "Deploys (Vercel)" in `docs/ARCHITECTURE.md`.
+Work collects on **`staging`**, never straight on `main`. Start a work branch from **`origin/staging`**
+(`git fetch origin staging && git checkout -B <branch> origin/staging`) so it carries the batch already
+waiting there, and open its PR **against `staging`**. `main` is the live site and moves only when
+`staging` is merged into it, one batch at a time. Each branch has its own Vercel preview — see
+"Deploys (Vercel)" in `docs/ARCHITECTURE.md`.
 
 ## Non-negotiables
 - **Never** derive tube weight from a density constant — use `SKU.weightPerTube`.


### PR DESCRIPTION
One sentence in `CLAUDE.md`, left behind when #146 merged. Docs only.

## Why

#146 recorded where a PR should land (`staging`) but not where a work branch should start. A branch cut from `main` misses whatever is already waiting in `staging`, so the batch only gets assembled at merge time and conflicts surface there instead of while the work is being done.

This adds the starting point next to the PR target:

```
git fetch origin staging && git checkout -B <branch> origin/staging
```

## Testing

Not run — no application code is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky4WZSfM4SLneh28Rc4iYB)_