### PR TITLE
Production: add mandatory Production PO No. (contract-manufacturer PO)

### DIFF
--- a/blueprints/add-new-stage-field.md
+++ b/blueprints/add-new-stage-field.md
@@ -50,6 +50,20 @@ Add a new data field to one of the 4 pipeline stages (Coil Inward, Production, B
 - Adding many columns may require horizontal scroll on mobile — test responsive layout
 
 ## Recent Field Changes
+- **2026-08, Stage 3: `productionPoNo` — a MANDATORY field that is mandatory on ONE path.** The PO
+  issued to the contract manufacturer for a batch. Two things worth reusing. (1) **Mandatory means
+  create-only, by default.** 1,286 production rows predated the field; adding it to `canSave`
+  unconditionally would have frozen every one of them behind a PO nobody can supply — the same trap
+  the `plant` edge case above was written for, arrived at from the opposite direction (there the
+  control had to disappear on edit; here the *guard* does). The guard reads `!editId && !poNo`, and
+  blank stays a legitimate stored value forever. (2) **Check whether the name is already taken.**
+  `poNumber` already existed on coils and baby coils meaning something else entirely, and
+  `childOrderId` is the customer's PO — so this became `productionPoNo`, and the three are now
+  tabulated in `docs/DATA-MODEL.md` ("The three POs"). Free text with a `<datalist>` of prior POs
+  (`productionPoOptions`) and `.trim().toUpperCase()` on save (`normalizeProductionPoNo`) — both in
+  `calc.js` with tests, because a stamp with no master behind it is only worth what its spelling
+  consistency is worth. Live DDL was applied BEFORE the app code shipped: `toSnake` sends every key
+  to PostgREST, so a missing column fails EVERY save on the stage, not just the ones using the field.
 - **2026-08 (#124), Stage 3: `plant` became a SCOPE, not just an inherited value** — the first time
   a set-once field also decides what a later stage may *consume*. Production's two coil pickers are
   drawn from one plant (`babyCoilsAtPlant`, one `filterByPlant` read by the FIFO adapter and the

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -8,7 +8,7 @@ All pipeline data lives in **Supabase Postgres**, accessed via `useSupabaseStore
 |-----------|---------------|------------------|
 | `jsw:coils` | `coils` | Stage 1 mother coil records. Carries the `plant` — set once here, inherited by everything downstream (see below) |
 | `jsw:babyCoils` | `baby_coils` | Stage 2 slitting output. Width-proportional `weight`/`cost_price`, `hr_coil_id` = mother, letter-suffixed `baby_coil_id`, `plant` inherited from the mother. Carries a manual `consumed` boolean (hides the coil from the Production picker/FIFO; set per-row or via bulk edit). **Hard-delete** table |
-| `jsw:productions` | `productions` | Stage 3 production batches. Each carries `coil_allocations` (JSONB `[{babyCoilId,hrCoilId,pieces,weight}]`, camelCase inner keys) — the baby-coil FIFO split (with mother id) — a `plant` inherited from the baby coils consumed, and a `status` |
+| `jsw:productions` | `productions` | Stage 3 production batches. Each carries `coil_allocations` (JSONB `[{babyCoilId,hrCoilId,pieces,weight}]`, camelCase inner keys) — the baby-coil FIFO split (with mother id) — a `plant` inherited from the baby coils consumed, a `status`, and a `production_po_no` — the PO issued to the **contract manufacturer** for these pipes (see "The three POs" below) |
 | `jsw:dispatches` | `dispatches` | Stage 4 dispatch **and invoice** records — now loaded from the daily "Upload Sales Excel" **Invoice** tab (via `buildDispatchRecords`, called from the Orders component); the Dispatch tab is a read-only records/reconciliation view. `bundle_entries` carry per-entry `invoiceNo`, `plant`, `shipToState`, `coilAllocations` (`{babyCoilId,hrCoilId,…}`), and legacy `traceHrCoilId` |
 | `jsw:skus` | `skus` | SKU master (falls back to `DEFAULT_SKUS` when table is empty) |
 | `jsw:distributorEstimates` | `distributor_estimates` | **Distributor Monthly Estimate** — the typed Best Estimate (planned invoiced MT) for one distributor in one month. `distributor_key` is the app's resolved distributor identity (ERP `distributor_code` when present, otherwise the normalised name — the same key `salesByDistributor` groups by), `month` is `'YYYY-MM'`. **Unique on `(distributor_key, month)`**, which is also the upsert arbiter. Written inline from the Sales tab; the plant Best Estimate is their sum, never typed (see `docs/adr/0001-…`) |
@@ -343,3 +343,30 @@ refuses, because reading it as "every plant" would hand a plant login the whole 
 `App.jsx` requires **both**: a session that parses *and* grants at least one tab. Sign-in says the
 credential is not set up correctly and names where it is fixed, rather than opening an app with no
 tabs. `blueprints/manage-app-login.md` carries the `update`.
+
+## The three POs
+
+Three unrelated purchase orders live in this schema. They share a concept and nothing else — no
+column, no join, no derivation between them.
+
+| Column | Who issues it | To whom | For what |
+|---|---|---|---|
+| `coils.po_number` | JSW One | HR coil supplier | Buying the **mother coil**. Typed at Coil Inward, **inherited** onto `baby_coils.po_number` |
+| `orders.child_order_id` | The **customer** | JSW One | The customer's PO for finished tubes. Arrives in the daily Sales Excel as the One Helix `PurchaseOrder` column; also lands on dispatch records |
+| `productions.production_po_no` | JSW One | **Contract manufacturer** | Converting steel into finished pipes — the batch on the Production tab |
+
+Keep the keys distinct. The `plant` dimension needed its own ADR (`adr/0005`) and a CONTEXT.md
+section purely because one word meant two things; a second field named `poNumber` would repeat that
+on purpose.
+
+### `production_po_no` specifics
+
+- **A stamp, nothing more.** No stock is reserved against it, no progress is tracked against it, and
+  nothing in the app knows which contract manufacturer a given PO was issued to — so the app cannot
+  and does not check a PO against the batch's `plant`.
+- **Mandatory on the create path only.** New batches cannot be saved without one; the batches
+  recorded before the field existed carry blank and stay editable. Blank is a real value here.
+- **Normalised on write** by `normalizeProductionPoNo` (`calc.js`) — `.trim().toUpperCase()`, nothing
+  else. Inner spacing and punctuation are the CM's format, not ours to rewrite.
+- **Free text with a datalist**, built by `productionPoOptions` from every non-deleted production.
+  There is no PO master; the datalist is the only thing holding spelling together.

--- a/e2e/pipeline.spec.js
+++ b/e2e/pipeline.spec.js
@@ -22,6 +22,12 @@ const selectFor = (page, label) =>
 const searchInputFor = (page, label) =>
   page.locator('label', { hasText: label }).locator('xpath=following-sibling::div[1]//input')
 
+// Production PO No. — the PO issued to the contract manufacturer, mandatory on the CREATE path.
+// Every "record a production" flow has to fill it now, so it lives in one helper.
+const PRODUCTION_PO = 'PO/2026/114'
+const fillProductionPo = (page, po = PRODUCTION_PO) =>
+  inputFor(page, 'Production PO No.').fill(po)
+
 const gotoTab = (page, name) => page.getByRole('button', { name, exact: true }).click()
 
 // The header plant selector (ticket #121). It defaults to "All Plants", which scopes nothing —
@@ -92,6 +98,7 @@ test.describe('5-stage pipeline', () => {
     await page.getByRole('button', { name: '+ Record Production' }).click()
     await pickSku(page)
     await inputFor(page, 'No. of Pieces').fill('10')
+    await fillProductionPo(page)
     await useSuggestion(page)
     await expect(page.getByText(/Fully allocated/)).toBeVisible()  // FIFO matched the baby coil
     await page.getByRole('button', { name: 'Save Production' }).click()
@@ -134,10 +141,42 @@ test.describe('5-stage pipeline', () => {
     await page.getByRole('button', { name: '+ Record Production' }).click()
     await pickSku(page)
     await inputFor(page, 'No. of Pieces').fill('100') // ~1.06T ≫ 0.05T capacity
+    await fillProductionPo(page)
     await useSuggestion(page)
     await expect(page.getByText(/Shortfall/)).toBeVisible()
-    // Allow + warn policy: save stays enabled.
+    // Allow + warn policy: save stays enabled. (The PO is filled above so this asserts the
+    // shortfall policy and not the PO guard.)
     await expect(page.getByRole('button', { name: 'Save Production' })).toBeEnabled()
+  })
+
+  test('Production PO No. is required to record a NEW batch', async ({ page }) => {
+    await signIn(page, 'admin')
+    await gotoTab(page, '1. Coil Inward')
+    await addCoil(page, { actualWeight: '10' })
+    const coilId = await page.locator('table tbody tr').first().locator('td').first().innerText()
+    await slit(page, coilId, '100')
+
+    await selectPlant(page, 'Hyderabad')
+    await gotoTab(page, '3. Production')
+    await page.getByRole('button', { name: '+ Record Production' }).click()
+    await pickSku(page)
+    await inputFor(page, 'No. of Pieces').fill('10')
+    await useSuggestion(page)
+
+    // Everything else about this batch is valid — fully allocated, one plant, inside capacity —
+    // so a blocked save here can only be the missing PO.
+    await expect(page.getByText(/Fully allocated/)).toBeVisible()
+    await expect(page.getByText(/Production PO No. is required/)).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Save Production' })).toBeDisabled()
+
+    await fillProductionPo(page)
+    await expect(page.getByText(/Production PO No. is required/)).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Save Production' })).toBeEnabled()
+
+    // Stored uppercase + trimmed, so one PO reads as one PO in the table and any export.
+    await inputFor(page, 'Production PO No.').fill('  po/2026/115 ')
+    await page.getByRole('button', { name: 'Save Production' }).click()
+    await expect(page.locator('table').getByText('PO/2026/115', { exact: true }).first()).toBeVisible()
   })
 
   test('no eligible baby coil until slitting is done', async ({ page }) => {

--- a/e2e/roles.spec.js
+++ b/e2e/roles.spec.js
@@ -422,6 +422,8 @@ test.describe('the plant selector scopes the pipeline stages', () => {
     await sku.fill(SKU_SIZE)
     await page.getByRole('button', { name: SKU_SIZE }).first().click()
     await page.locator('label', { hasText: 'No. of Pieces' }).locator('xpath=following-sibling::input[1]').fill('5')
+    // Production PO No. — mandatory on the create path (PO issued to the contract manufacturer).
+    await page.locator('label', { hasText: 'Production PO No.' }).locator('xpath=following-sibling::input[1]').fill('PO/2026/114')
     // No coil is allocated — nothing has been slit at NPMD in this fixture.
     await page.getByRole('button', { name: 'Save Production' }).click()
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import {
   resolveShipToState, REGIONS, UNMAPPED_REGION, normStateName,
   UNATTRIBUTED_PLANT, plantLabel, dispatchPlantLabel, plantForErpRow, erpRowPicker,
   coilInwardPlants, DEFAULT_COIL_PLANT, babyCoilPlant, productionPlant, crossPlantAllocationRows,
+  normalizeProductionPoNo, productionPoOptions,
   ALL_PLANTS, plantFilterOptions, filterByPlant, filterDispatchesByPlant, withDispatchEntries,
   plantMaster, plantsServingRegion,
   accessFor, parseStoredSession,
@@ -1039,7 +1040,7 @@ function Slitting({ coils, babyCoils, setBabyCoils, productions, viewPlant = ALL
 // stricter, better rule. `productions` stays whole so a record's edit still resolves and the guards
 // below still see every batch.
 function Production({ coils, babyCoils, productions, setProductions, dispatches, skus, operatingPlant, viewPlant = ALL_PLANTS }) {
-  const emptyForm = { dateOfProduction: today(), skuCode: '', tubeCount: '' }
+  const emptyForm = { dateOfProduction: today(), skuCode: '', tubeCount: '', productionPoNo: '' }
   const [form, setForm] = useState(emptyForm)
   const [editId, setEditId] = useState(null)
   const [showForm, setShowForm] = useState(false)
@@ -1084,6 +1085,19 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
   const skuOptions = useMemo(() =>
     skus.filter(s => s.status === 'published').map(s => ({ value: s.skuCode, label: s.description || s.skuCode })),
   [skus])
+
+  // ── PRODUCTION PO No. — the PO issued to the CONTRACT MANUFACTURER for these pipes. It is NOT
+  // the coil's `poNumber` (what we bought the HR coil under, Stage 1) and NOT the customer's
+  // `childOrderId` (their PO for the tubes, Orders/Dispatch). A stamp only: nothing is computed
+  // from it, no stock is reserved, and no rule ties it to the plant — no master records which CM a
+  // PO was issued to, so the app has nothing to check it against.
+  //
+  // Free text, because these POs live in procurement and not in this app. The datalist is the only
+  // thing standing between that and three spellings of one PO, so it is drawn from EVERY
+  // production, not the plant-scoped view: the PO an operator is about to type is the one somebody
+  // typed yesterday, whichever plant that batch was at.
+  const poOptions = useMemo(() => productionPoOptions(productions), [productions])
+  const poNo = normalizeProductionPoNo(form.productionPoNo)
 
   const sku = useMemo(() => skus.find(s => s.skuCode === form.skuCode), [skus, form.skuCode])
   const weightPerPiece = weightPerPieceFromSku(sku)
@@ -1240,6 +1254,9 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
       dateOfProduction: form.dateOfProduction,
       skuCode: form.skuCode,
       tubeCount: pieces,
+      // Stored trimmed + uppercased so one PO reads as one PO in the datalist and in any export.
+      // A blank here is a real value, not a failure: every batch predating this field carries one.
+      productionPoNo: poNo,
       weightPerPiece,
       totalWeight,
       coilAllocations: allocations,
@@ -1270,7 +1287,7 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
   const cancelForm = () => { setForm(emptyForm); setEditId(null); setShowForm(false); setManualAlloc(null) }
   const openNew = () => { setForm(emptyForm); setEditId(null); setManualAlloc(null); setShowForm(true) }
   const startEdit = (row) => {
-    setForm({ dateOfProduction: row.dateOfProduction, skuCode: row.skuCode, tubeCount: String(row.tubeCount) })
+    setForm({ dateOfProduction: row.dateOfProduction, skuCode: row.skuCode, tubeCount: String(row.tubeCount), productionPoNo: row.productionPoNo || '' })
     setManualAlloc((row.coilAllocations || []).length ? row.coilAllocations.map(a => ({ _rid: uid(), babyCoilId: a.babyCoilId, pieces: Number(a.pieces || 0) })) : null)
     setEditId(row.id); setShowForm(true)
   }
@@ -1283,13 +1300,24 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
   // Under-allocating is still fine — that saves as 'partial' and blocks nothing.
   // A row holding another plant's coil is the second hard stop (ticket #124) — a batch may not be
   // persisted spanning two plants, however its rows came to be that way.
-  const canSave = !!form.skuCode && pieces > 0 && !over105 && crossPlantRows.length === 0
+  //
+  // The Production PO is mandatory on the CREATE path ONLY. Every one of the batches already in the
+  // register was recorded before this field existed and carries no PO, so a guard that also ran on
+  // edit would freeze that history — nobody could fix a piece count on a June batch without
+  // inventing a PO for it. Blank on an old row is the truth, and the truth has to stay saveable.
+  const missingPoOnNew = !editId && !poNo
+  const canSave = !!form.skuCode && pieces > 0 && !over105 && crossPlantRows.length === 0 && !missingPoOnNew
 
   const allocatedOf = r => (r.coilAllocations || []).reduce((s, a) => s + Number(a.pieces || 0), 0)
   const sourceCoilsOf = r => (r.coilAllocations || []).filter(a => a.babyCoilId || a.hrCoilId).length
   const columns = [
     { label: 'Date', key: 'dateOfProduction' },
     PLANT_COLUMN,
+    // Plant says WHICH contract manufacturer; the PO says under which order they made it. They read
+    // together, so they sit together. Blank (every batch before this field) shows as the same em-dash
+    // every other empty cell in the app uses — inventing a word for it would assert more than the
+    // data says.
+    { label: 'Production PO', value: r => r.productionPoNo || '—' },
     { label: 'SKU', value: r => skuDesc(r.skuCode) },
     { label: 'Pieces', key: 'tubeCount' },
     { label: 'Wt/Piece (T)', value: r => fmtT3(r.weightPerPiece) },
@@ -1303,12 +1331,12 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
   ]
 
   const downloadProductionsCSV = () => {
-    const header = ['Date', 'Plant', 'SKU', 'Pieces', 'Wt/Piece (T)', 'Total Wt (T)', 'Allocated (pcs)', '# Source Coils', 'Assigned Coils', 'Status']
+    const header = ['Date', 'Plant', 'Production PO', 'SKU', 'Pieces', 'Wt/Piece (T)', 'Total Wt (T)', 'Allocated (pcs)', '# Source Coils', 'Assigned Coils', 'Status']
     // `shownProductions`, not `productions` — the export is the table, downloaded. Coil Inward and
     // Slitting already export what they show; this one alone exported the whole company, so a
     // scoped screen produced an unscoped file with no scope named anywhere in it.
     downloadCSV(`production-${today()}${plantFileSuffix(viewPlant)}.csv`, header, shownProductions.filter(p => !p.deleted).map(r => [
-      r.dateOfProduction, plantLabel(r.plant), skuDesc(r.skuCode), r.tubeCount, fmtT3(r.weightPerPiece), fmtT(r.totalWeight),
+      r.dateOfProduction, plantLabel(r.plant), r.productionPoNo || '—', skuDesc(r.skuCode), r.tubeCount, fmtT3(r.weightPerPiece), fmtT(r.totalWeight),
       `${allocatedOf(r)} / ${r.tubeCount}`, sourceCoilsOf(r),
       (r.coilAllocations || []).map(a => `${a.babyCoilId || a.hrCoilId}×${a.pieces}`).join('; ') || '—', r.status,
     ]))
@@ -1342,6 +1370,14 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
             <Field label="Date of Production"><Input type="date" value={form.dateOfProduction} onChange={v => f('dateOfProduction', v)} /></Field>
             <Field label="SKU"><SearchSelect value={form.skuCode} onChange={v => { f('skuCode', v); setManualAlloc(null) }} options={skuOptions} placeholder="Search SKU..." /></Field>
             <Field label="No. of Pieces"><Input type="number" min="0" step="1" value={form.tubeCount} onChange={v => f('tubeCount', v === '' ? '' : Math.max(0, Math.floor(Number(v) || 0)))} /></Field>
+            {/* Required on NEW batches only (see `canSave`). Editing one of the batches recorded
+                before this field existed must stay possible, so the guard never looks at an edit. */}
+            <Field label="Production PO No." helper={editId ? 'PO issued to the contract manufacturer' : 'Required — PO issued to the contract manufacturer'}>
+              <Input list="production-po-list" value={form.productionPoNo} onChange={v => f('productionPoNo', v)} placeholder="e.g. PO/2026/114" />
+              <datalist id="production-po-list">
+                {poOptions.map(po => <option key={po} value={po} />)}
+              </datalist>
+            </Field>
           </div>
           {/* Plant is shown, never typed — it is the scope the coils below are drawn from, and the
               saved record re-derives it from the allocations themselves (productionPlant). Under the
@@ -1425,7 +1461,9 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
             </div>
           </div>
 
-          {/* Status badges (informational — never block save) */}
+          {/* Status badges. Most are informational; three are hard stops that also disable Save —
+              over-105% capacity, a cross-plant row, and a missing Production PO on a new batch. Each
+              says so in its own text, so the block is read top to bottom without a key. */}
           <div className="mt-3 space-y-2">
             {pieces > 0 && allocatedPieces === 0 && babyCoilOptions.length === 0 && <Badge ok={false} text={`No baby coils available at ${scopeName} (none slit, or all consumed/deleted). Production saved unallocated until a coil is slit.`} />}
             {pieces > 0 && allocatedPieces === 0 && babyCoilOptions.length > 0 && matchedCount === 0 && <Badge ok={false} text="No coil matching this tube's width (±5 mm) and the coil→pipe thickness rule — nothing to suggest, but you can pick an off-spec coil below (listed with its Δ thickness & width). Another plant's coil is never offered." />}
@@ -1433,6 +1471,7 @@ function Production({ coils, babyCoils, productions, setProductions, dispatches,
             {unpickedRows && <Badge ok={false} text="A row has pieces entered but no coil selected — click a coil from the dropdown list (rows without a coil are NOT saved)." />}
             {allocatedPieces > 0 && allocatedPieces === pieces && !overCapacity && <Badge ok={true} text={`Fully allocated across ${sourceCoils} coil(s).`} />}
             {crossPlantRows.length > 0 && <Badge ok={false} text={`${crossPlantRows.map(r => r.babyCoilId).join(', ')} ${crossPlantRows.length > 1 ? 'are' : 'is'} not at ${scopeName} — a production cannot consume coils from two plants. Remove ${crossPlantRows.length > 1 ? 'those rows' : 'that row'}, or switch the header back to the plant ${crossPlantRows.length > 1 ? 'they belong' : 'it belongs'} to. Save is blocked until it clears.`} />}
+            {missingPoOnNew && <Badge ok={false} text="Production PO No. is required — enter the PO issued to the contract manufacturer for these pipes. Save is blocked until it is filled." />}
             {over105
               ? <Badge ok={false} text="A coil is filled beyond 105% of its capacity — a coil cannot give more steel than it holds. Reduce that row, or click “Fix split” to spill the excess onto the next coil. Save is blocked until it clears." />
               : overCapacity && <Badge ok={true} text="A coil is in the 97–105% band — allowed (manual top-up past the 97% auto-advance)." />}

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -1127,6 +1127,40 @@ export function productionPlant(coilAllocations, babyCoils = [], coils = []) {
   return found.size === 1 ? [...found][0] : ''
 }
 
+// ── PRODUCTION PO No. (ticket: contract-manufacturing PO) ──────────────────────────────────────
+// The PO **we issue to the contract manufacturer** to make finished pipes. It is the THIRD PO in
+// this app and shares nothing with the other two: `coils.poNumber` is the PO we BUY HR coil under
+// (inherited mother → baby), and `orders.childOrderId` is the CUSTOMER's PO for the tubes. Keeping
+// the three under distinct keys is deliberate — one name for two documents is the bug class that
+// cost `plant` a whole ADR (docs/adr/0005).
+//
+// It is a STAMP: nothing is computed from it. No reservation, no progress tracking, no plant check
+// (no master says which CM a PO was issued to, so the app cannot know that a PO belongs to Nippon
+// rather than NPMD).
+//
+// Normalised on the way IN so the datalist of previously-used POs converges instead of drifting:
+// "po/2026/114 " and "PO/2026/114" are the same purchase order and must not read as two. Trim then
+// uppercase — nothing more. Inner spacing and punctuation are left exactly as typed, because a PO
+// number's own format is the CM's, not ours to reformat.
+export function normalizeProductionPoNo(value) {
+  return String(value ?? '').trim().toUpperCase()
+}
+
+// The distinct POs already stamped on production rows — the datalist behind the Production PO No.
+// box. Drawn from ALL productions, never the plant-scoped view: a PO issued for one CM's batch is
+// still the PO an operator is most likely typing next, and hiding it would only invite a re-typo.
+// Deleted rows are skipped (a soft-deleted batch is not a record of anything), blanks drop out, and
+// the result is sorted so the list reads the same on every render.
+export function productionPoOptions(productions = []) {
+  const seen = new Set()
+  ;(productions || []).forEach(p => {
+    if (p?.deleted) return
+    const po = normalizeProductionPoNo(p?.productionPoNo)
+    if (po) seen.add(po)
+  })
+  return [...seen].sort()
+}
+
 // ── PLANT FILTER (ticket #121) ─────────────────────────────────────────────────────────────────
 // One selector, offered in the header and applied globally — never a per-tab filter, so nobody has
 // to reason about which view is scoped and which is not. It scopes every tab that shows rows

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -14,6 +14,7 @@ import {
   PLANTS, PLANT_IDS, UNATTRIBUTED_PLANT, normPlantKey, plantIndex, resolvePlant, plantById, plantLabel,
   dispatchPlantLabel, plantForErpRow, erpRowPicker,
   coilInwardPlants, DEFAULT_COIL_PLANT, babyCoilPlant, productionPlant,
+  normalizeProductionPoNo, productionPoOptions,
   ALL_PLANTS, plantFilterOptions, plantKeysIn, plantNamesIn, filterByPlant, filterDispatchesByPlant, withDispatchEntries,
   crossPlantAllocationRows,
   plantMaster, plantsServingRegion, servedRegions, filterByPlants, filterDispatchesByPlants,
@@ -1709,6 +1710,51 @@ describe('pipeline rows carry their plant (ticket #120)', () => {
     )).toBe('hyderabad')
     // Neither side knows: blank, never a guess.
     expect(productionPlant([alloc('X-1', 'X')], [], [])).toBe('')
+  })
+})
+
+describe('normalizeProductionPoNo — the CM PO is stamped in one canonical shape', () => {
+  // A stamp with no master behind it is only as useful as it is consistent. Trim + uppercase is
+  // the whole rule: enough that the same PO typed on two shifts collapses to one datalist entry,
+  // not so much that it reformats a number whose format belongs to the contract manufacturer.
+  it('trims and uppercases, leaving inner formatting alone', () => {
+    expect(normalizeProductionPoNo('  po/2026/114 ')).toBe('PO/2026/114')
+    expect(normalizeProductionPoNo('PO-2026-114')).toBe('PO-2026-114')
+    expect(normalizeProductionPoNo('po 2026 114')).toBe('PO 2026 114')   // inner spacing kept
+  })
+
+  it('treats blank-ish input as blank, never as a value', () => {
+    // Blank is a real state here: every production row predating this field has one, and the
+    // create-path guard must read all of these as "no PO given".
+    expect(normalizeProductionPoNo('')).toBe('')
+    expect(normalizeProductionPoNo('   ')).toBe('')
+    expect(normalizeProductionPoNo(null)).toBe('')
+    expect(normalizeProductionPoNo(undefined)).toBe('')
+  })
+
+  it('is idempotent — re-saving a row cannot drift its PO', () => {
+    const once = normalizeProductionPoNo(' po/2026/114 ')
+    expect(normalizeProductionPoNo(once)).toBe(once)
+  })
+})
+
+describe('productionPoOptions — the datalist behind the PO box', () => {
+  const rows = [
+    { productionPoNo: 'PO/2026/114' },
+    { productionPoNo: 'po/2026/114 ' },              // same PO, typed differently → one entry
+    { productionPoNo: 'PO/2026/113' },
+    { productionPoNo: '' },                          // pre-PO row: contributes nothing
+    { productionPoNo: 'PO/2026/999', deleted: true },// soft-deleted batch is not a record
+    {},                                              // legacy row with no field at all
+  ]
+
+  it('collapses case/whitespace variants and drops blanks, deleted and legacy rows', () => {
+    expect(productionPoOptions(rows)).toEqual(['PO/2026/113', 'PO/2026/114'])
+  })
+
+  it('survives an empty or missing register', () => {
+    expect(productionPoOptions([])).toEqual([])
+    expect(productionPoOptions()).toEqual([])
   })
 })
 

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -83,6 +83,7 @@ create table if not exists productions (
   coil_allocations jsonb default '[]',
   status text,                -- 'allocated' | 'partial' | 'unallocated'
   plant text,                 -- inherited from the baby coils consumed (ticket #120)
+  production_po_no text,      -- PO issued to the CONTRACT MANUFACTURER for these pipes (see below)
   deleted boolean default false,
   created_at timestamptz default now()
 );
@@ -124,6 +125,26 @@ begin
                  where table_schema = 'public' and table_name = 'productions' and column_name = 'plant') then
     alter table productions add column plant text;
     update productions set plant = 'hyderabad';
+  end if;
+end $$;
+
+-- ── Production PO No. ──────────────────────────────────────────────────────────────────────────
+-- The PO **we issue to the contract manufacturer** to make finished pipes. This is the THIRD PO in
+-- the schema and is unrelated to the other two:
+--   coils.po_number         the PO we BUY HR coil under        (inherited mother → baby)
+--   orders.child_order_id   the CUSTOMER's PO for the tubes    (One Helix "PurchaseOrder")
+--   productions.production_po_no   ← this one
+-- A stamp: nothing is computed from it. No stock is reserved against it, and no constraint ties it
+-- to `plant`, because nothing in the app records which contract manufacturer a PO was issued to.
+--
+-- Deliberately NO backfill. The field is mandatory on the app's CREATE path only, so the batches
+-- recorded before it existed keep a blank PO and stay editable. A later `where … is null` update
+-- would re-stamp rows the app left blank on purpose — hence the gate on the column, not the data.
+do $$
+begin
+  if not exists (select 1 from information_schema.columns
+                 where table_schema = 'public' and table_name = 'productions' and column_name = 'production_po_no') then
+    alter table productions add column production_po_no text;
   end if;
 end $$;
 


### PR DESCRIPTION
Adds a **Production PO No.** box to the Production tab — the PO issued to the **contract manufacturer** that makes the pipes — and requires it on new batches.

## The three POs

This is the **third** PO in the schema. It shares nothing with the other two, so it gets its own key rather than overloading `poNumber`:

| Column | Who issues it | To whom | For what |
|---|---|---|---|
| `coils.po_number` | JSW One | HR coil supplier | Buying the mother coil (Stage 1, inherited onto baby coils) |
| `orders.child_order_id` | The **customer** | JSW One | Their PO for finished tubes (One Helix `PurchaseOrder`) |
| `productions.production_po_no` | JSW One | **Contract manufacturer** | Converting steel into pipes — this PR |

`plant` needed its own ADR purely because one word meant two things; a second field named `poNumber` would repeat that on purpose. The three are now tabulated in `docs/DATA-MODEL.md`.

## What it does — and deliberately doesn't

It is a **stamp**. No stock is reserved against it, no progress is tracked against it, and no rule ties it to the batch's `plant` — nothing in the app records which contract manufacturer a PO was issued to, so there is nothing to check it against.

## Mandatory on the create path only

All **1,286** existing production rows predate this field. A guard that also ran on edit would freeze that history behind a PO nobody can supply — so `canSave` reads `!editId && !poNo`. Blank stays a legitimate stored value and shows as the same em-dash as every other empty cell.

## Changes

- **`src/lib/calc.js`** — `normalizeProductionPoNo` (trim + uppercase, nothing more: the PO's own format belongs to the CM) and `productionPoOptions`, which builds the datalist from every non-deleted production. With no PO master behind a free-text field, the datalist is the only thing holding spelling together. Both unit-tested.
- **`src/App.jsx`** — 4th field in the Production form grid with a datalist of previously-used POs; table column beside Plant; CSV column; a blocking badge that says why Save is disabled.
- **`supabase-setup.sql`** — column on the `CREATE TABLE` plus a gated `ALTER` for existing databases. **No backfill**, deliberately: a later `where … is null` would re-stamp rows the app left blank on purpose.
- **`e2e/`** — every flow that records a production now fills the PO, plus a new test covering the guard and the uppercase/trim round-trip.
- **Docs** — `docs/DATA-MODEL.md` gains a "The three POs" section; `blueprints/add-new-stage-field.md` logs the change.

## Deploy note

The live database column was applied **before** this code, because `toSnake` sends every key to PostgREST — a missing column fails *every* save on the stage, not just ones using the field. The `ALTER` is additive and gated, so re-running `supabase-setup.sql` is a no-op.

## Testing

- 484 unit tests pass (5 new)
- **44/44 e2e pass** (1 new), run against Chromium — including the new guard test asserting Save is disabled without a PO and that `  po/2026/115 ` round-trips to `PO/2026/115`
- `npm run build` clean

## Known limitation

Free text with no master behind it. The datalist and uppercasing reduce spelling drift but don't prevent it — the first PO typed wrong will be suggested cleanly thereafter. If PO-wise progress tracking is ever wanted, expect a cleanup pass first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWhSZq2iawqUYfxtnxpGoG)_