### PR TITLE
Workbook parity: plant stock columns, movement identity, and fresh production cap

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,9 +37,10 @@ _Avoid_: Unconfirmed, provisional, tentative
 
 **Indent**:
 The whole book placed on the plant to date — Invoiced MTD plus Confirmed plus Non-confirmed,
-invoiced and open alike. The daily WhatsApp message calls this line *Indent*; the app's KPI card and
-the PB MTD workbook still call the identical figure *Total Orders*.
-_Avoid_: Total Orders in new work on the daily message; booking, requisition
+invoiced and open alike. The daily WhatsApp message and the **PB MTD workbook** both call this line
+*Indent* (Sep-2026). The app's KPI card and its table columns still call the identical figure
+*Total Orders*.
+_Avoid_: Total Orders in new work anywhere; booking, requisition
 
 **Servable – Unconfirmed**:
 The part of Non-confirmed a serving plant can cover from finished stock on hand right now, size by
@@ -51,12 +52,16 @@ _Avoid_: Ready stock (reads as finished-goods inventory), available orders, serv
 the per-distributor report, a different question)
 
 **Pending to Dispatch**:
-Confirmed plus Non-confirmed. Everything owed to a distributor that has not left the plant.
-**Two scopes, and they differ — settle this before either spreads further.** In the PB MTD workbook,
-the plant split and `buildPlantMtdSummary` it is Confirmed + Non-confirmed, as above. On the **daily
-WhatsApp message** since Sep-2026 it is **Confirmed + Servable – Unconfirmed** — a smaller figure,
-because unconfirmed tonnage with no stock behind it is deliberately off that message. Never quote
-one at the other; on 04-Sep-2026 they were 4550.7 T and 805.3 T for the same book.
+Confirmed plus **Servable – Unconfirmed** — what is owed to distributors AND already sitting on the
+floor. Unconfirmed tonnage with no stock behind it is deliberately excluded.
+**Settled Sep-2026 (ADR-0008)**, after this entry had asked for it twice: the **daily WhatsApp
+message** and the **PB MTD workbook** now both use this meaning, and the wide figure is called
+*Pending to Serve* below.
+**The app screens have NOT moved** and still print the wide figure under this name — so the same
+phrase means **819 T in the workbook and 4,542 T on screen** (07-Sep-2026). That is known, accepted
+and not yet fixed; renaming the screens is ~20 places including CSV headers other spreadsheets may
+consume. Every workbook block prints its own formula so a reader can always tell which they hold.
+Never quote one at the other.
 _Avoid_: Backlog, outstanding, open orders, unshipped
 
 **Invoiced**:
@@ -64,12 +69,14 @@ Tonnage billed to a distributor, taken from the daily sales file. The only actua
 measured against.
 _Avoid_: Dispatched, shipped, sold, billed
 
-**Pending to serve**:
-The same tonnage as **Pending to Dispatch**, under the name the PB MTD workbook's KPI card and the
-daily reports use. Two names for one number is a wart, not a distinction — `Pending to Dispatch` is
-the preferred term and the one to use in new work; this entry exists so nobody reads them as two
-different figures. Worth settling on one before either spreads further.
-_Avoid_: treating it as anything other than Confirmed + Non-confirmed
+**Pending to Serve**:
+Confirmed plus Non-confirmed — **the whole open order book**, everything owed to a distributor that
+has not left the plant, whether or not the steel exists yet.
+This entry used to say it was "the same tonnage as Pending to Dispatch" and called two names for one
+number a wart. Since ADR-0008 they are **two different figures** and the wart is gone: this is the
+wide one. It is what the workbook's `BY PLANT` block, `buildPlantMtdSummary` and the `pb-mtd-report`
+skill print, and it is what the app screens still (wrongly) label *Pending to Dispatch*.
+_Avoid_: treating it as interchangeable with Pending to Dispatch — since Sep-2026 it is not
 
 ## Plant
 
@@ -116,8 +123,9 @@ The `BY PLANT` block beneath the PB MTD workbook's Dashboard KPIs: where the com
 above it actually sits, one row per plant, closed by an `ALL PLANTS` row equal to the cards. It is a
 **breakdown, never a filter** — no headline number moves because of it, and the rows sum back to the
 total including `Unattributed`. Beside it, **Invoiced** is labelled `Hyderabad only`, because only
-Hyderabad has ever invoiced: the reports have always compared four plants' Pending to Dispatch
+Hyderabad has ever invoiced: the reports have always compared four plants' Pending to Serve
 against one plant's Invoiced, and the split makes that visible rather than correcting it.
+(That caption is empty in Sep-2026 — all four plants have now invoiced.)
 The daily text and WhatsApp messages carry the **same** split under the same headline — the same
 figures from the same builder, reached through `scripts/daily-splits.mjs`, so a number on a phone and
 a number in the spreadsheet are the same number and not two answers that agree today.
@@ -224,13 +232,24 @@ Breakdown and the PB MTD workbook's Distributor × SKU sheet; the Dashboard's Fr
 at plant level.
 _Avoid_: Available stock, uncommitted stock, ATP, sellable stock
 
+**On floor, by plant**:
+What one named plant actually holds of one size — steel someone can walk out and count. The
+Distributor × SKU sheet prints one such column per plant. It is **never** the service-area pool
+apportioned between the distributors queued against it: an apportioned figure corresponds to nothing
+physical and would move when a *different* distributor ordered (ADR-0009). The cells add to the
+area's **On-hand**, which is more than the **Free Stock** beside them — Free Stock is that floor less
+what the area has already promised. `0.0` means the plant serves this region and holds none; `—`
+means it does not serve the region at all; `?` means the distributor has no region to ask about.
+_Avoid_: allocated stock, the distributor's stock, its share
+
 **Reservation**:
 A claim by one distributor on specific stock. **The plant has none** — the term exists here only to
 name what On-hand is not. Every distributor sees the same On-hand tonnage.
 _Avoid_: Allocation, earmark, blocked stock
 
 **Short by**:
-The part of a distributor's Pending to Dispatch that the plant's On-hand cannot cover for that SKU.
+The part of a distributor's pending (Confirmed + Non-confirmed) that the plant's On-hand cannot cover
+for that SKU.
 Measured against On-hand, not Free Stock — it answers "does the plant physically hold it", so a row
 can read no shortfall beside a negative Free Stock. Because stock is unreserved, two distributors can
 each be shown as covered by the same tonnage.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -380,3 +380,80 @@ no `deleted` column, so PostgREST 400s and the **live path of that script cannot
 database — invisible so far because remote sessions all reach it through `--agg`, which never
 fetches. `scripts/daily-splits.mjs`'s new `SKU_COLS` omits it. Not fixed in the other script here:
 worth doing, but it is a different change and deserves its own test.
+
+## 2026-09-08 — `calc.js` has a NUL byte too, and `grep` will not tell you
+
+`src/lib/reports.js` was known to carry a literal NUL byte at offset 38185 — a map-key separator
+inside `buildServableSummary` (`` `${name}\0${s.id}` ``). Building the workbook parity change turned
+up a **second one**: `src/lib/calc.js`, offset 127114, the same idiom
+(`` invoiceNo + '\0' + skuCode ``).
+
+So the rule is wider than it was written down as. **Both** files report as binary to `grep` (use
+`grep -a`), and **neither** may be edited with `sed`, which can mangle the byte silently. Use Python
+or the Edit tool, and check `count(b'\x00') == 1` after writing — an offset that moves is fine and
+expected when you add text above it; a count that changes is not.
+
+The cost of not knowing this is not a crash. It is a `grep` that returns "binary file matches" and a
+search you quietly believe found nothing.
+
+## 2026-09-08 — a test can start passing for the wrong reason
+
+Sheet 4 of the PB MTD workbook gained four plant columns, inserted **before** Free Stock and Short by.
+An existing test asserted:
+
+```js
+expect(ws.getCell(un, 9).value).toBe('?')      // Free Stock
+expect(ws.getCell(un, 10).value).toBe('?')     // Short by
+```
+
+After the insert, columns 9 and 10 are **Hyderabad** and **Lepakshi** — which also read `?` on an
+Unmapped row, for an entirely different reason (no region, so no plants to ask). The test kept
+passing while no longer testing anything it named. It was only noticed because the other three Sheet 4
+tests failed loudly and it was read while fixing them.
+
+**Positional assertions on a rendered sheet are the fragile kind.** Inserting a column is a normal,
+expected change, and it silently re-points every index after it. Where a column can move, find it by
+header rather than by number — and when a change inserts columns, re-read *every* test that indexes
+past the insertion point, not just the failing ones.
+
+## 2026-09-08 — the workbook and the message now cannot drift, by construction
+
+The daily WhatsApp message was reshaped in `8d5de14`; the workbook was left behind for a week, and in
+that week "Pending to Dispatch" meant 4,542 T in one and 819 T in the other. Nothing was broken — both
+figures were right — and no test could fail, because each side was internally consistent.
+
+The fix that actually holds is not the rename. It is
+`scripts/daily-messages.test.mjs` building **both** from one set of rows and asserting the whole
+`servableSplit` and whole `plantPipeline` are deep-equal. Verified it bites by injecting a 0.5 MT
+drift into the workbook's servable total: two tests failed. A weaker test — each side's own totals,
+or a spot-checked headline — would have passed throughout the week the two disagreed.
+
+**Where two surfaces must agree, assert them against each other, not each against itself.**
+
+## 2026-09-08 — a handoff that points at an ephemeral path loses its plan
+
+The handoff for this work said "the approved plan is at `/root/.claude/plans/fizzy-scribbling-wand.md`
+— read it first" and deliberately carried only what the plan did *not* say. Remote sessions get a
+fresh container, so `/root/.claude/plans/` did not exist. Searched the filesystem, the full git
+history across all branches, and GitHub PRs and issues: gone. The plan held the 10-commit sequence,
+both sheet mock-ups with real figures and the agreed decisions table — all of it user-approved and
+none of it reconstructible with confidence.
+
+One commit was fully specified by the handoff itself and was built; the rest waited on the user
+re-supplying the plan. **A handoff must carry its own content, or point at something durable** — a
+commit, an issue, a file in the repo. `/root/` does not survive the session that wrote it.
+
+## 2026-09-08 — Supabase egress is blocked, and the MCP fallback does not scale
+
+`scripts/daily-splits.mjs` fails here with
+`403 Forbidden — Host not in allowlist: hztblmccvvarmgxmunrp.supabase.co`. That is the org's egress
+policy; the proxy README is explicit that a 403 is to be **reported, not routed around**.
+
+The documented fallback — dump rows via the Supabase MCP and use the script's `--in` flag — **does not
+work at this size**. Measured: `dispatches` alone is **54 MB of JSON** across 8,458 rows (orders 1 MB,
+baby coils 1 MB). Pulling that through MCP results is not viable.
+
+So live verification of this change could not run in-session. The unit and integration tests all pass
+and the anti-drift guard holds, but **the figures were never checked against the live book**, and
+verification steps 3–5 of the plan (the baby-coil trap, the movement identity on real data, the
+digit-for-digit diff against the WhatsApp report) remain outstanding until that host is allowlisted.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -443,17 +443,68 @@ One commit was fully specified by the handoff itself and was built; the rest wai
 re-supplying the plan. **A handoff must carry its own content, or point at something durable** — a
 commit, an issue, a file in the repo. `/root/` does not survive the session that wrote it.
 
-## 2026-09-08 — Supabase egress is blocked, and the MCP fallback does not scale
+## 2026-09-08 — Supabase egress is blocked, but the MCP CAN carry the whole book
 
 `scripts/daily-splits.mjs` fails here with
 `403 Forbidden — Host not in allowlist: hztblmccvvarmgxmunrp.supabase.co`. That is the org's egress
 policy; the proxy README is explicit that a 403 is to be **reported, not routed around**.
 
-The documented fallback — dump rows via the Supabase MCP and use the script's `--in` flag — **does not
-work at this size**. Measured: `dispatches` alone is **54 MB of JSON** across 8,458 rows (orders 1 MB,
-baby coils 1 MB). Pulling that through MCP results is not viable.
+Two wrong turns before finding the way through, both worth writing down.
 
-So live verification of this change could not run in-session. The unit and integration tests all pass
-and the anti-drift guard holds, but **the figures were never checked against the live book**, and
-verification steps 3–5 of the plan (the baby-coil trap, the movement identity on real data, the
-digit-for-digit diff against the WhatsApp report) remain outstanding until that host is allowlisted.
+**"54 MB of dispatches" was measuring deleted rows.** `select sum(pg_column_size(d.*)) from dispatches`
+returns 17 MB / 54 MB of JSON across 8,458 rows — and it looked like the MCP fallback could not
+possibly carry it. But every builder starts with `notDeleted(...)`. **Non-deleted, the whole table is
+209 dispatches and 858 bundle entries.** Filter `deleted is not true` before measuring anything in
+this database, or the size of the problem is wrong by an order of magnitude.
+
+**An oversized MCP result is written to a file, not lost.** When `execute_sql` exceeds the token
+limit, the harness saves the full payload to
+`~/.claude/projects/.../tool-results/*.txt` and returns the path. That file can be parsed with a
+script — so the rows never pass through the model's context at all, and nothing is transcribed by
+hand. Deliberately making a query too big is the cheap path, not the failure path. Pad a small result
+with `repeat('pad', 40000)` to force it.
+
+The whole live book — 1,596 orders, 858 dispatch entries, 1,359 productions, 2,451 allocations, 2,715
+baby coils, 462 coils, 320 SKUs — came across as `~`-delimited text this way, every table carrying an
+`md5()` computed in Postgres and re-checked after writing. All eight matched, and Σ weight per table
+matched the database exactly.
+
+**Two things that would have corrupted it silently:**
+
+- `concat_ws('~', a, b, c)` **drops NULLs entirely** rather than emitting an empty field, so a CHS SKU
+  with no `height`/`breadth` came back with 7 fields where an SHS row had 10 — positional parsing
+  destroyed, no error. Use `coalesce(col::text,'')` on every column, and assert
+  `min(array_length(...)) = max(array_length(...))`.
+- The delimiter has to be proved absent from the data first (`count(*) where col like '%~%'`), not
+  assumed.
+
+
+## 2026-09-08 — the identity was right in the common case and wrong in general
+
+`salesByDistributor.onhandByPlant` shipped with this stated in a code comment, an ADR and
+DATA-MODEL.md:
+
+```
+Σ onhandByPlant  −  onhandByPlantUnmatched  ===  onhand     ("exact, always")
+```
+
+Running it against the live book at D = 07-Sep-2026 failed on **54 of 667** Distributor × SKU rows.
+Every one of the 54 had `onhand === 0`.
+
+The reasoning behind the claim was sound as far as it went. `producedPool` is `produced − dispatched`,
+so the serving plants partition the same rows and the unfloored weights sum exactly. What it missed is
+that there are **two** floorings, not one: each cell floors its own plant, and `onhand` floors the
+COMBINED pool. While the area holds stock they agree. When the whole area is over-invoiced for a size
+the left side is negative and `onhand` is 0. The identity needs the floor:
+
+```
+max(0,  Σ onhandByPlant  −  onhandByPlantUnmatched )  ===  onhand
+```
+
+The code was already correct — no figure changed. What was wrong was the claim made about it, in
+three places, and a test that only exercised the positive case. A test written from the same reasoning
+as the code will agree with the code; that is not verification.
+
+**The unit tests could not have caught this, because I wrote both from the same model of the problem.
+Real data disagreed with the model on the first run.** That is the whole argument for running a change
+against the live book before believing it.

--- a/docs/ALGORITHMS.md
+++ b/docs/ALGORITHMS.md
@@ -156,12 +156,13 @@ so a batch's plant describes what it actually ate, never what a form said.
 
 `buildPlantMtdSummary` (`src/lib/reports.js`) breaks the Dashboard sheet's headline tonnage down per
 plant, in a block rendered **beneath** the KPI cards — `Plant | Invoiced MTD | Confirmed | Non-Conf |
-Pending to Dispatch | Total Orders`, closed by an `ALL PLANTS` row. It is reached as
+Pending to Serve | Indent`, closed by an `ALL PLANTS` row (renamed Sep-2026, ADR-0008 — the columns
+are the same figures under the names that no longer collide with the KPI card above them). It is reached as
 `buildMtdDashboardData(...).plantSplit`, so the workbook and anything else reporting the split read
 one object.
 
 - **No headline moves.** Every KPI above the block is computed exactly as before; the block is a
-  *partition* of those figures, never a replacement. Company-wide Pending to Dispatch stays at the
+  *partition* of those figures, never a replacement. Company-wide Pending to Serve stays at the
   2615.441 MT it reads today — scoping the report to Hyderabad instead would drop it to 761.441 MT
   overnight with nothing changed in the business (#117 phase 4).
 - **Two axes, two sources, neither typed.** Pending comes from the **order row's** `plant` (#118);
@@ -253,8 +254,9 @@ distributor filed under the wrong region) is invisible to the Σ checks (`docs/a
 
 ## Daily report — the plant split (ticket #128)
 
-The same two metrics, cut the other way: **Invoiced MTD** and **Pending to Dispatch** per plant (the
-card the daily reports label *Pending to serve*), in the daily PB MTD text and WhatsApp messages,
+The same two metrics, cut the other way: **Invoiced MTD** and **Pending to Serve** per plant (the
+wide book — since ADR-0008 this is NOT the workbook's *Pending to Dispatch* card, which is the
+smaller stock-backed figure), in the daily PB MTD text and WhatsApp messages,
 from `buildPlantMtdSummary` — the identical function the
 workbook's `BY PLANT` block renders (above). `scripts/daily-splits.mjs` emits it alongside the region
 split, off one fetch and one `D`.
@@ -318,3 +320,61 @@ at (#118, ADR-0005). So the split is a plain partition on a stored column, no id
   either inside a plant filter would let a production stop counting against the coil it consumed.
 - **`Unattributed` keeps its tonnage**, exactly as on the other splits, and every column ties back
   to its ungrouped figure or the script refuses to emit.
+
+
+## PB MTD workbook — the Sep-2026 parity blocks
+
+The workbook was brought level with the daily WhatsApp message, which `8d5de14` had reshaped. Four
+blocks were added to the Dashboard sheet and one column group to Distributor × SKU. Every figure
+comes from a builder the message already calls — there is no arithmetic here that exists twice.
+
+**Naming (ADR-0008).** `Total Orders` → **Indent** everywhere; the wide open book → **Pending to
+Serve**; **Pending to Dispatch** is now `Confirmed + Servable – Unconfirmed`. The app screens are
+knowingly out of scope, so the phrase means one thing in the file and another on screen — which is
+why every block prints its own formula.
+
+**SERVABLE BY REGION** (`buildServableSummary`). Counted once per `(region, size)`, never per
+distributor: inside a service area stock is shared and reserved to nobody, so summing per-distributor
+servable figures invents steel the plant does not hold (ADR-0002). Reads `?` for a region with no
+service area, and the total sums only regions that HAVE an answer — with none at all the card reads
+`N/A`, because a plain sum of nothing is a confident zero meaning the opposite.
+
+**STOCK MOVEMENT** (`buildPlantPipelineSummary`). Finished pipe only:
+
+```
+openingFg + producedMtd − invoicedMtd + producedAfterD − invoicedAfterD  ===  fgLeft
+```
+
+- `openingFg` is a **complement** (`producedAll − produced(≥MONTH)`), not a `date < 1st` filter. An
+  undated production row is a data fault, and a date test would drop it from Opening while `fgLeft`
+  kept it — the movement columns would quietly lose steel.
+- The two **after-D** terms close the rest: `fgLeft` has no date cap while Opening and both MTD
+  columns stop at D, so tonnage dated later sits in Current and in neither. It is reported in the
+  caption, not absorbed.
+- `checks.movementTiesToFgLeft` asserts it on **every row and the total**, and the block prints
+  `⚠ … do not circulate this sheet` on breach.
+- **Current is the Physical Inventory headline**, reached a completely different way (Σ produced −
+  Σ invoiced per plant, against Σ positive on-hand less over-shipment). That makes it a genuine
+  cross-check rather than arithmetic checking itself.
+
+**BY PLANT — RAW MATERIAL.** A **position, not a movement**: a coil is not dispatched, so
+`Opening + In − Out` has nothing to measure and none is implied. Baby coil reads `babyCoilStock` —
+the scrap floor and the operator's `consumed` flag (ADR-0007) — which is the Dashboard's own card. A
+plain `Σ max(0, weight − consumed)` is a different and larger number (**1,645.5 T** on 08-Sep-2026),
+and having both in circulation is how a card and a workbook start disagreeing about the same steel.
+
+**RM is `?`, never 0, when the coil registers were not supplied.** `notDeleted(null)` returns `[]`, so
+an unsupplied register computes a perfectly confident zero. `pipelineScope.rmKnown` carries the
+absence and every RM cell renders `?`. An **empty** register is still a real zero — only a **missing**
+one is unknown. Both registers or neither: the full-coil figure excludes mothers that were slit and
+the slit set is read off `babyCoils`, so coils alone would re-report already-cut steel as whole.
+
+**ON FLOOR, BY PLANT** on Distributor × SKU (`salesByDistributor.onhandByPlant`, ADR-0009). Real
+stock per plant, never an apportioned share, reconciling exactly through
+`Σ cells − onhandByPlantUnmatched === onhand`. See the ADR for the four cell marks and why `0.0` and
+`—` must never share a symbol.
+
+**They cannot drift apart.** `scripts/daily-messages.test.mjs` builds the workbook data and the
+message data from one set of rows and asserts the whole servable split and the whole plant pipeline
+are deep-equal. Comparing whole objects is the point — a test asserting each side's own totals would
+pass while the two printed different Hyderabads.

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -383,10 +383,12 @@ nothing in Supabase changes.
 | `onhandByPlantUnmatched` | The tonnage one plant invoiced beyond what it recorded producing, floored out of the cells above. Makes the breakdown reconcile exactly. |
 
 ```
-Σ onhandByPlant  −  onhandByPlantUnmatched  ===  onhand
+max(0,  Σ onhandByPlant  −  onhandByPlantUnmatched )  ===  onhand
 ```
 
-Exact and always true. `onhand` floors the **combined** service-area pool while each cell floors its
-**own** plant, so a plant that over-invoiced is the only thing that can part them — reported rather
-than absorbed, which is what lets the sheet assert its own breakdown adds up. See
+True on every row, and the floor is load-bearing. `onhand` floors the **combined** service-area pool
+while each cell floors its **own** plant; `onhandByPlantUnmatched` carries the difference the second
+flooring makes. While the area holds stock the cells simply add up to `onhand`. When the whole area
+is over-invoiced for a size the left-hand side goes negative while `onhand` is 0 — 54 of 667 rows on
+the live book at 07-Sep-2026. See
 `docs/adr/0009-plant-stock-columns-show-real-stock-not-an-apportioned-share.md`.

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -39,8 +39,8 @@ separate migration of existing rows.
 
 ## Plant (ticket #118)
 Four manufacturing companies ship the order book. Until #118 the app had no column to put them in,
-so all four counted as Hyderabad's — 2615.441 MT of Pending to Dispatch where Hyderabad's own was
-761.441 MT.
+so all four counted as Hyderabad's — 2615.441 MT of Pending to Serve (the wide open book; ADR-0008
+renamed it from *Pending to Dispatch* in Sep-2026) where Hyderabad's own was 761.441 MT.
 
 Plant is resolved from the ERP's **`Ship From Code`**, which is spelled identically in both sheets.
 The ERP's own name string — `CM name` in Orders, `Ship from location` in Invoice — is a **fallback
@@ -370,3 +370,23 @@ on purpose.
   else. Inner spacing and punctuation are the CM's format, not ours to rewrite.
 - **Free text with a datalist**, built by `productionPoOptions` from every non-deleted production.
   There is no PO master; the datalist is the only thing holding spelling together.
+
+
+## Derived: `onhandByPlant` on a distributor's SKU row (Sep-2026)
+
+`salesByDistributor` emits two extra **derived** fields on each SKU row. Neither is stored, and
+nothing in Supabase changes.
+
+| Field | Meaning |
+|---|---|
+| `onhandByPlant` | `{ [plantId]: MT }` — what each plant that **serves this row's region** actually holds of that size. A **missing key** means the plant does not serve the region; a `0` means it serves and holds none; the whole field is **`null`** for an `Unmapped` distributor. |
+| `onhandByPlantUnmatched` | The tonnage one plant invoiced beyond what it recorded producing, floored out of the cells above. Makes the breakdown reconcile exactly. |
+
+```
+Σ onhandByPlant  −  onhandByPlantUnmatched  ===  onhand
+```
+
+Exact and always true. `onhand` floors the **combined** service-area pool while each cell floors its
+**own** plant, so a plant that over-invoiced is the only thing that can part them — reported rather
+than absorbed, which is what lets the sheet assert its own breakdown adds up. See
+`docs/adr/0009-plant-stock-columns-show-real-stock-not-an-apportioned-share.md`.

--- a/docs/adr/0008-the-workbooks-pending-to-dispatch-is-the-stock-backed-figure.md
+++ b/docs/adr/0008-the-workbooks-pending-to-dispatch-is-the-stock-backed-figure.md
@@ -1,0 +1,76 @@
+# In the workbook, "Pending to Dispatch" is the stock-backed figure
+
+The PB MTD workbook's **Pending to Dispatch** is **Confirmed + Servable – Unconfirmed** — the part of
+the open book the floor can actually cover today. The whole open book (**Confirmed + Non-confirmed**)
+keeps the name it already had elsewhere: **Pending to Serve**. **Total Orders** becomes **Indent**
+throughout the workbook.
+
+## What was happening
+
+One phrase meant two things, in two places a reader holds side by side.
+
+```
+                          04-Sep-2026, the same order book
+  workbook  "Pending to Dispatch"   4,550.7 T   Confirmed + Non-confirmed
+  WhatsApp  "Pending to Dispatch"     805.3 T   Confirmed + Servable – Unconfirmed
+```
+
+The daily message was reshaped in `8d5de14` to answer a question a plant can act on today — *is the
+steel already on the floor?* — and took the existing name with it. The workbook kept the old meaning.
+`CONTEXT.md` had recorded the collision and asked for it to be settled "before either spreads
+further"; it then spread further.
+
+Nothing was wrong with either figure. Both are useful and both are still printed. The fault was that
+one name carried both, so a manager quoting "pending to dispatch" in a meeting could be off by a
+factor of five and nobody in the room could tell which number they were holding.
+
+## The decision
+
+The name goes to the **smaller, stock-backed** figure, because that is the one someone acts on: it
+answers what can be shipped, and it is the figure the daily message has printed since Sep-2026 and
+that people already read every morning.
+
+This was contested. A design pass argued the opposite — leave the name on the wide figure, rename the
+message instead, roughly a tenth of the blast radius. That trade-off was put explicitly, with a
+mock-up showing the collision *moving* rather than closing, and the wider change was chosen anyway.
+
+## What this costs, and why it was accepted
+
+**The app screens are out of scope.** They still say "Pending to Dispatch" for the wide figure, so
+after this the same phrase means **819 T in the workbook and 4,542 T on screen**. That is worse
+before it is better, and it was accepted knowingly: the screens are ~20 places including CSV headers
+other spreadsheets may already consume, and moving them is its own change with its own risk.
+
+Two things make it survivable in the meantime:
+
+- **Every workbook block prints its own formula.** The KPI card's caption reads
+  `Conf + Servable–Unconf`; the `SERVABLE BY REGION` note names both figures and gives the wide one
+  in tonnes; the `BY PLANT` note says outright that its Pending to Serve column is the whole book and
+  **not** the card above it. A reader can always tell which figure they hold without knowing this ADR
+  exists.
+- **Both figures appear together** on the Order Status Summary — Servable – Unconfirmed, Pending to
+  Serve and Pending to Dispatch on three consecutive lines. The relationship is visible, not implied.
+
+## The third name we nearly created
+
+A grep for every occurrence found a third name already in play, and one broken definition behind it.
+The `pb-mtd-report` skill has been printing **Pending to Serve** for the wide figure in nine places —
+which this decision makes exactly right, so that skill needs no change. But `CONTEXT.md` *defined*
+*Pending to serve* as "the same tonnage as Pending to Dispatch" and called two names for one number
+"a wart". Left alone, the glossary would have asserted the two figures were equal on the very day
+they stopped being. The definition is corrected here; the usage was already correct.
+
+That grep was the one piece of work the handoff into this change flagged as never done. Worth noting
+that the answer it produced was not the one expected — the risk was in the glossary, not in the skill
+everyone assumed would need rewriting.
+
+## Consequences
+
+- `salesKpis` and the app's own field names are **unchanged**. This is a naming decision about what
+  the workbook prints, not a change to how anything is computed.
+- The workbook's KPI card reads **N/A**, never 0, when no region can answer the servable question —
+  the totals sum only regions that have an answer, so a plain sum of none is a confident zero meaning
+  the opposite of "nobody has mapped these states yet".
+- `scripts/daily-messages.test.mjs` now builds the workbook data and the message data from one set of
+  rows and asserts they are deep-equal, so the two cannot drift apart again by accident.
+- Renaming the app screens remains open, and is the thing that actually closes this.

--- a/docs/adr/0009-plant-stock-columns-show-real-stock-not-an-apportioned-share.md
+++ b/docs/adr/0009-plant-stock-columns-show-real-stock-not-an-apportioned-share.md
@@ -1,0 +1,61 @@
+# Plant stock columns show real stock, not an apportioned share
+
+The `ON FLOOR, BY PLANT` columns on the workbook's Distributor × SKU sheet show **what each plant
+actually holds** of that size. They are never the service-area pool divided among the distributors
+queued against it.
+
+## The alternative we rejected
+
+An apportioned column is tempting because it makes the arithmetic tidy: give each distributor its
+"share" of the area's stock and the numbers stop repeating down the sheet. It fails on two counts.
+
+**It is not checkable.** The promise a stock column makes is that someone can walk onto the floor and
+count it. An apportioned figure corresponds to nothing physical, so a plant manager disputing it has
+nothing to measure against.
+
+**It moves when somebody else orders.** A share is a function of demand, so a distributor's stock
+column would change because a *different* distributor placed an order — nothing physical having
+happened. A stock figure that reacts to somebody else's demand is not a stock figure. The test for
+this multiplies one distributor's pending by a thousand and asserts both cells sit still.
+
+## What the cells mean
+
+Four marks, four different facts. They must never share a value:
+
+```
+54.7   this plant holds that much of this size
+0.0    it serves the region and holds NONE of it        — a real, countable answer
+—      it does not serve the region at all              — it cannot ship to you
+?      the distributor has no region                    — nobody can say which plants serve it
+```
+
+The `0.0` / `—` distinction is the one that bites. The sheet's existing `dash` helper renders a real
+zero as `-`, which is exactly the mark a non-serving plant must own — so the plant columns needed
+their own renderer. "We have none of it here" and "we cannot ship it to you at all" are opposite
+instructions to whoever reads the sheet, and ADR-0006 already forbids showing a plant's stock outside
+its service area. `?` follows the same rule as every other stock cell: unknown is not empty.
+
+## How it reconciles
+
+`producedPool` is `produced − dispatched`, and the serving plants partition the same rows the area
+pool reads, so the unfloored per-plant weights sum to the area figure exactly. The one wedge is
+flooring: `onhand` floors the **combined** pool while each cell floors its **own** plant. A plant that
+invoiced beyond what it recorded producing is therefore the only thing that can part them, and that
+tonnage is reported rather than absorbed:
+
+```
+Σ onhandByPlant  −  onhandByPlantUnmatched  ===  onhand
+```
+
+Exact, always, and asserted. Without it a plant's over-invoicing would leave the cells quietly
+overstating the floor, and the sheet could not claim its own breakdown adds up.
+
+## Consequences
+
+- The cells sum to the area's **floor**, which is **more** than the Free Stock beside them: Free Stock
+  is that floor less what the area has already promised. The caption says so, because a reader who
+  assumes the two should match will think the sheet is broken.
+- There is still **no total row** on the sheet. Inside a service area stock is shared and reserved to
+  nobody, so summing a column would report more steel than the plants hold (ADR-0002).
+- Column order groups the plants by the region they serve, so a distributor's real cells sit together
+  rather than straddling dashes.

--- a/docs/adr/0009-plant-stock-columns-show-real-stock-not-an-apportioned-share.md
+++ b/docs/adr/0009-plant-stock-columns-show-real-stock-not-an-apportioned-share.md
@@ -38,17 +38,21 @@ its service area. `?` follows the same rule as every other stock cell: unknown i
 ## How it reconciles
 
 `producedPool` is `produced − dispatched`, and the serving plants partition the same rows the area
-pool reads, so the unfloored per-plant weights sum to the area figure exactly. The one wedge is
-flooring: `onhand` floors the **combined** pool while each cell floors its **own** plant. A plant that
-invoiced beyond what it recorded producing is therefore the only thing that can part them, and that
-tonnage is reported rather than absorbed:
+pool reads, so the unfloored per-plant weights sum to the area's unfloored weight exactly. What sits
+between that and `onhand` is **two different floorings**: each cell floors its own plant (so a plant
+that invoiced beyond what it recorded producing is carried out into `onhandByPlantUnmatched`), and
+`onhand` floors the **combined** pool. The identity therefore carries a floor of its own:
 
 ```
-Σ onhandByPlant  −  onhandByPlantUnmatched  ===  onhand
+max(0,  Σ onhandByPlant  −  onhandByPlantUnmatched )  ===  onhand
 ```
 
-Exact, always, and asserted. Without it a plant's over-invoicing would leave the cells quietly
-overstating the floor, and the sheet could not claim its own breakdown adds up.
+Asserted, and it holds on every row. **The floor is not decoration.** While the area holds stock the
+two sides agree and the cells simply add up to the floor total. When the WHOLE AREA is over-invoiced
+for a size, the left-hand side is negative while `onhand` is 0 — and on the live book at 07-Sep-2026
+that was **54 of 667 rows**. The un-floored form, which is what this ADR first claimed, would have
+failed the renderer's tie-out on real data the first time it ran. It was caught by running the
+builders against the live book rather than by reasoning about them.
 
 ## Consequences
 

--- a/scripts/daily-messages.test.mjs
+++ b/scripts/daily-messages.test.mjs
@@ -11,7 +11,8 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import { buildPlantMtdSummary, buildRegionMtdSummary } from '../src/lib/reports.js'
+import { buildPlantMtdSummary, buildRegionMtdSummary, buildMtdDashboardData } from '../src/lib/reports.js'
+import { resolveProductionWeights } from '../src/lib/calc.js'
 
 const D = '2026-08-18'
 
@@ -180,5 +181,65 @@ describe('scripts/servable-orders.mjs — whose floor it is, and who may have it
     expect(out).toContain('📍 South only')
     expect(out).toMatch(/1044\.0 T pending sits with 1 distributor outside South/)
     expect(out).not.toContain('PUNE STEEL')
+  })
+})
+
+// ── The anti-drift guard: the workbook and the WhatsApp message are the SAME figures ─────────────
+// This is the assertion that makes "they cannot drift apart" true by construction rather than by
+// discipline. The workbook was reshaped to match the message; nothing stops the next change to
+// either one from quietly un-matching them again EXCEPT a test that builds both from one set of
+// rows and compares them field for field.
+//
+// A weaker test — asserting each side's own totals, or spot-checking a headline — would pass
+// happily while the two printed different Hyderabads, which is exactly the failure this run exists
+// to end. Comparing whole objects is the point.
+const coils = [
+  { id: 'c1', deleted: false, hrCoilId: 'H1', plant: 'hyderabad', actualWeight: 260 },
+  { id: 'c2', deleted: false, hrCoilId: 'N1', plant: 'npmd', actualWeight: 140 },
+]
+const babyCoils = [
+  { id: 'b1', deleted: false, babyCoilId: 'B1', hrCoilId: 'H9', plant: 'hyderabad', weight: 44 },
+  { id: 'b2', deleted: false, babyCoilId: 'B2', hrCoilId: 'H9', plant: 'hyderabad', weight: 0.1 },  // scrap, ADR-0007
+]
+
+describe('the workbook and the daily message cannot drift apart', () => {
+  const rowsAll = { orders, dispatches, productions, skus, coils, babyCoils, stateRegions: null, distributors: null, plants: null }
+  const splitAll = () => JSON.parse(run('daily-splits.mjs', ['--date', D, '--in', fixture('rows-all', rowsAll)]))
+  // Exactly what App.jsx hands the workbook: weights resolved live off the SKU master first
+  // (`resolveProductionWeights`), which is the same thing daily-splits.mjs does to its own rows.
+  const workbook = () => buildMtdDashboardData(orders, dispatches,
+    resolveProductionWeights(productions, skus, babyCoils), skus,
+    { date: D, coils, babyCoils })
+  const plain = (v) => JSON.parse(JSON.stringify(v))
+
+  it('prints the same servable split, field for field', () => {
+    expect(splitAll().servableSplit).toEqual(plain(workbook().servable))
+  })
+
+  it('prints the same plant pipeline — production, FG and RM — field for field', () => {
+    expect(splitAll().plantPipeline).toEqual(plain(workbook().pipeline))
+  })
+
+  it('agrees on the figures a reader would compare across the two', () => {
+    const s = splitAll(), w = workbook()
+    // The four the eye goes to first, on a phone and on a printed sheet.
+    expect(s.servableSplit.totals.pendingToDispatch).toBeCloseTo(w.servable.totals.pendingToDispatch, 6)
+    expect(s.servableSplit.totals.servableUnconfirmed).toBeCloseTo(w.servable.totals.servableUnconfirmed, 6)
+    expect(s.plantPipeline.totals.producedMtd).toBeCloseTo(w.pipeline.totals.producedMtd, 6)
+    expect(s.plantPipeline.totals.rmTotal).toBeCloseTo(w.pipeline.totals.rmTotal, 6)
+    // And Fresh Production MTD, the headline the per-plant rows must partition, is the same figure
+    // on both — the bug commit 1 fixed was precisely this pair disagreeing on a back-dated run.
+    expect(w.inventoryProduction.freshProductionMtd).toBeCloseTo(s.plantPipeline.totals.producedMtd, 6)
+  })
+
+  it('applies the baby-coil scrap floor on BOTH sides, not just one', () => {
+    // 44 T of free strip plus a 0.1 T end. The end is scrap (ADR-0007) and must be excluded by the
+    // message AND the workbook: a naive Σ max(0, weight − consumed) returns 44.1 on live data it
+    // returns over a thousand tonnes too much, and having both numbers in circulation is how a card
+    // and a broadcast start disagreeing about the same steel.
+    const s = splitAll(), w = workbook()
+    expect(w.pipeline.totals.babyLeft).toBeCloseTo(44, 6)
+    expect(s.plantPipeline.totals.babyLeft).toBeCloseTo(44, 6)
+    expect(w.pipeline.diagnostics.babyNotCounted).toBeCloseTo(0.1, 6)
   })
 })

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3649,7 +3649,12 @@ function Reports({ skus, productions, dispatches, coils, babyCoils, orders, esti
       // estimates for the report month (ADR-0001), so it can't drift from what the Sales tab shows.
       // The state → region master rides along for the same reason: the workbook's Region column and
       // the Sales tab's are one mapping, not two.
-      else await R.generateMtdDashboardReport(orders, dispatches, productions, skus, { estimates, stateRegions, plants, distributors, ...reportOpts })
+      // `coils`/`babyCoils` ride along so the workbook can print the raw-material position (#130).
+      // They are ALREADY plant-scoped by the header selector, exactly as `productions` is, so a
+      // scoped workbook's RM block covers the same plants as every other figure in the file.
+      // Omitting them is not a smaller report, it is an unanswerable one: the sheet prints "?"
+      // rather than a confident zero, because the builder cannot tell "no steel" from "not asked".
+      else await R.generateMtdDashboardReport(orders, dispatches, productions, skus, { estimates, stateRegions, plants, distributors, coils, babyCoils, ...reportOpts })
     } catch (e) {
       setErr(String(e?.message || e))
     } finally {

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -2031,10 +2031,17 @@ export function salesByDistributor(orders, dispatches, month = '', skus = [], op
       onhandByPlant[id] = Math.max(0, w)                 // a plant cannot hold negative steel
       if (w < 0) onhandByPlantUnmatched -= w             // magnitude, as unmatchedDispatch reports it
     })
-    // Σ cells − unmatched === onhand, exactly, always. `onhand` floors the COMBINED pool while the
-    // cells floor each plant on its own, so a plant that invoiced beyond what it recorded producing
-    // is the one thing that can part them. Reporting that tonnage rather than absorbing it is what
-    // lets the sheet assert its own breakdown instead of quietly not adding up.
+    // The identity, and it carries a FLOOR:
+    //
+    //     max(0, Σ onhandByPlant − onhandByPlantUnmatched) === onhand
+    //
+    // `Σ cells − unmatched` is the area's UNFLOORED weight. `onhand` floors it. Two different
+    // floorings sit between them: the cells floor each plant on its own (so a plant that invoiced
+    // beyond what it recorded producing is carried out into `unmatched`), and `onhand` floors the
+    // COMBINED pool. While the area holds stock the two agree and the cells simply add up to it.
+    // When the WHOLE AREA is over-invoiced for a size, the left side is negative and `onhand` is 0 —
+    // which is why the floor is not decoration. On the live book at 07-Sep-2026 that was 54 of 667
+    // rows, so the un-floored form would have failed the renderer's tie-out on real data.
     return { ...s, onhand, allPending, allConfirmed, freeStock: onhand - allConfirmed,
       shortBy: Math.max(0, s.pending - onhand), onhandByPlant, onhandByPlantUnmatched }
   }

--- a/src/lib/calc.js
+++ b/src/lib/calc.js
@@ -1968,6 +1968,7 @@ export function salesByDistributor(orders, dispatches, month = '', skus = [], op
   // WHOSE pool a row reads, never how the pool is divided.
   const master = plantMaster(opts.plants)
   const poolByRegion = new Map(), pendingByRegion = new Map(), confirmedByRegion = new Map()
+  const poolByPlant = new Map()
   if (opts.productions) {
     new Set(regionByKey.values()).forEach(region => {
       // An `Unmapped` distributor has no known service area — UNKNOWN, not empty. It gets no pool,
@@ -1978,6 +1979,18 @@ export function salesByDistributor(orders, dispatches, month = '', skus = [], op
       poolByRegion.set(region, producedPool(
         filterByPlants(opts.productions, plants),
         filterDispatchesByPlants(dispatches, plants), null, keyOf))
+      // ── ON FLOOR, BY PLANT: one pool per SERVING PLANT, not the area pool divided up ──────────
+      // The workbook prints these beside each distributor × SKU row, and the promise it makes is
+      // that a cell is steel someone can walk out and count at that plant. An apportioned share
+      // would satisfy no such check, and it would MOVE when a different distributor's order
+      // changed — a stock figure that reacts to somebody else's demand is not a stock figure.
+      //
+      // `producedPool` is produced − dispatched, so it is additive: the serving plants partition
+      // the same rows the area pool reads, and their unfloored weights sum to the area's exactly.
+      // The only wedge between the cells and `onhand` is per-plant flooring, reported below.
+      poolByPlant.set(region, new Map([...plants].map(id => [id, producedPool(
+        filterByPlants(opts.productions, [id]),
+        filterDispatchesByPlants(dispatches, [id]), null, keyOf)])))
       pendingByRegion.set(region, {}); confirmedByRegion.set(region, {})
     })
     Object.entries(map).forEach(([key, r]) => {
@@ -1994,7 +2007,8 @@ export function salesByDistributor(orders, dispatches, month = '', skus = [], op
     const pool = poolByRegion.get(region)
     // No pool ⇒ no service area known. Every stock column is null, which every surface renders as
     // "?" or "—" — never as a figure.
-    if (!pool) return { ...s, onhand: null, allPending: null, allConfirmed: null, freeStock: null, shortBy: null }
+    if (!pool) return { ...s, onhand: null, allPending: null, allConfirmed: null, freeStock: null, shortBy: null,
+      onhandByPlant: null, onhandByPlantUnmatched: null }
     // A SKU can't hold negative stock — over-dispatched sizes floor to 0 here (the tonnage is
     // accounted for plant-wide by unmatchedDispatch, which has no place on a per-distributor row).
     const onhand = Math.max(0, Number(pool[s.id]?.availableWeight || 0))
@@ -2006,8 +2020,23 @@ export function salesByDistributor(orders, dispatches, month = '', skus = [], op
     // same physical stock. Goes NEGATIVE when a size is committed beyond what is on the floor —
     // that is the signal, so it is not floored. Same shape as the Dashboard's Free FG.
     const allConfirmed = confirmedByRegion.get(region)[s.id] || 0
+    // One cell per serving plant. A plant that serves this region and holds none of the size reads
+    // 0 — a real answer; a plant that does not serve it gets NO KEY at all, which the renderer
+    // prints as a dash. "Cannot ship to you" and "is empty" are different facts and must not share
+    // a symbol (the same rule that keeps an Unmapped row on `?` rather than 0).
+    const onhandByPlant = {}
+    let onhandByPlantUnmatched = 0
+    ;(poolByPlant.get(region) || new Map()).forEach((p, id) => {
+      const w = Number(p[s.id]?.availableWeight || 0)
+      onhandByPlant[id] = Math.max(0, w)                 // a plant cannot hold negative steel
+      if (w < 0) onhandByPlantUnmatched -= w             // magnitude, as unmatchedDispatch reports it
+    })
+    // Σ cells − unmatched === onhand, exactly, always. `onhand` floors the COMBINED pool while the
+    // cells floor each plant on its own, so a plant that invoiced beyond what it recorded producing
+    // is the one thing that can part them. Reporting that tonnage rather than absorbing it is what
+    // lets the sheet assert its own breakdown instead of quietly not adding up.
     return { ...s, onhand, allPending, allConfirmed, freeStock: onhand - allConfirmed,
-      shortBy: Math.max(0, s.pending - onhand) }
+      shortBy: Math.max(0, s.pending - onhand), onhandByPlant, onhandByPlantUnmatched }
   }
 
   const finish = (o) => ({ ...o, pending: o.confirmed + o.nonConfirmed, totalOrders: o.mtdInvoice + o.confirmed + o.nonConfirmed })

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -3461,3 +3461,94 @@ describe('plantNamesIn — whose rows these are, in words (ticket #128)', () => 
     expect(plantNamesIn([{ plant: 'npmd' }, { plant: 'hyderabad' }], master)).toEqual(['Hyd Works', 'Pune Works'])
   })
 })
+
+// ── ON FLOOR, BY PLANT — the Distributor × SKU plant columns ─────────────────────────────────────
+// The workbook is about to print one stock column per plant beside each distributor × SKU row. The
+// figure in each cell is WHAT THAT PLANT ACTUALLY HOLDS — steel someone can walk out and count —
+// never the area pool divided up. An apportioned share would be a number nobody can verify against
+// a floor, and it would move when a DIFFERENT distributor's order changed.
+describe('salesByDistributor — on-floor stock per plant (Distributor × SKU columns)', () => {
+  const skus = [{ skuCode: 'S1', productType: 'SHS', height: 50, breadth: 50, thickness: 2, length: 6000 }]
+  // Two plants serve South and both hold this size; the two West plants hold none of it.
+  const productions = [
+    { deleted: false, skuCode: 'S1', plant: 'hyderabad', dateOfProduction: '2026-08-01', tubeCount: 100, totalWeight: 54.7 },
+    { deleted: false, skuCode: 'S1', plant: 'lepakshi', dateOfProduction: '2026-08-02', tubeCount: 30, totalWeight: 12 },
+  ]
+  const south = { deleted: false, mmId: 'S1', distributorCode: 'D1', customer: 'PATEL', shipToState: 'TELANGANA', orderStatus: 'Confirmed', confirmed: 20, nonConfirmed: 100 }
+  const west = { deleted: false, mmId: 'S1', distributorCode: 'D2', customer: 'PQR', shipToState: 'MAHARASHTRA', orderStatus: 'Confirmed', confirmed: 0, nonConfirmed: 300 }
+  const run = (orders, dispatches = []) => salesByDistributor(orders, dispatches, '2026-08', skus, { productions })
+
+  it('names only the plants that SERVE the row’s region', () => {
+    const s = run([south, west]).find(r => r.id === 'D1').skuRows[0]
+    expect(Object.keys(s.onhandByPlant).sort()).toEqual(['hyderabad', 'lepakshi'])
+    // A missing key is "not your area" — and it must be missing, not zero. A plant that cannot ship
+    // to you is not a plant that is empty, and the renderer prints those two as "—" and "0".
+    expect(s.onhandByPlant).not.toHaveProperty('npmd')
+    expect(s.onhandByPlant).not.toHaveProperty('tapi')
+  })
+
+  it('shows what each plant actually holds, never an apportioned share', () => {
+    const s = run([south, west]).find(r => r.id === 'D1').skuRows[0]
+    expect(s.onhandByPlant.hyderabad).toBeCloseTo(54.7)
+    expect(s.onhandByPlant.lepakshi).toBeCloseTo(12)
+    // The proof it is not a share: this distributor's pending is 120 T against 66.7 T on the floor.
+    // An apportioned figure would have to reference that demand. These two do not move with it.
+    const bigger = run([{ ...south, nonConfirmed: 100000 }, west]).find(r => r.id === 'D1').skuRows[0]
+    expect(bigger.onhandByPlant.hyderabad).toBeCloseTo(54.7)
+    expect(bigger.onhandByPlant.lepakshi).toBeCloseTo(12)
+  })
+
+  it('the plant cells add up to the area figure already on the row', () => {
+    const s = run([south, west]).find(r => r.id === 'D1').skuRows[0]
+    const sum = Object.values(s.onhandByPlant).reduce((t, v) => t + v, 0)
+    expect(sum).toBeCloseTo(s.onhand)
+    expect(sum).toBeCloseTo(66.7)
+  })
+
+  it('a plant that serves the region but holds none of the size reads 0, not a blank', () => {
+    const w = run([south, west]).find(r => r.id === 'D2').skuRows[0]
+    expect(Object.keys(w.onhandByPlant).sort()).toEqual(['npmd', 'tapi'])
+    expect(w.onhandByPlant.npmd).toBe(0)
+    expect(w.onhandByPlant.tapi).toBe(0)
+    expect(w.onhand).toBe(0)   // West's floor really is empty — that is a fact, not a gap
+  })
+
+  it('an Unmapped distributor reads null — unknown is not empty', () => {
+    // No state ⇒ no region ⇒ nobody can say which plants serve it. `?`, never 0 and never a dash.
+    const nowhere = { deleted: false, mmId: 'S1', distributorCode: 'D9', customer: 'NEW BUYER', shipToState: '', orderStatus: 'Confirmed', confirmed: 0, nonConfirmed: 80 }
+    const s = run([nowhere]).find(r => r.id === 'D9').skuRows[0]
+    expect(s.onhandByPlant).toBeNull()
+    expect(s.onhand).toBeNull()
+  })
+
+  it('stays absent entirely when no productions are supplied (existing callers unchanged)', () => {
+    const s = salesByDistributor([south], [], '2026-08', skus)[0].skuRows[0]
+    expect(s.onhandByPlant).toBeUndefined()
+    expect(s.onhandByPlantUnmatched).toBeUndefined()
+    expect(s.onhand).toBeUndefined()
+  })
+
+  // ── The one case where the cells and the area figure part company ──────────────────────────────
+  // `onhand` floors the COMBINED pool; the cells floor each plant separately. They differ by exactly
+  // the tonnage one plant invoiced beyond what it recorded producing — the same `unmatchedDispatch`
+  // quantity the Dashboard already reports. Stating the identity here means the renderer can check
+  // it rather than printing a breakdown that silently does not add up.
+  it('reconciles through unmatched dispatch when one plant is over-invoiced', () => {
+    const overAtLepakshi = [{ deleted: false, dateOfDispatch: '2026-08-05',
+      bundleEntries: [{ skuCode: 'S1', plant: 'lepakshi', weight: 20 }] }]   // holds 12, invoices 20
+    const s = run([south, west], overAtLepakshi).find(r => r.id === 'D1').skuRows[0]
+    expect(s.onhandByPlant.hyderabad).toBeCloseTo(54.7)
+    expect(s.onhandByPlant.lepakshi).toBe(0)              // −8 floored: a plant cannot hold negative
+    expect(s.onhand).toBeCloseTo(46.7)                    // combined 66.7 − 20 invoiced
+    const sum = Object.values(s.onhandByPlant).reduce((t, v) => t + v, 0)
+    expect(sum).toBeCloseTo(54.7)
+    // Σ cells − per-plant unmatched === the area figure. Exact, and the renderer's tie-out.
+    expect(sum - s.onhandByPlantUnmatched).toBeCloseTo(s.onhand)
+    expect(s.onhandByPlantUnmatched).toBeCloseTo(8)
+  })
+
+  it('reports no unmatched tonnage in the ordinary case', () => {
+    const s = run([south, west]).find(r => r.id === 'D1').skuRows[0]
+    expect(s.onhandByPlantUnmatched).toBe(0)
+  })
+})

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -3542,9 +3542,31 @@ describe('salesByDistributor — on-floor stock per plant (Distributor × SKU co
     expect(s.onhand).toBeCloseTo(46.7)                    // combined 66.7 − 20 invoiced
     const sum = Object.values(s.onhandByPlant).reduce((t, v) => t + v, 0)
     expect(sum).toBeCloseTo(54.7)
-    // Σ cells − per-plant unmatched === the area figure. Exact, and the renderer's tie-out.
-    expect(sum - s.onhandByPlantUnmatched).toBeCloseTo(s.onhand)
+    // Σ cells − per-plant unmatched === the area figure, WHILE the area is not itself over-invoiced.
+    // The general form carries a floor — see the next test but one.
+    expect(Math.max(0, sum - s.onhandByPlantUnmatched)).toBeCloseTo(s.onhand)
     expect(s.onhandByPlantUnmatched).toBeCloseTo(8)
+  })
+
+  // ── Found by running this against the live book, not by reasoning about it ────────────────────
+  // On 07-Sep-2026, 54 of 667 Distributor x SKU rows failed `Sum cells - unmatched === onhand`.
+  // Every one of them had `onhand === 0`: the WHOLE service area was over-invoiced for that size,
+  // so the combined weight is negative and `onhand` floors it, while the left-hand side stays
+  // negative. The floor is the missing term — the identity needs it to be true in general.
+  it('needs the floor when the whole AREA is over-invoiced, not just one plant', () => {
+    // South holds 66.7 (54.7 Hyderabad + 12 Lepakshi) and 80 is invoiced against it.
+    const overArea = [{ deleted: false, dateOfDispatch: '2026-08-05',
+      bundleEntries: [{ skuCode: 'S1', plant: 'hyderabad', weight: 80 }] }]
+    const s = run([south, west], overArea).find(r => r.id === 'D1').skuRows[0]
+    expect(s.onhandByPlant.hyderabad).toBe(0)             // 54.7 - 80 = -25.3, floored
+    expect(s.onhandByPlant.lepakshi).toBeCloseTo(12)
+    expect(s.onhandByPlantUnmatched).toBeCloseTo(25.3)
+    expect(s.onhand).toBe(0)                              // combined -13.3, floored
+    const sum = Object.values(s.onhandByPlant).reduce((t, v) => t + v, 0)
+    // The UNFLOORED form is off by exactly the area's own over-invoicing...
+    expect(sum - s.onhandByPlantUnmatched).toBeCloseTo(-13.3)
+    // ...and the floored form is the identity that actually holds.
+    expect(Math.max(0, sum - s.onhandByPlantUnmatched)).toBeCloseTo(s.onhand)
   })
 
   it('reports no unmatched tonnage in the ordinary case', () => {

--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -778,6 +778,22 @@ export function buildPlantPipelineSummary(productions, dispatches, coils, babyCo
   const inPrev = (p) => dashMonthKey(p.dateOfProduction) === PREV && dashDay(p.dateOfProduction) <= DAY
   const dispMt = (rows) => rows.reduce((t, d) =>
     t + (d.bundleEntries || []).reduce((u, e) => u + num(e.weight), 0), 0)
+  const dispMtWhen = (rows, pred) => dispMt(rows.filter(pred))
+  const dispInMonth = (d) => dashMonthKey(d.dateOfDispatch) === MONTH && d.dateOfDispatch <= D
+
+  // ── The movement columns (ticket #130): Opening + Production − Dispatch = Current ───────────────
+  // OPENING IS THE COMPLEMENT, not its own date filter: everything the register holds MINUS what
+  // this month carries. A row with no date at all is a data fault, and the complement keeps its
+  // tonnage on the opening side rather than dropping it out of the identity entirely — a movement
+  // table that silently loses steel is worse than one that shows it sitting in the wrong column.
+  //
+  // `fromMonth` is this month ONWARDS, so it also catches rows dated later than D (a forward-dated
+  // entry, or a back-dated report). Those cannot be in Opening and are not in the MTD columns
+  // either, so they are the exact residual between the identity and `fgLeft` — reported as
+  // `producedAfterD` / `invoicedAfterD` rather than absorbed. `invoicedAfterD` mirrors
+  // `regionSplit.diagnostics.invoicedAfterD`, which already names the same tonnage on the region cut.
+  const prodFromMonth = (p) => dashMonthKey(p.dateOfProduction) >= MONTH
+  const dispFromMonth = (d) => dashMonthKey(d.dateOfDispatch) >= MONTH
 
   // Every stored plant value actually PRESENT across the four registers. A plant with nothing gets
   // no row (there is nothing to say about it); a value the master does not know still keeps its
@@ -802,6 +818,7 @@ export function buildPlantPipelineSummary(productions, dispatches, coils, babyCo
       plant: id, name: plantLabel(id, master),
       producedMtd: 0, producedPrev: 0, producedD1: 0, producedD: 0,
       producedAll: 0, invoicedAll: 0, fgLeft: 0,
+      openingFg: 0, invoicedMtd: 0, producedAfterD: 0, invoicedAfterD: 0,
       fullCoilLeft: 0, babyLeft: 0, rmTotal: 0, productionRows: 0,
     }
     row.producedMtd += prodMt(prod, inMonth)
@@ -813,6 +830,13 @@ export function buildPlantPipelineSummary(productions, dispatches, coils, babyCo
     row.producedAll += prodMt(prod, () => true)
     row.invoicedAll += dispMt(disp)
     row.fgLeft = row.producedAll - row.invoicedAll
+    // Movement: what this plant held on the 1st, what it invoiced this month, and the tonnage dated
+    // past D that belongs to neither column.
+    row.invoicedMtd += dispMtWhen(disp, dispInMonth)
+    row.producedAfterD += prodMt(prod, p => prodFromMonth(p) && !inMonth(p))
+    row.invoicedAfterD += dispMtWhen(disp, d => dispFromMonth(d) && !dispInMonth(d))
+    row.openingFg = (row.producedAll - prodMt(prod, prodFromMonth))
+      - (row.invoicedAll - dispMtWhen(disp, dispFromMonth))
     row.fullCoilLeft += fullCoilLeft
     row.babyLeft += babyLeft
     row.rmTotal = row.fullCoilLeft + row.babyLeft
@@ -829,6 +853,7 @@ export function buildPlantPipelineSummary(productions, dispatches, coils, babyCo
     producedD1: sum('producedD1'), producedD: sum('producedD'),
     fgLeft: sum('fgLeft'), fullCoilLeft: sum('fullCoilLeft'),
     babyLeft: sum('babyLeft'), rmTotal: sum('rmTotal'),
+    openingFg: sum('openingFg'), invoicedMtd: sum('invoicedMtd'),
   }
 
   // The company figures, computed UNGROUPED over the same rows — a real second pass, not this
@@ -843,6 +868,15 @@ export function buildPlantPipelineSummary(productions, dispatches, coils, babyCo
     diff(totals.producedMtd, allProducedMtd), diff(totals.fgLeft, allFgLeft),
     diff(totals.fullCoilLeft, allFullCoilLeft), diff(totals.babyLeft, allBabyLeft))
 
+  // The movement identity, per plant and on the total: what a plant held on the 1st, plus what it
+  // made, less what it invoiced, IS what it holds now. The two after-D terms close it exactly —
+  // tonnage dated past the report date is in `fgLeft` (which has no date cap) but in neither
+  // Opening nor the MTD columns, so it is added back rather than left as an unexplained gap.
+  const afterD = (r) => r.producedAfterD - r.invoicedAfterD
+  const movementGap = (r) => diff(r.openingFg + r.producedMtd - r.invoicedMtd + afterD(r), r.fgLeft)
+  const maxMovementGap = plants.reduce((m, r) => Math.max(m, movementGap(r)),
+    movementGap({ ...totals, producedAfterD: sum('producedAfterD'), invoicedAfterD: sum('invoicedAfterD') }))
+
   return {
     date: D,
     month: MONTH,
@@ -853,6 +887,10 @@ export function buildPlantPipelineSummary(productions, dispatches, coils, babyCo
       fgTiesToAllPlants: diff(totals.fgLeft, allFgLeft) <= 0.01,
       rmTiesToAllPlants: diff(totals.fullCoilLeft, allFullCoilLeft) <= 0.01
         && diff(totals.babyLeft, allBabyLeft) <= 0.01,
+      // Opening + Production − Dispatch = Current, asserted on every row AND on the total. A breach
+      // means the movement columns describe a different register from the FG figure above them.
+      movementTiesToFgLeft: maxMovementGap <= 0.01,
+      maxMovementGap,
       maxAbsDiff,
       allPlantsProducedMtd: allProducedMtd,
       allPlantsFgLeft: allFgLeft,
@@ -868,6 +906,12 @@ export function buildPlantPipelineSummary(productions, dispatches, coils, babyCo
       // RM moved has the answer without re-deriving it (ADR-0007).
       babyNotCounted: liveBabies.reduce((t, b) =>
         t + (babyCoilIsStock(b, consumedByBaby) ? 0 : Math.max(0, babyCoilFree(b, consumedByBaby))), 0),
+      // Tonnage dated LATER than D. Non-zero on a back-dated report or a forward-dated entry; it
+      // sits in Current but in neither Opening nor the MTD columns, so the movement caption names it
+      // rather than letting a reader hunt for the difference. Mirrors the region cut's own
+      // `invoicedAfterD`, which reports the same tonnage on a different grouping.
+      producedAfterD: sum('producedAfterD'),
+      invoicedAfterD: sum('invoicedAfterD'),
       plantsPresent: plants.length,
     },
   }

--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -729,6 +729,10 @@ export function buildServableSummary(orders, dispatches, skus, {
       // Never folded into the totals as zero — map the state on the Sales tab and it resolves.
       unmappedUnconfirmed: unmapped ? unmapped.unconfirmed : 0,
       unmappedDistributors: unmapped ? unmapped.distributors : 0,
+      // How many regions could answer the servable question at all. ZERO means the workbook's
+      // Pending to Dispatch is UNKNOWN, not zero — `totals` sums only the regions that have an
+      // answer, so with none it reads a confident 0 that means the opposite of what it says.
+      regionsAnswering: regions.filter(g => g.servableUnconfirmed != null).length,
       // Sizes ordered for more than the area's free stock, biggest gap first — the production list.
       shortSizes: shortSizes.sort((a, b) => b.short - a.short),
       sizesWithStock: cells.size,
@@ -1367,6 +1371,8 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   // saying different things about whose tonnage the column holds. Empty when there is nothing to
   // name. `ps` is the split itself, used again by the BY PLANT block further down.
   const ps = data.plantSplit
+  const sv = data.servable
+  const svKnown = sv.diagnostics.regionsAnswering > 0
   const invScope = ps.invoicing.suffix
   // Whether this workbook covers the whole company or one plant. `fileSuffix` is what #121 already
   // sets for a scoped download (alongside the `— <Plant> only` sheet titles), so it is the existing
@@ -1376,9 +1382,17 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   const allPlantsScope = !opts.fileSuffix
   const cards = [
     { h: 'BEST ESTIMATE (MT)', v: naMt(k.bestEstimate), s: 'Σ distributor estimates', c: DASH.be },
-    { h: 'ORDER PIPELINE (MT)', v: naMt(k.orderPipeline), s: 'Invoiced + Conf + Non-Conf', c: DASH.pipeline },
+    { h: 'INDENT (MT)', v: naMt(k.orderPipeline), s: 'Invoiced + Conf + Non-Conf', c: DASH.pipeline },
     { h: 'INVOICED MTD (MT)', v: naMt(k.invoicedMtd), s: (k.invoicedPctPipeline == null ? '' : `${Math.round(k.invoicedPctPipeline)}% of pipeline`) + invScope, c: DASH.invoiced },
-    { h: 'PENDING TO SERVE (MT)', v: naMt(k.pending), s: 'Conf + Non-Conf', c: DASH.pending },
+    // THE RENAME (commit 5). This card used to print the whole open book under the name the daily
+    // message gives to a tenth of it. It now carries the message's figure — Confirmed plus only the
+    // unconfirmed tonnage the floor can actually cover — and the wide book keeps the name it already
+    // has everywhere else, "Pending to Serve", on the Order Status table and the BY PLANT block.
+    // N/A, never 0, when no region can answer: `totals` sums only the regions that have an answer,
+    // so with none at all a plain sum reads a confident zero meaning "nothing is servable" — the
+    // opposite of "nobody has mapped these states yet".
+    { h: 'PENDING TO DISPATCH (MT)', v: naMt(svKnown ? sv.totals.pendingToDispatch : null),
+      s: 'Conf + Servable–Unconf', c: DASH.pending },
     { h: 'PHYSICAL INVENTORY (MT)', v: naMt(k.physicalInventory), s: 'produced − invoiced', c: DASH.physinv },
     { h: 'INV. AGEING (DAYS AVG)', v: naMt(k.invAgeingDaysAvg), s: 'FIFO, tonnage-wtd', c: DASH.ageing },
   ]
@@ -1431,7 +1445,7 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   const os = data.orderStatus, op = data.orderPipelineMtd, ip = data.inventoryProduction
   let leftRow = table(8, 1, 4, 5, 6, 'ORDER STATUS SUMMARY', DASH.bandStatus, 'Metric', [
     { label: 'Best Estimate (BE)', value: naMt(os.bestEstimate) },
-    { label: 'Orders Received (Total Orders)', value: os.ordersReceived },
+    { label: 'Indent', value: os.ordersReceived },
     { label: `Invoiced MTD${invScope}`, value: os.invoicedMtd },
     { label: 'Confirmed Pending Invoice', value: os.confirmed },
     { label: 'Non-Confirmed Orders', value: os.nonConfirmed },
@@ -1447,8 +1461,8 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
     { label: 'Ageing 61–90 d', value: ip.buckets.d61_90, indent: true },
     { label: 'Ageing 90+ d', value: ip.buckets.d90plus, indent: true },
   ])
-  const rightEnd = table(8, 7, 10, 11, 12, 'ORDER PIPELINE — MTD', DASH.bandPipeline, 'Line', [
-    { label: 'Total Orders', value: op.totalOrders },
+  const rightEnd = table(8, 7, 10, 11, 12, 'ORDER BOOK — MTD', DASH.bandPipeline, 'Line', [
+    { label: 'Indent', value: op.totalOrders },
     { label: 'Current Month Orders', value: op.ordersMonthIntake },
     { label: `Invoiced Orders MTD${invScope}`, value: op.invoicedMtd },
     { label: `Invoiced MTD (Prev Month, same days)${invScope}`, value: op.invoicedPrev },
@@ -1492,7 +1506,7 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   psBand.alignment = { horizontal: 'left', vertical: 'middle' }
   pr += 1
   const psHead = psRow(pr, ['Plant', `Invoiced MTD${invScope}`,
-    'Confirmed', 'Non-Conf', 'Pending to Dispatch', 'Total Orders'])
+    'Confirmed', 'Non-Conf', 'Pending to Serve', 'Indent'])
   psHead.forEach(c => { c.font = { bold: true }; c.fill = fill(COLOR.head) })
   ws.getRow(pr).height = 26
   pr += 1
@@ -1520,7 +1534,7 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   const psTied = ps.checks.invoicedTiesToAllPlants && ps.checks.pendingTiesToAllPlants
   psNote.value = (psTied ? '' : `⚠ THE PLANT ROWS DO NOT ADD UP TO THE TOTALS ABOVE (out by ${ps.checks.maxAbsDiff.toFixed(3)} MT) — do not circulate this sheet. `)
     + (ps.invoicing.note ? ps.invoicing.note + ' ' : '')
-    + `Pending to Dispatch comes from each ORDER line's plant, Invoiced from each INVOICE line's plant — both the ERP's own Ship From Code, neither typed. ${UNATTRIBUTED_PLANT} is a line whose plant the ERP did not let us resolve: its tonnage stays inside every total above, exactly as ${UNMAPPED_REGION} does on the region sheet, because a labelling gap is not missing weight. A plant listed with 0 Invoiced holds orders and has invoiced nothing this month — it is not an empty row. Values are exact; only the display is rounded.`
+    + `Pending to Serve (Confirmed + Non-Confirmed — the whole open book, NOT the stock-backed Pending to Dispatch on the KPI card above) comes from each ORDER line's plant, Invoiced from each INVOICE line's plant — both the ERP's own Ship From Code, neither typed. ${UNATTRIBUTED_PLANT} is a line whose plant the ERP did not let us resolve: its tonnage stays inside every total above, exactly as ${UNMAPPED_REGION} does on the region sheet, because a labelling gap is not missing weight. A plant listed with 0 Invoiced holds orders and has invoiced nothing this month — it is not an empty row. Values are exact; only the display is rounded.`
   psNote.font = psTied ? { italic: true, size: 9, color: { argb: 'FF6B7280' } } : { bold: true, size: 9, color: { argb: 'FFB91C1C' } }
   psNote.alignment = { wrapText: true, vertical: 'top' }
   ws.getRow(pr).height = 46
@@ -1598,7 +1612,7 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   // The Invoiced header carries its scope for the same reason the Dashboard's card does (#127):
   // Total Orders beside it is Invoiced + every plant's pending, so the two columns are not like for
   // like and the sheet says so rather than leaving the reader to find out.
-  styleHeaderRow(ws3.addRow(['Region', 'State', 'Distributor', 'Plan (MT)', 'Total Orders (MT)',
+  styleHeaderRow(ws3.addRow(['Region', 'State', 'Distributor', 'Plan (MT)', 'Indent (MT)',
     `Invoiced MTD (MT)${invScope}`, '% of Plan', 'Gap to Plan (MT)']))
 
   const PCT_1DP = '0.0%'     // a fraction in the cell; Excel renders it as a percentage
@@ -1648,7 +1662,7 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   const unalloc = ws3.addRow([`Of which invoiced by distributors with no Plan: ${dr.unallocatedInvoiced.toFixed(1)} MT`])
   ws3.mergeCells(`A${unalloc.number}:H${unalloc.number}`)
   unalloc.getCell(1).font = { bold: true, size: 9, color: { argb: 'FF92400E' } }
-  const note3 = ws3.addRow([`Total Orders blends two time windows: Invoiced MTD is this month, while Confirmed and Non-Confirmed are an all-time order-book snapshot of orders not yet delivered. A distributor sitting on an old unserved backlog therefore reads as a heavy orderer. Plan is a typed monthly target per distributor; the Dashboard Best Estimate KPI is their sum, not a separate figure, and % of Plan measures INVOICED tonnage against it only. A distributor with no Plan still shows its invoiced tonnage, and that tonnage is counted in the actual but not in the plan, so % of Plan can exceed 100% without the plan having been beaten. Region comes from the state → region master, and State from the distributor’s own order and invoice lines. A state nobody has mapped groups under Unmapped, and so does a distributor with no lines at all to derive a state from — a Plan set before the first order lands there. Either way the tonnage still counts in the grand total.${ps.invoicing.note ? ' ' + ps.invoicing.note : ''}`])
+  const note3 = ws3.addRow([`Indent (Invoiced MTD + Confirmed + Non-Confirmed) blends two time windows: Invoiced MTD is this month, while Confirmed and Non-Confirmed are an all-time order-book snapshot of orders not yet delivered. A distributor sitting on an old unserved backlog therefore reads as a heavy orderer. Plan is a typed monthly target per distributor; the Dashboard Best Estimate KPI is their sum, not a separate figure, and % of Plan measures INVOICED tonnage against it only. A distributor with no Plan still shows its invoiced tonnage, and that tonnage is counted in the actual but not in the plan, so % of Plan can exceed 100% without the plan having been beaten. Region comes from the state → region master, and State from the distributor’s own order and invoice lines. A state nobody has mapped groups under Unmapped, and so does a distributor with no lines at all to derive a state from — a Plan set before the first order lands there. Either way the tonnage still counts in the grand total.${ps.invoicing.note ? ' ' + ps.invoicing.note : ''}`])
   ws3.mergeCells(`A${note3.number}:H${note3.number}`)
   note3.getCell(1).font = { italic: true, size: 9, color: { argb: 'FF6B7280' } }
   note3.getCell(1).alignment = { wrapText: true, vertical: 'top' }

--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -917,7 +917,11 @@ export function buildPlantPipelineSummary(productions, dispatches, coils, babyCo
   }
 }
 
-export function buildMtdDashboardData(orders, dispatches, productions, skus, { date = today(), estimates = [], stateRegions = null, plants = null, distributors = null } = {}) {
+export function buildMtdDashboardData(orders, dispatches, productions, skus, { date = today(), estimates = [], stateRegions = null, plants = null, distributors = null,
+  // NAMED, never positional. Roughly 35 call sites in reports.test.js already pass the options
+  // bag as the 5th argument; a 5th positional `coils` would have swallowed every one of them —
+  // the DATE included — and the whole suite would have quietly reported on today instead of D.
+  coils = null, babyCoils = null } = {}) {
   const D = date, D1 = dashShift(D, -1), D2 = dashShift(D, -2)
   const MONTH = dashMonthKey(D), PREV = dashPrevMonth(D), DAY = dashDay(D)
   // The plant Best Estimate is DERIVED — Σ of the month's distributor estimates, never typed
@@ -1055,9 +1059,43 @@ export function buildMtdDashboardData(orders, dispatches, productions, skus, { d
   // has not been shown.
   const plantSplit = buildPlantMtdSummary(orders, dispatches, { date: D })
 
+  // ── The servable split and the plant pipeline (workbook parity, commit 3) ──────────────────────
+  // Both are carried here so the workbook reads the SAME functions the daily WhatsApp message does.
+  // The message was reshaped in 8d5de14 and the workbook was left behind; two builders answering one
+  // question two ways is exactly how the sheet and the broadcast drift apart in a reader's hands.
+  // Nothing is drawn from these yet — this step only proves they arrive intact.
+  const servable = buildServableSummary(orders, dispatches, skus,
+    { date: D, productions, stateRegions, plants, distributors })
+
+  // ── `null` is not `[]` ─────────────────────────────────────────────────────────────────────────
+  // `notDeleted(null)` returns `[]`, so an unsupplied register does not fail — it computes a
+  // perfectly confident RM of ZERO. A workbook printing "0 T of steel" is not a gap a reader can
+  // see; it is a lie they act on. So the absence is carried as a FLAG and rendered "?", never 0.
+  //
+  // BOTH registers or neither: the full-coil figure excludes mothers that were slit, and the set of
+  // slit mothers is read off `babyCoils`. Supply coils alone and every slit mother counts as stock
+  // again — steel already cut up, re-reported as whole. That is a worse answer than "unknown".
+  const rmKnown = coils != null && babyCoils != null
+  const pipelineRaw = buildPlantPipelineSummary(productions, dispatches, coils, babyCoils, { date: D })
+  const blankRm = (o) => ({ ...o, fullCoilLeft: null, babyLeft: null, rmTotal: null })
+  const pipeline = rmKnown ? pipelineRaw : {
+    ...pipelineRaw,
+    plants: pipelineRaw.plants.map(blankRm),
+    totals: blankRm(pipelineRaw.totals),
+    // A tie-out check over a figure nobody supplied would read `true` — 0 matching 0. Unknown is not
+    // a passing check, so it reads null and the sheet cannot claim RM reconciles.
+    checks: { ...pipelineRaw.checks, rmTiesToAllPlants: null, allPlantsFullCoilLeft: null, allPlantsBabyLeft: null },
+    diagnostics: { ...pipelineRaw.diagnostics, unattributedRmTotal: null, babyNotCounted: null },
+  }
+
   return {
     date: D, month: MONTH, prevMonth: PREV, day: DAY, daysRemaining: remaining, bestEstimate: BE,
     plantSplit,
+    servable,
+    pipeline,
+    // What the pipeline block is allowed to claim. `rmKnown: false` means the caller never handed
+    // over the coil registers, so every RM cell above is null and the renderer must print "?".
+    pipelineScope: { rmKnown },
     distributorRegions,
     distributorSku: { rows: distSkuRows },
     kpis: { bestEstimate: BE, orderPipeline: totalOrders, invoicedMtd, invoicedPctPipeline, pending, physicalInventory, invAgeingDaysAvg, unmatchedDispatch: unmatched },

--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -1340,13 +1340,20 @@ const DASH = {
 const MT_1DP = '#,##0.0'
 const naMt = (v) => (v == null ? 'N/A' : Number(v))                       // numeric cell (MT or a ratio): number → numFmt, null → "N/A"
 const naPct = (v) => (v == null ? 'N/A' : `${Math.round(Number(v))}%`)      // percentage cell as text (whole number)
+// UNKNOWN, not zero. Used where the workbook was never handed the register behind a figure (RM
+// without its coils) or where no region can answer (servable under an unmapped book). A sheet that
+// prints 0 there states a fact it does not have; "?" is the only honest cell.
+const qMt = (v) => (v == null ? '?' : Number(v))
 
 export async function generateMtdDashboardReport(orders, dispatches, productions, skus, opts = {}) {
   const date = opts.date || today()
   const company = opts.companyName || 'JSW One Pipes & Tubes'
   const data = buildMtdDashboardData(orders, dispatches, productions, skus,
     { date, estimates: opts.estimates ?? [], stateRegions: opts.stateRegions ?? null,
-      plants: opts.plants ?? null, distributors: opts.distributors ?? null })
+      plants: opts.plants ?? null, distributors: opts.distributors ?? null,
+      // Undefined, not [], when the caller has no register: `notDeleted([])` is a confident zero
+      // and `notDeleted(null)` is the same zero. Only ABSENCE reaches `rmKnown` as unknown.
+      coils: opts.coils ?? null, babyCoils: opts.babyCoils ?? null })
   const ExcelJS = await loadExcelJS()
   const wb = new ExcelJS.Workbook()
   const cL = (n) => String.fromCharCode(64 + n)
@@ -1372,6 +1379,7 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   // name. `ps` is the split itself, used again by the BY PLANT block further down.
   const ps = data.plantSplit
   const sv = data.servable
+  const pipe = data.pipeline
   const svKnown = sv.diagnostics.regionsAnswering > 0
   const invScope = ps.invoicing.suffix
   // Whether this workbook covers the whole company or one plant. `fileSuffix` is what #121 already
@@ -1442,6 +1450,21 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
     return r
   }
 
+  // A 6-cell row across the 12-column grid — the shape every block below the cards shares.
+  // Tonnage renders to ONE DECIMAL (the cards above are whole): a plant holding 0.4 MT must not
+  // read as a plant holding nothing. The format alone rounds it; every cell holds the exact value,
+  // so the totals keep tying to the cards.
+  const psPairs = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]]
+  const psRow = (rowNum, values) => psPairs.map(([c1, c2], i) => {
+    ws.mergeCells(`${cL(c1)}${rowNum}:${cL(c2)}${rowNum}`)
+    const c = ws.getCell(rowNum, c1)
+    c.value = values[i]
+    c.alignment = { horizontal: i === 0 ? 'left' : 'right', vertical: 'middle', wrapText: true }
+    if (typeof values[i] === 'number') c.numFmt = MT_1DP
+    c.border = ALL_BORDERS
+    return c
+  })
+
   const os = data.orderStatus, op = data.orderPipelineMtd, ip = data.inventoryProduction
   let leftRow = table(8, 1, 4, 5, 6, 'ORDER STATUS SUMMARY', DASH.bandStatus, 'Metric', [
     { label: 'Best Estimate (BE)', value: naMt(os.bestEstimate) },
@@ -1449,12 +1472,23 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
     { label: `Invoiced MTD${invScope}`, value: os.invoicedMtd },
     { label: 'Confirmed Pending Invoice', value: os.confirmed },
     { label: 'Non-Confirmed Orders', value: os.nonConfirmed },
+    // The three lines that make the rename readable. A reader holding this sheet beside a screen
+    // still saying "Pending to Dispatch = 4,542" can see both figures here and which is which.
+    { label: 'Servable – Unconfirmed', value: qMt(svKnown ? sv.totals.servableUnconfirmed : null), indent: true },
+    { label: 'Pending to Serve', value: os.confirmed + os.nonConfirmed },
+    { label: 'Pending to Dispatch', value: qMt(svKnown ? sv.totals.pendingToDispatch : null) },
     { label: 'Invoice % of BE', value: naPct(os.invoicePctOfBe), strong: true },
   ])
   leftRow += 1 // spacer between the two stacked left-hand tables
   const leftEnd = table(leftRow, 1, 4, 5, 6, 'INVENTORY & PRODUCTION', DASH.bandInv, 'Metric', [
     { label: 'Fresh Production MTD', value: ip.freshProductionMtd },
+    { label: 'Produced (Prev Month, same days)', value: pipe.totals.producedPrev },
     { label: 'Physical Inventory', value: ip.physicalInventory },
+    // RM is a POSITION, not a movement: a coil has no "dispatch", so there is no movement table for
+    // it and none is implied. "?" when the registers were never supplied — see qMt.
+    { label: 'RM — Full Coil', value: qMt(pipe.totals.fullCoilLeft) },
+    { label: 'RM — Baby Coil', value: qMt(pipe.totals.babyLeft) },
+    { label: 'RM Total', value: qMt(pipe.totals.rmTotal) },
     { label: 'Inventory Ageing (Days Avg)', value: naMt(ip.invAgeingDaysAvg) },
     { label: 'Ageing 0–30 d', value: ip.buckets.d0_30, indent: true },
     { label: 'Ageing 31–60 d', value: ip.buckets.d31_60, indent: true },
@@ -1478,7 +1512,11 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
 
   // ── BY PLANT — the split, directly BENEATH the totals it breaks down (ticket #127) ────────────
   // Not a replacement for a single figure above it. The ALL PLANTS row is the same tonnage as the
-  // INVOICED MTD and PENDING TO SERVE cards, and `plantSplit.checks` has already asserted that.
+  // INVOICED MTD card and the Pending to Serve line on the Order Status table, and
+  // `plantSplit.checks` has already asserted that. NOTE since commit 5: its Pending column is the
+  // WIDE book and no longer matches the PENDING TO DISPATCH card, which now carries the
+  // stock-backed figure. That is why the column is named Pending to Serve and why the note below
+  // spells the difference out — the two sit inches apart on one sheet.
   //
   // The Invoiced column carries its scope in its own header, because this is the one place in the
   // workbook where one plant's Invoiced sits directly beside four plants' Pending. Naming it is the
@@ -1487,17 +1525,53 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   // Tonnage renders to ONE DECIMAL (the cards above are whole) — a plant holding 0.4 MT must not
   // read as a plant holding nothing. The cell format alone rounds it; every cell holds the exact
   // value, so the ALL PLANTS row keeps tying to the cards.
-  const psPairs = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]]
-  const psRow = (rowNum, values) => psPairs.map(([c1, c2], i) => {
-    ws.mergeCells(`${cL(c1)}${rowNum}:${cL(c2)}${rowNum}`)
-    const c = ws.getCell(rowNum, c1)
-    c.value = values[i]
-    c.alignment = { horizontal: i === 0 ? 'left' : 'right', vertical: 'middle', wrapText: true }
-    if (typeof values[i] === 'number') c.numFmt = MT_1DP
-    c.border = ALL_BORDERS
-    return c
-  })
+  // ── One banded block: title, header, body rows, a bold total, an italic note ────────────────
+  // Every block below the KPI cards has this shape, and sharing the renderer is what keeps them
+  // looking like one sheet. `bad` flips the note red and is how a block states its own tie-out
+  // failure: the house rule is that a breakdown which does not add up to the headline above it is
+  // WORSE than no breakdown, so the sheet has to say so on its own face rather than look fine.
+  const block = (startRow, title, argb, headers, bodyRows, totalRow, note, bad = false) => {
+    let r = startRow
+    ws.mergeCells(`${cL(1)}${r}:${cL(N)}${r}`)
+    const b = ws.getCell(r, 1)
+    b.value = title; b.font = { bold: true, color: { argb: 'FFFFFFFF' } }
+    b.fill = fill(argb); b.alignment = { horizontal: 'left', vertical: 'middle' }
+    r += 1
+    psRow(r, headers).forEach(c => { c.font = { bold: true }; c.fill = fill(COLOR.head) })
+    ws.getRow(r).height = 26
+    r += 1
+    if (!bodyRows.length) { psRow(r, ['Nothing to report']); r += 1 }
+    bodyRows.forEach(vals => { psRow(r, vals); r += 1 })
+    if (totalRow) {
+      psRow(r, totalRow).forEach(c => { c.font = { bold: true }; c.fill = fill(COLOR.grand) })
+      r += 1
+    }
+    ws.mergeCells(`${cL(1)}${r}:${cL(N)}${r}`)
+    const n = ws.getCell(r, 1)
+    n.value = (bad ? '⚠ THIS BLOCK DOES NOT ADD UP TO THE FIGURES ABOVE IT — do not circulate this sheet. ' : '') + note
+    n.font = bad ? { bold: true, size: 9, color: { argb: 'FFB91C1C' } }
+      : { italic: true, size: 9, color: { argb: 'FF6B7280' } }
+    n.alignment = { wrapText: true, vertical: 'top' }
+    ws.getRow(r).height = 34
+    return r + 2
+  }
+
+  // ── SERVABLE BY REGION — the block the KPI card's new meaning rests on ────────────────────────
+  // Counted once per (region, size), never per distributor: inside a service area the stock is
+  // shared and reserved to nobody, so adding per-distributor servable figures would invent steel
+  // the plant does not hold (ADR-0002). An Unmapped region reads "?" in both derived columns —
+  // no region means no service area, so the question has no answer, which is not the same as zero.
   let pr = Math.max(leftEnd, rightEnd) + 1
+  const svTied = sv.checks.confirmedTiesToBook && sv.checks.unconfirmedTiesToBook
+    && sv.checks.servableWithinUnconfirmed
+  pr = block(pr, 'SERVABLE BY REGION — WHAT THE FLOOR CAN COVER TODAY', DASH.bandStatus,
+    ['Region', 'Confirmed', 'Non-Conf', 'Servable – Unconf', 'Pending to Dispatch'],
+    sv.regions.map(g => [g.region, g.confirmed, g.unconfirmed,
+      qMt(g.servableUnconfirmed), qMt(g.pendingToDispatch)]),
+    ['TOTAL (= the Pending to Dispatch card)', sv.totals.confirmed, sv.totals.unconfirmed,
+      qMt(svKnown ? sv.totals.servableUnconfirmed : null), qMt(svKnown ? sv.totals.pendingToDispatch : null)],
+    `Servable – Unconfirmed is the part of Non-Confirmed the serving plants can cover from stock on hand RIGHT NOW, after Confirmed has taken its claim. Pending to Dispatch = Confirmed + Servable – Unconfirmed, and it is the KPI card above. It is NOT the whole order book: that is Pending to Serve (${(sv.totals.confirmed + sv.totals.unconfirmed).toFixed(1)} MT), on the Order Status table and in the BY PLANT block below. Counted once per region and size — never per distributor, because inside a service area stock is reserved to nobody and adding those figures would report more steel than the plants hold (ADR-0002). "?" means the region has no service area to read stock from${sv.diagnostics.unmappedUnconfirmed > 0 ? `; ${sv.diagnostics.unmappedUnconfirmed.toFixed(1)} MT of Non-Confirmed sits there unanswerable until its states are mapped on the Sales tab` : ''}. Values are exact; only the display is rounded.`,
+    !svTied)
   ws.mergeCells(`${cL(1)}${pr}:${cL(N)}${pr}`)
   const psBand = ws.getCell(pr, 1)
   psBand.value = 'BY PLANT — WHERE THE TONNAGE ABOVE ACTUALLY SITS'
@@ -1538,6 +1612,44 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   psNote.font = psTied ? { italic: true, size: 9, color: { argb: 'FF6B7280' } } : { bold: true, size: 9, color: { argb: 'FFB91C1C' } }
   psNote.alignment = { wrapText: true, vertical: 'top' }
   ws.getRow(pr).height = 46
+  pr += 2
+
+  // ── STOCK MOVEMENT — where this month's finished tonnage came from and went ───────────────────
+  // Opening + Production − Dispatch = Current, per plant AND on the total. Opening is built as a
+  // COMPLEMENT (everything the register holds, less what this month carries) rather than its own
+  // `date < 1st` filter: an undated production row is a data fault, and a date test would drop it
+  // from Opening while Current kept it — the movement columns would quietly lose steel. Tonnage
+  // dated LATER than the report date sits in Current but in neither Opening nor the MTD columns,
+  // so the note names it instead of leaving an unexplained gap.
+  //
+  // Finished pipe only. A coil has no "dispatch", so raw material gets a POSITION block below and
+  // no movement table — inventing one would imply a flow the data cannot support.
+  const mv = pipe.totals
+  const mon1 = new Date(date + 'T00:00:00Z').toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })
+  const afterD = pipe.diagnostics.producedAfterD || pipe.diagnostics.invoicedAfterD
+    ? ` ${(pipe.diagnostics.producedAfterD).toFixed(1)} MT produced and ${(pipe.diagnostics.invoicedAfterD).toFixed(1)} MT invoiced are dated AFTER ${ddmmyyyy(date)}: they are inside Current but in neither Opening nor the two MTD columns, which is the whole of the difference.`
+    : ''
+  pr = block(pr, `STOCK MOVEMENT — ${monthLabel} (FINISHED PIPE)`, DASH.bandInv,
+    ['Plant', `Opening (01-${mon1})`, 'Production', 'Dispatch', 'Current'],
+    pipe.plants.map(r => [r.name, r.openingFg, r.producedMtd, r.invoicedMtd, r.fgLeft]),
+    [`${allPlantsScope ? 'ALL PLANTS' : 'TOTAL (this workbook’s plant only)'} (= Physical Inventory above)`,
+      mv.openingFg, mv.producedMtd, mv.invoicedMtd, mv.fgLeft],
+    `Opening + Production − Dispatch = Current, on every row and on the total. Opening is what the plant held on the 1st, reached as everything it has ever made less everything this month carries — not a date filter, so a row the ERP left undated keeps its tonnage here instead of vanishing from the identity. Current is the same tonnage as the PHYSICAL INVENTORY card above, reached a completely different way (Σ produced − Σ invoiced against Σ positive on-hand less over-shipment), which is what makes this a real cross-check rather than arithmetic checking itself.${afterD} Finished pipe only — raw material has no dispatch, so it is shown as a position below and not as a movement. Values are exact; only the display is rounded.`,
+    !pipe.checks.movementTiesToFgLeft)
+
+  // ── BY PLANT — RAW MATERIAL: a position, never a movement ─────────────────────────────────────
+  // Baby coil reads `babyCoilStock`: the scrap floor and the operator's `consumed` flag (ADR-0007),
+  // which is the Dashboard's own Baby Coils Left card. A plain Σ max(0, weight − consumed) is a
+  // DIFFERENT and larger number, and having both in circulation is how a card and a workbook start
+  // disagreeing about the same steel.
+  pr = block(pr, 'BY PLANT — RAW MATERIAL (POSITION AS ON REPORT DATE)', DASH.bandPlant,
+    ['Plant', 'Full Coil', 'Baby Coil', 'RM Total'],
+    pipe.plants.map(r => [r.name, qMt(r.fullCoilLeft), qMt(r.babyLeft), qMt(r.rmTotal)]),
+    [allPlantsScope ? 'ALL PLANTS' : 'TOTAL (this workbook’s plant only)',
+      qMt(mv.fullCoilLeft), qMt(mv.babyLeft), qMt(mv.rmTotal)],
+    `Full Coil is mother coils not yet slit; Baby Coil is slit strip still free, after the ${'\u2265'}0.2 MT scrap floor and the operator's consumed flag (ADR-0007) — the same rule as the Dashboard's Baby Coils Left card, so the two cannot disagree. ${pipe.diagnostics.babyNotCounted == null ? '' : `${pipe.diagnostics.babyNotCounted.toFixed(1)} MT of baby-coil weight is excluded by that rule.`} "?" means this workbook was never handed the coil registers, NOT that the plants hold no steel — regenerate from the Reports tab to fill it. There is deliberately no movement table for raw material: a coil is not dispatched, so Opening + In − Out has nothing to measure. Values are exact; only the display is rounded.`,
+    pipe.checks.rmTiesToAllPlants === false)
+  pr -= 2
 
   // ── Sheet 2 — every SKU with on-hand inventory > MIN_ONHAND_MT (MT) + FIFO age buckets ──
   const ws2 = wb.addWorksheet(`SKU Ageing (>${MIN_ONHAND_MT} MT)`, {

--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -1047,6 +1047,11 @@ export function buildMtdDashboardData(orders, dispatches, productions, skus, { d
         // The renderer prints "?" for null; App.jsx already renders it as an em dash.
         pending: s.pending, onhand: s.onhand ?? null, freeStock: s.freeStock ?? null,
         allConfirmed: s.allConfirmed ?? null, shortBy: s.shortBy ?? null,
+        // ON FLOOR, BY PLANT. Same `?? null` discipline as the columns above: an Unmapped
+        // distributor has no service area, so there is no set of plants to ask — that is null and
+        // renders "?", not an empty object which would render four confident dashes.
+        onhandByPlant: s.onhandByPlant ?? null,
+        onhandByPlantUnmatched: s.onhandByPlantUnmatched ?? null,
       })
     })
   })
@@ -1787,51 +1792,84 @@ export async function generateMtdDashboardReport(orders, dispatches, productions
   // stock than the plant physically holds; and the sheet's rows only exist where an order line
   // carried a SKU code, so a Pending / Invoiced total would not tie to the Dashboard either. It is a
   // detail listing — the totals live on the Dashboard sheet (ADR-0002). ──
+  // Column order groups the plants by the region they serve — South's pair, then West's — so a
+  // distributor's two real cells sit together instead of straddling two dashes.
+  const areaMaster = plantMaster(opts.plants ?? null)
+  const plantCols = []
+  REGIONS.forEach(rg => [...plantsServingRegion(rg, areaMaster)]
+    .sort((a, b) => areaMaster.findIndex(x => x.id === a) - areaMaster.findIndex(x => x.id === b))
+    .forEach(id => { if (!plantCols.includes(id)) plantCols.push(id) }))
+  const P1 = 9, P2 = 8 + plantCols.length, FREEC = P2 + 1, SHORTC = P2 + 2
+
   const ws4 = wb.addWorksheet('Distributor × SKU', {
-    views: [{ state: 'frozen', xSplit: 4, ySplit: 3 }],
+    views: [{ state: 'frozen', xSplit: 4, ySplit: 4 }],
     pageSetup: { orientation: 'landscape', fitToPage: true, fitToWidth: 1, fitToHeight: 0, margins: { left: 0.3, right: 0.3, top: 0.4, bottom: 0.4, header: 0.2, footer: 0.2 } },
   })
   ws4.columns = [{ width: 11 }, { width: 20 }, { width: 34 }, { width: 18 },
-    { width: 13 }, { width: 12 }, { width: 12 }, { width: 12 }, { width: 17 }, { width: 11 }]
-  writeTitle(ws4, 10, `${company} — DISTRIBUTOR × SKU — PENDING vs INVOICED vs SERVICE-AREA STOCK — ${monthLabel}`, date)
-  styleHeaderRow(ws4.addRow(['Region', 'State', 'Distributor', 'SKU',
-    `Invoiced MTD${invScope}`, 'Confirmed', 'Non-Conf', 'Pending', 'Free Stock (area)', 'Short by']))
+    { width: 13 }, { width: 12 }, { width: 12 }, { width: 12 },
+    ...plantCols.map(() => ({ width: 11 })), { width: 17 }, { width: 11 }]
+  writeTitle(ws4, SHORTC, `${company} — DISTRIBUTOR × SKU — PENDING vs INVOICED vs SERVICE-AREA STOCK — ${monthLabel}`, date)
+  // TWO header rows: the plant columns need a band of their own saying what they are, because
+  // "Hyderabad" over a tonnage is ambiguous on its own — a reader could take it for an apportioned
+  // share of the area pool. The band says ON FLOOR, and the note below says the rest.
+  const h1 = ws4.addRow(['Region', 'State', 'Distributor', 'SKU', `Invoiced MTD${invScope}`,
+    'Confirmed', 'Non-Conf', 'Pending',
+    'ON FLOOR, BY PLANT — what each plant actually holds', ...plantCols.slice(1).map(() => ''),
+    'Free Stock (area)', 'Short by'])
+  const h2 = ws4.addRow(['', '', '', '', '', '', '', '',
+    ...plantCols.map(id => plantLabel(id, areaMaster)), '', ''])
+  ;[...Array(8).keys()].map(i => i + 1).concat([FREEC, SHORTC])
+    .forEach(c => ws4.mergeCells(h1.number, c, h2.number, c))
+  ws4.mergeCells(h1.number, P1, h1.number, P2)
+  styleHeaderRow(h1); styleHeaderRow(h2)
+  ws4.getRow(h1.number).height = 24
   const dsk = data.distributorSku
   const ds4HeaderRow = ws4.lastRow.number
   if (!dsk.rows.length) {
-    const r = ws4.addRow(['No distributor has pending or month-to-date invoiced tonnage', '', '', '', '', '', '', '', '', ''])
+    const r = ws4.addRow(['No distributor has pending or month-to-date invoiced tonnage',
+      ...Array(SHORTC - 1).fill('')])
     r.eachCell(c => { c.border = ALL_BORDERS })
   }
   // A stock cell the app cannot answer prints "?" — never a "-" and never 0. `dash` renders a real
   // 0.0 as "-", so without this an Unmapped distributor's row would be indistinguishable from one
   // whose area genuinely holds nothing, which are opposite instructions to whoever reads the sheet.
   const stockCell = (v) => (v == null ? '?' : dash(v))
+  // THREE different facts, three different marks. `dash` is no use here: it renders a real 0 as
+  // "-", which is exactly the symbol a NON-SERVING plant must own, and the two say opposite things
+  // to whoever reads the sheet ("we have none of it here" vs "we cannot ship it to you at all").
+  //   number  this plant holds that much of this size
+  //   0.0     it serves the region and holds none — a real, countable answer
+  //   —       it does not serve the region
+  //   ?       the distributor has no region, so there is no set of plants to ask
+  const plantCell = (row, id) => row.onhandByPlant == null ? '?'
+    : (Object.prototype.hasOwnProperty.call(row.onhandByPlant, id) ? Number(row.onhandByPlant[id]) : '—')
   dsk.rows.forEach(row => {
     const r = ws4.addRow([row.region, row.state || '—', row.customer, row.sku,
       dash(row.invoicedMtd), dash(row.confirmed), dash(row.nonConfirmed), dash(row.pending),
+      ...plantCols.map(id => plantCell(row, id)),
       stockCell(row.freeStock), stockCell(row.shortBy)])
-    ;[5, 6, 7, 8, 9, 10].forEach(i => numCell(r, i, MT1))
+    ;[5, 6, 7, 8, ...plantCols.map((_, i) => P1 + i), FREEC, SHORTC].forEach(i => numCell(r, i, MT1))
     r.eachCell(c => { c.border = ALL_BORDERS })
   })
   if (dsk.rows.length) {
-    ws4.autoFilter = { from: { row: ds4HeaderRow, column: 1 }, to: { row: ws4.lastRow.number, column: 10 } }
+    ws4.autoFilter = { from: { row: ds4HeaderRow, column: 1 }, to: { row: ws4.lastRow.number, column: SHORTC } }
   }
   ws4.addRow([])
   // Who serves whom is READ OFF THE MASTER, never spelled out here. A caption that states a rule as
   // a literal is exactly what let this sheet claim "Free Stock is every plant's stock combined" for
   // a month after the opposite had been decided (ADR-0006) — so the sentence has to come from the
   // same data the figures came from, and go stale only when they do.
-  const areaMaster = plantMaster(opts.plants ?? null)
+
   const servedBy = REGIONS.map(r => {
     const names = [...plantsServingRegion(r, areaMaster)].map(id => plantLabel(id, areaMaster))
     const list = names.length > 1 ? `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}` : names[0]
     return names.length ? `${list} serve${names.length === 1 ? 's' : ''} ${r}` : ''
   }).filter(Boolean).join('; ')
-  const note4 = ws4.addRow([`Free Stock (area) is the stock of the plants that SERVE THIS DISTRIBUTOR'S REGION — produced minus invoiced at those plants — LESS the Confirmed tonnage of every distributor in that same service area, i.e. what is promised to nobody yet. ${servedBy || 'No plant has a service area set'} (Masters tab). A distributor is never offered stock from a plant that does not serve it. A region whose plants have produced nothing therefore shows no Free Stock at all and its distributors' full pending as "Short by" — that is the true position, not a missing figure, and it fills itself in the day one of those plants produces. Inside one service area the stock is NOT reserved to anyone, so the same tonnage is repeated on every distributor's row there waiting on that size, and it is deliberately NOT totalled anywhere on this sheet: adding the column up would report more stock than the plants hold. For the same reason "Short by" (Pending − on-hand in the area, floored at zero) can read "-" on a row whose size several distributors are queued against — it says the area has the tonnage, not that this distributor will get it. A "?" means the distributor's service area is unknown, not that it has no stock: its state carries no region mapping (${UNMAPPED_REGION}), so map the state on the Sales tab. Rows are the live pairs only (Pending or Invoiced MTD above zero), sorted Region → Distributor → Pending.${ps.invoicing.note ? ' ' + ps.invoicing.note : ''}`])
-  ws4.mergeCells(`A${note4.number}:J${note4.number}`)
+  const note4 = ws4.addRow([`ON FLOOR, BY PLANT is what each plant ACTUALLY HOLDS of that size — steel someone can walk out and count — never the area pool divided up, so the cells do not move when a different distributor's order changes. They add up to the area's floor, and Free Stock is that floor LESS what the area has already promised, which is why the cells sum to MORE than the Free Stock beside them. A number means that plant holds it; 0.0 means the plant serves this region and holds none of that size; "—" means the plant does not serve this region at all (it cannot ship to you — that is not the same as being empty); "?" means the distributor has no region, so there is no set of plants to ask. Free Stock (area) is the stock of the plants that SERVE THIS DISTRIBUTOR'S REGION — produced minus invoiced at those plants — LESS the Confirmed tonnage of every distributor in that same service area, i.e. what is promised to nobody yet. ${servedBy || 'No plant has a service area set'} (Masters tab). A distributor is never offered stock from a plant that does not serve it. A region whose plants have produced nothing therefore shows no Free Stock at all and its distributors' full pending as "Short by" — that is the true position, not a missing figure, and it fills itself in the day one of those plants produces. Inside one service area the stock is NOT reserved to anyone, so the same tonnage is repeated on every distributor's row there waiting on that size, and it is deliberately NOT totalled anywhere on this sheet: adding the column up would report more stock than the plants hold. For the same reason "Short by" (Pending − on-hand in the area, floored at zero) can read "-" on a row whose size several distributors are queued against — it says the area has the tonnage, not that this distributor will get it. A "?" means the distributor's service area is unknown, not that it has no stock: its state carries no region mapping (${UNMAPPED_REGION}), so map the state on the Sales tab. Rows are the live pairs only (Pending or Invoiced MTD above zero), sorted Region → Distributor → Pending.${ps.invoicing.note ? ' ' + ps.invoicing.note : ''}`])
+  ws4.mergeCells(note4.number, 1, note4.number, SHORTC)
   note4.getCell(1).font = { italic: true, size: 9, color: { argb: 'FF6B7280' } }
   note4.getCell(1).alignment = { wrapText: true, vertical: 'top' }
-  ws4.getRow(note4.number).height = 62
+  ws4.getRow(note4.number).height = 76
 
   await downloadWorkbook(wb, `PB-MTD-Dashboard-${date}${fileScope(opts)}.xlsx`)
   return data

--- a/src/lib/reports.js
+++ b/src/lib/reports.js
@@ -907,8 +907,16 @@ export function buildMtdDashboardData(orders, dispatches, productions, skus, { d
   // Fresh production MTD (productions already live-resolved by caller). Physical Inventory is derived
   // below as the sum of POSITIVE per-SKU on-hand (a SKU can't hold negative stock; SKUs shipped beyond
   // their tracked production are floored to 0), so it ties to the SKU ageing sheet and its buckets.
+  //
+  // CAPPED AT <= D, exactly as `invoicedMtd` above is. It was month-only until ticket #130, which made
+  // it the one MTD figure on the sheet that counted tonnage the report date has not reached. Nothing
+  // noticed while every run was same-day — the two predicates agree until a production row is dated
+  // after D. `buildPlantPipelineSummary` splits this figure per plant with its own `<= D` rule, so an
+  // uncapped headline would sit above rows that do not add up to it, which ALGORITHMS.md forbids
+  // outright: a breakdown that does not partition its own total is worse than no breakdown.
   const prodLines = (productions || []).filter(p => !p.deleted)
-  const freshProductionMtd = prodLines.reduce((t, p) => dashMonthKey(p.dateOfProduction) === MONTH ? t + num(p.totalWeight) : t, 0)
+  const freshProductionMtd = prodLines.reduce((t, p) =>
+    dashMonthKey(p.dateOfProduction) === MONTH && p.dateOfProduction <= D ? t + num(p.totalWeight) : t, 0)
 
   // Targets (only when a Best Estimate is supplied).
   const invoicePctOfBe = BE != null ? (invoicedMtd / BE) * 100 : null

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -427,7 +427,7 @@ describe('generateMtdDashboardReport (render smoke test)', () => {
     const ws = wb.getWorksheet('Dashboard')
     expect(String(ws.getCell('A1').value)).toContain('PB MTD DASHBOARD')
     expect(ws.getCell('A8').value).toBe('ORDER STATUS SUMMARY')
-    expect(ws.getCell('G8').value).toBe('ORDER PIPELINE — MTD')
+    expect(ws.getCell('G8').value).toBe('ORDER BOOK — MTD')
     expect(Number(ws.getCell(5, 9).value)).toBeCloseTo(58, 6)   // Physical Inventory KPI card (card 5 → col 9, value row 5)
     expect(Number(ws.getCell('E13').value)).toBe(8)             // Order Status → Confirmed Pending Invoice
     expect(ws.getCell('E15').value).toBe('1%')                  // Order Status → Invoice % of BE (30/2500, whole number)
@@ -649,7 +649,7 @@ describe('distributor sheet — region grouping (issue #104)', () => {
 
   it('lists a distributor with orders but no Plan and no invoice — the widened row filter', () => {
     // BACKLOG STEEL has only an all-time order-book position; the sheet it replaces dropped it,
-    // which understated its region now that Total Orders is a headline column.
+    // which understated its region now that Indent is a headline column.
     const listed = gData().regions.flatMap(g => g.rows.map(r => r.customer))
     expect(listed).toContain('BACKLOG STEEL')
     expect(listed).toContain('PLAN ONLY')     // and a plan nobody has started serving
@@ -682,7 +682,7 @@ describe('distributor sheet — rendered layout (issue #104)', () => {
     const ws3 = wb.getWorksheet('Distributor by Region')
     expect(String(ws3.getCell('A1').value)).toContain('DISTRIBUTOR ORDERS & INVOICING BY REGION')
     expect([1, 2, 3, 4, 5, 6, 7, 8].map(c => ws3.getCell(3, c).value)).toEqual([
-      'Region', 'State', 'Distributor', 'Plan (MT)', 'Total Orders (MT)',
+      'Region', 'State', 'Distributor', 'Plan (MT)', 'Indent (MT)',
       'Invoiced MTD (MT)', '% of Plan', 'Gap to Plan (MT)',
     ])
   })
@@ -738,11 +738,11 @@ describe('distributor sheet — rendered layout (issue #104)', () => {
     expect(Number(wb.getWorksheet('Dashboard').getCell(5, 1).value)).toBe(data.kpis.bestEstimate)
   })
 
-  it('footnotes that Total Orders blends two time windows, and keeps the no-Plan note', async () => {
+  it('footnotes that Indent blends two time windows, and keeps the no-Plan note', async () => {
     const { wb } = await render()
     const ws3 = wb.getWorksheet('Distributor by Region')
     const notes = ws3.getColumn(1).values.map(v => String(v ?? '')).join(' ')
-    expect(notes).toContain('Total Orders blends two time windows')
+    expect(notes).toContain('Indent (Invoiced MTD + Confirmed + Non-Confirmed) blends two time windows')
     expect(notes).toContain('all-time order-book snapshot')
     expect(notes).toContain('old unserved backlog')
     expect(notes).toContain('% of Plan can exceed 100% without the plan having been beaten')
@@ -1702,5 +1702,74 @@ describe('buildMtdDashboardData carries the servable split and the plant pipelin
     const r = buildMtdDashboardData([], ppDispatches, ppProductions, [],
       { date: '2026-09-04', coils: ppCoils, babyCoils: ppBabies })
     expect(r.pipeline.totals.producedMtd).toBeCloseTo(r.inventoryProduction.freshProductionMtd, 6)
+  })
+})
+
+// ── Commit 5: the names move to the figures they now denote ──────────────────────────────────────
+// One phrase meant two things. "Pending to Dispatch" printed 4,542 T in this workbook (every open
+// order) and 819 T on the phone (only the part with stock behind it). The workbook now uses the
+// phone's meaning, and the wide figure takes the name it already has everywhere else — "Pending to
+// Serve". "Total Orders" becomes "Indent" throughout.
+//
+// SCOPE: this workbook only. The app screens keep the old wording knowingly, which is exactly why
+// every block prints its own formula — a reader must be able to tell which figure they hold.
+describe('workbook naming: Indent, Pending to Serve, Pending to Dispatch (commit 5)', () => {
+  const everyCellText = (wb) => {
+    const out = []
+    wb.worksheets.forEach(ws => ws.eachRow({ includeEmpty: false }, row =>
+      row.eachCell({ includeEmpty: false }, c => { if (c.value != null) out.push(String(c.value)) })))
+    return out
+  }
+
+  it('"Total Orders" appears NOWHERE in the workbook — headers, labels or captions', async () => {
+    const { wb } = await renderMtdWorkbook(dOrders, dDispatches, dProductions, dSkus,
+      { date: '2026-07-15', estimates: dEstimates })
+    expect(everyCellText(wb).filter(t => t.includes('Total Orders'))).toEqual([])
+  })
+
+  it('calls the order book "Indent" on the KPI card and in both Sheet 1 tables', async () => {
+    const { wb } = await renderMtdWorkbook(dOrders, dDispatches, dProductions, dSkus,
+      { date: '2026-07-15', estimates: dEstimates })
+    const ws = wb.getWorksheet('Dashboard')
+    expect(ws.getCell(4, 3).value).toBe('INDENT (MT)')          // KPI card 2
+    expect(Number(ws.getCell(5, 3).value)).toBeCloseTo(48, 6)   // value unchanged — only the name moved
+    expect(ws.getCell('G8').value).toBe('ORDER BOOK — MTD')
+    const text = everyCellText(wb)
+    expect(text).toContain('Indent')
+    expect(text).toContain('Indent (MT)')                        // Sheet 3 column
+  })
+
+  it('names the wide figure "Pending to Serve" in the BY PLANT block', async () => {
+    const { wb } = await renderMtdWorkbook(dOrders, dDispatches, dProductions, dSkus,
+      { date: '2026-07-15', estimates: dEstimates })
+    const ws = wb.getWorksheet('Dashboard')
+    const head = ws.getColumn(1).values.findIndex(v => String(v || '').startsWith('BY PLANT')) + 1
+    const row = ws.getRow(head).values.map(v => String(v ?? ''))
+    expect(row).toContain('Pending to Serve')
+    expect(row).toContain('Indent')
+    expect(row).not.toContain('Pending to Dispatch')   // the wide column must not wear the new name
+  })
+
+  // ── The rename's whole point: the KPI card now carries the SMALLER, stock-backed figure ────────
+  // South holds 30 T; 10 T of it is Confirmed, so 20 T is free against 60 T of unconfirmed demand.
+  // West holds none. So Pending to Dispatch is 30 + 5 = 35 T, against a wide book of 110 T.
+  it('the PENDING TO DISPATCH card carries Confirmed + Servable–Unconfirmed, not the whole book', async () => {
+    const { wb, data } = await renderMtdWorkbook(svOrders, [], svProductions, svSkus, { date: '2026-09-04' })
+    const ws = wb.getWorksheet('Dashboard')
+    expect(ws.getCell(4, 7).value).toBe('PENDING TO DISPATCH (MT)')
+    expect(Number(ws.getCell(5, 7).value)).toBeCloseTo(35, 6)
+    expect(String(ws.getCell(6, 7).value)).toContain('Servable')      // the caption states the formula
+    // And it is genuinely the smaller of the two — the wide book is still 110 T and still reported.
+    expect(data.kpis.pending).toBeCloseTo(110, 6)
+    expect(Number(ws.getCell(5, 7).value)).toBeLessThan(data.kpis.pending)
+  })
+
+  it('reads N/A, never 0, when no region can answer the servable question', async () => {
+    // Every distributor unmapped ⇒ no service area ⇒ nobody can say what the floor covers. A card
+    // printing 0 there would say "nothing is servable", which is a different claim from "unknown".
+    const noState = svOrders.map(o => ({ ...o, shipToState: '' }))
+    const { wb } = await renderMtdWorkbook(noState, [], svProductions, svSkus, { date: '2026-09-04' })
+    const ws = wb.getWorksheet('Dashboard')
+    expect(ws.getCell(5, 7).value).toBe('N/A')
   })
 })

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -430,7 +430,7 @@ describe('generateMtdDashboardReport (render smoke test)', () => {
     expect(ws.getCell('G8').value).toBe('ORDER BOOK — MTD')
     expect(Number(ws.getCell(5, 9).value)).toBeCloseTo(58, 6)   // Physical Inventory KPI card (card 5 → col 9, value row 5)
     expect(Number(ws.getCell('E13').value)).toBe(8)             // Order Status → Confirmed Pending Invoice
-    expect(ws.getCell('E15').value).toBe('1%')                  // Order Status → Invoice % of BE (30/2500, whole number)
+    expect(ws.getCell('E18').value).toBe('1%')                  // Order Status → Invoice % of BE (30/2500, whole number)
     expect(Number(ws.getCell('K18').value)).toBeCloseTo(145.2941, 3) // Order Pipeline → Daily Run Rate Required
 
     const ws2 = wb.getWorksheet('SKU Ageing (>2 MT)')
@@ -1771,5 +1771,137 @@ describe('workbook naming: Indent, Pending to Serve, Pending to Dispatch (commit
     const { wb } = await renderMtdWorkbook(noState, [], svProductions, svSkus, { date: '2026-09-04' })
     const ws = wb.getWorksheet('Dashboard')
     expect(ws.getCell(5, 7).value).toBe('N/A')
+  })
+})
+
+// ── Commit 6: the four new Sheet 1 blocks ────────────────────────────────────────────────────────
+// Worked by hand so the expectations are arithmetic, not whatever the code happens to emit.
+//
+//   Hyderabad  produced 100 (02-Aug) + 60 (02-Sep) = 160, invoiced 30 (25-Aug) + 20 (04-Sep) = 50
+//              FG 110 · opening 70 (=100−30) · MTD produced 60, invoiced 20 → 70+60−20 = 110 ✓
+//   NPMD       produced 40 (03-Sep), invoiced 0 → FG 40 · opening 0 · 0+40−0 = 40 ✓
+//   ALL        opening 70 + produced 100 − invoiced 20 = FG 150, and Physical Inventory
+//              (200 produced − 50 invoiced, reached a completely different way) is 150 too.
+//   RM         full coil 500 (H1, never slit) + baby 50 (B1, above the scrap floor) = 550
+//   South      holds 110, 10 confirmed → 100 free against 40 unconfirmed → servable 40, PtD 50
+//   West       holds  40,  5 confirmed →  35 free against 100 unconfirmed → servable 35, PtD 40
+//              so Pending to Dispatch is 90 against a wide book of 155
+const s6D = '2026-09-04'
+const s6Skus = [{ skuCode: 'S1', productType: 'SHS', height: 50, breadth: 50, thickness: 2, length: 6000, weightPerTube: 10, status: 'published' }]
+const s6Productions = [
+  { id: 'p1', skuCode: 'S1', plant: 'hyderabad', dateOfProduction: '2026-08-02', tubeCount: 0, totalWeight: 100 },
+  { id: 'p2', skuCode: 'S1', plant: 'hyderabad', dateOfProduction: '2026-09-02', tubeCount: 0, totalWeight: 60 },
+  { id: 'p3', skuCode: 'S1', plant: 'npmd', dateOfProduction: '2026-09-03', tubeCount: 0, totalWeight: 40 },
+]
+const s6Dispatches = [
+  { id: 'd1', dateOfDispatch: '2026-08-25', bundleEntries: [{ skuCode: 'S1', plant: 'hyderabad', weight: 30 }] },
+  { id: 'd2', dateOfDispatch: '2026-09-04', bundleEntries: [{ skuCode: 'S1', plant: 'hyderabad', weight: 20 }] },
+]
+const s6Coils = [{ id: 'c1', hrCoilId: 'H1', plant: 'hyderabad', actualWeight: 500 }]
+const s6Babies = [{ id: 'b1', babyCoilId: 'B1', hrCoilId: 'H9', plant: 'hyderabad', weight: 50 }]
+const s6Orders = [
+  { id: 'o1', distributorCode: 'D-S', customer: 'SOUTH A', shipToState: 'TELANGANA', orderStatus: '', orderDate: '2026-09-01', mmId: 'S1', confirmed: 10, nonConfirmed: 40 },
+  { id: 'o2', distributorCode: 'D-W', customer: 'WEST A', shipToState: 'MAHARASHTRA', orderStatus: '', orderDate: '2026-09-01', mmId: 'S1', confirmed: 5, nonConfirmed: 100 },
+]
+const s6Render = (opts = {}) => renderMtdWorkbook(s6Orders, s6Dispatches, s6Productions, s6Skus,
+  { date: s6D, coils: s6Coils, babyCoils: s6Babies, ...opts })
+const bandRow = (ws, text) => ws.getColumn(1).values.findIndex(v => String(v || '').startsWith(text))
+const labelRow = (ws, text) => ws.getColumn(1).values.findIndex(v => String(v || '').trim() === text)
+
+describe('Sheet 1 — the four new blocks (commit 6)', () => {
+  it('Order Status Summary carries Servable – Unconfirmed, Pending to Serve and Pending to Dispatch', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Dashboard')
+    const val = (label) => Number(ws.getCell(labelRow(ws, label), 5).value)
+    expect(val('Servable – Unconfirmed')).toBeCloseTo(75, 6)
+    expect(val('Pending to Serve')).toBeCloseTo(155, 6)      // the whole open book, 15 + 140
+    expect(val('Pending to Dispatch')).toBeCloseTo(90, 6)    // only what the floor can back
+    expect(val('Pending to Dispatch')).toBeLessThan(val('Pending to Serve'))
+  })
+
+  it('Inventory & Production carries prev-month production and the three RM lines', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Dashboard')
+    const val = (label) => Number(ws.getCell(labelRow(ws, label), 5).value)
+    expect(val('Fresh Production MTD')).toBeCloseTo(100, 6)
+    expect(val('Produced (Prev Month, same days)')).toBeCloseTo(100, 6)
+    expect(val('RM — Full Coil')).toBeCloseTo(500, 6)
+    expect(val('RM — Baby Coil')).toBeCloseTo(50, 6)
+    expect(val('RM Total')).toBeCloseTo(550, 6)
+  })
+
+  it('prints ? for raw material when the coil registers were never supplied', async () => {
+    const { wb } = await renderMtdWorkbook(s6Orders, s6Dispatches, s6Productions, s6Skus, { date: s6D })
+    const ws = wb.getWorksheet('Dashboard')
+    expect(ws.getCell(labelRow(ws, 'RM — Full Coil'), 5).value).toBe('?')
+    expect(ws.getCell(labelRow(ws, 'RM Total'), 5).value).toBe('?')
+    // The finished-pipe side is answerable without them and must still read a number.
+    expect(Number(ws.getCell(labelRow(ws, 'Fresh Production MTD'), 5).value)).toBeCloseTo(100, 6)
+  })
+
+  it('SERVABLE BY REGION lists each region and totals to the KPI card', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Dashboard')
+    const band = bandRow(ws, 'SERVABLE BY REGION')
+    expect(band).toBeGreaterThan(0)
+    expect(ws.getRow(band + 1).values.map(v => String(v ?? ''))).toContain('Servable – Unconf')
+    const south = band + 2
+    expect(ws.getCell(south, 1).value).toBe('South')
+    expect(Number(ws.getCell(south, 3).value)).toBeCloseTo(10, 6)    // confirmed
+    expect(Number(ws.getCell(south, 5).value)).toBeCloseTo(40, 6)    // non-confirmed
+    expect(Number(ws.getCell(south, 7).value)).toBeCloseTo(40, 6)    // servable – unconfirmed
+    expect(Number(ws.getCell(south, 9).value)).toBeCloseTo(50, 6)    // pending to dispatch
+    const total = band + 4
+    expect(String(ws.getCell(total, 1).value)).toContain('TOTAL')
+    expect(Number(ws.getCell(total, 9).value)).toBeCloseTo(90, 6)
+  })
+
+  it('STOCK MOVEMENT adds up per plant and overall: Opening + Production − Dispatch = Current', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Dashboard')
+    const band = bandRow(ws, 'STOCK MOVEMENT')
+    expect(band).toBeGreaterThan(0)
+    const at = (r, c) => Number(ws.getCell(r, c).value)
+    const hyd = band + 2
+    expect(ws.getCell(hyd, 1).value).toBe('Hyderabad')
+    expect(at(hyd, 3)).toBeCloseTo(70, 6)     // opening
+    expect(at(hyd, 5)).toBeCloseTo(60, 6)     // produced MTD
+    expect(at(hyd, 7)).toBeCloseTo(20, 6)     // invoiced MTD
+    expect(at(hyd, 9)).toBeCloseTo(110, 6)    // current FG
+    expect(at(hyd, 3) + at(hyd, 5) - at(hyd, 7)).toBeCloseTo(at(hyd, 9), 6)
+    const all = band + 4
+    expect(String(ws.getCell(all, 1).value)).toContain('ALL PLANTS')
+    expect(at(all, 3) + at(all, 5) - at(all, 7)).toBeCloseTo(at(all, 9), 6)
+    expect(at(all, 9)).toBeCloseTo(150, 6)
+  })
+
+  it('the movement Current column IS the Physical Inventory headline, reached a different way', async () => {
+    const { wb, data } = await s6Render()
+    const ws = wb.getWorksheet('Dashboard')
+    const all = bandRow(ws, 'STOCK MOVEMENT') + 4
+    expect(Number(ws.getCell(all, 9).value)).toBeCloseTo(data.kpis.physicalInventory, 6)
+    expect(data.pipeline.checks.movementTiesToFgLeft).toBe(true)
+  })
+
+  it('BY PLANT — RAW MATERIAL splits the coil registers by plant', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Dashboard')
+    const band = bandRow(ws, 'BY PLANT — RAW MATERIAL')
+    expect(band).toBeGreaterThan(0)
+    const hyd = band + 2
+    expect(ws.getCell(hyd, 1).value).toBe('Hyderabad')
+    expect(Number(ws.getCell(hyd, 3).value)).toBeCloseTo(500, 6)
+    expect(Number(ws.getCell(hyd, 5).value)).toBeCloseTo(50, 6)
+    expect(Number(ws.getCell(hyd, 7).value)).toBeCloseTo(550, 6)
+  })
+
+  it('says so on its own face when a block does not add up', async () => {
+    // The house rule: a breakdown that does not tie to the headline above it is worse than no
+    // breakdown. The sheet must refuse to look trustworthy rather than refuse to open.
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Dashboard')
+    const notes = ws.getColumn(1).values.map(v => String(v || ''))
+    expect(notes.some(t => t.includes('Opening + Production − Dispatch = Current'))).toBe(true)
+    expect(notes.some(t => t.includes('do not circulate this sheet'))).toBe(false)  // this fixture ties
   })
 })

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -1553,6 +1553,51 @@ describe('buildPlantPipelineSummary — production and stock by plant', () => {
     expect(ppSummary().plants.find(p => p.name === 'NPMD').producedD).toBeCloseTo(5)
   })
 
+  it('movement adds up: Opening + Production − Dispatch = Current, per plant and overall', () => {
+    const p = ppSummary()
+    // Hyderabad: made 7 in Aug and invoiced nothing then, so it opened Sep holding 7.
+    const hyd = p.plants.find(x => x.name === 'Hyderabad')
+    expect(hyd.openingFg).toBeCloseTo(7)
+    expect(hyd.invoicedMtd).toBeCloseTo(6)
+    expect(hyd.openingFg + hyd.producedMtd - hyd.invoicedMtd).toBeCloseTo(hyd.fgLeft)  // 7 + 20 − 6 = 21
+    // NPMD produced nothing before September, so it opened at zero.
+    const npmd = p.plants.find(x => x.name === 'NPMD')
+    expect(npmd.openingFg).toBeCloseTo(0)
+    expect(npmd.openingFg + npmd.producedMtd - npmd.invoicedMtd).toBeCloseTo(npmd.fgLeft)  // 0 + 5 − 2 = 3
+    // And on the total, which is what the sheet prints under the rows.
+    expect(p.totals.openingFg + p.totals.producedMtd - p.totals.invoicedMtd).toBeCloseTo(p.totals.fgLeft)
+    expect(p.checks.movementTiesToFgLeft).toBe(true)
+    expect(p.diagnostics.producedAfterD).toBeCloseTo(0)
+    expect(p.diagnostics.invoicedAfterD).toBeCloseTo(0)
+  })
+
+  it('a row dated after D stays in Current but out of Opening and MTD — and is named, not absorbed', () => {
+    // The back-dated-report case. `fgLeft` has no date cap, so tonnage produced after D is already
+    // in Current; it cannot be in Opening (it is this month) nor in Production MTD (it is past D).
+    // Without the two after-D terms the identity would silently miss by exactly that amount.
+    const prods = [...ppProductions, { id: 'pr6', plant: 'npmd', dateOfProduction: '2026-09-28', totalWeight: 11 }]
+    const p = buildPlantPipelineSummary(prods, ppDispatches, ppCoils, ppBabies, { date: '2026-09-04' })
+    const npmd = p.plants.find(x => x.name === 'NPMD')
+    expect(npmd.producedMtd).toBeCloseTo(5)          // the 11 is NOT in MTD
+    expect(npmd.openingFg).toBeCloseTo(0)            // nor in Opening
+    expect(npmd.fgLeft).toBeCloseTo(14)              // but it IS in Current: 5 + 11 − 2
+    expect(npmd.openingFg + npmd.producedMtd - npmd.invoicedMtd).not.toBeCloseTo(npmd.fgLeft)
+    // The residual is reported, and the check still passes once it is accounted for.
+    expect(p.diagnostics.producedAfterD).toBeCloseTo(11)
+    expect(p.checks.movementTiesToFgLeft).toBe(true)
+  })
+
+  it('undated production rows stay on the opening side rather than falling out of the identity', () => {
+    // A row with no date is a data fault. Opening is built as a COMPLEMENT precisely so its tonnage
+    // lands somewhere visible instead of making the movement columns quietly lose steel.
+    const prods = [...ppProductions, { id: 'pr7', plant: 'hyderabad', totalWeight: 4 }]
+    const p = buildPlantPipelineSummary(prods, ppDispatches, ppCoils, ppBabies, { date: '2026-09-04' })
+    const hyd = p.plants.find(x => x.name === 'Hyderabad')
+    expect(hyd.openingFg).toBeCloseTo(11)            // 7 dated August + 4 undated
+    expect(hyd.openingFg + hyd.producedMtd - hyd.invoicedMtd).toBeCloseTo(hyd.fgLeft)
+    expect(p.checks.movementTiesToFgLeft).toBe(true)
+  })
+
   it('reports FG as what the plant made and has not invoiced', () => {
     const p = ppSummary()
     expect(p.plants.find(x => x.name === 'Hyderabad').fgLeft).toBeCloseTo(21)  // 27 made − 6 invoiced

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -971,30 +971,36 @@ describe('buildMtdDashboardData — distributor × SKU rows', () => {
 const labelsOf = (ws) => ws.getColumn(1).values.filter(v => v != null).map(v => String(v))
 
 describe('Distributor × SKU sheet — rendering', () => {
-  it('renders the ten columns in order, one row per live pair, in sort order', async () => {
+  it('renders the fourteen columns in order, one row per live pair, in sort order', async () => {
     const { wb } = await renderMtdWorkbook(dsOrders, dsDispatches, dsProductions, dsSkus, dsOpts)
     expect(wb.worksheets.map(w => w.name))
       .toEqual(['Dashboard', 'SKU Ageing (>2 MT)', 'Distributor by Region', 'Distributor × SKU'])
     const ws = wb.getWorksheet('Distributor × SKU')
     // The Invoiced header carries the #127 scope label: every invoice in this fixture is now
     // attributed to Hyderabad (it has to be, or the stock filter has nothing to read).
-    expect(ws.getRow(3).values.slice(1)).toEqual(['Region', 'State', 'Distributor', 'SKU',
-      'Invoiced MTD · Hyderabad only', 'Confirmed', 'Non-Conf', 'Pending', 'Free Stock (area)', 'Short by'])
-    expect(ws.getRow(4).values.slice(1, 5))
+    // Two header rows since commit 7: the plant columns carry a band of their own.
+    expect([1, 2, 3, 4, 5, 6, 7, 8].map(c => ws.getCell(3, c).value)).toEqual(['Region', 'State',
+      'Distributor', 'SKU', 'Invoiced MTD · Hyderabad only', 'Confirmed', 'Non-Conf', 'Pending'])
+    expect(String(ws.getCell(3, 9).value)).toContain('ON FLOOR, BY PLANT')
+    expect([9, 10, 11, 12].map(c => ws.getCell(4, c).value))
+      .toEqual(['Hyderabad', 'Lepakshi', 'NPMD', 'Tapi'])
+    expect(ws.getCell(4, 13).value).toBe('Free Stock (area)')
+    expect(ws.getCell(4, 14).value).toBe('Short by')
+    expect(ws.getRow(5).values.slice(1, 5))
       .toEqual(['South', 'KARNATAKA', 'ARIHANT STEEL POINT', '50x50 x 2'])
-    expect(ws.getRow(9).values.slice(1, 4)).toEqual(['Unmapped', '—', 'MAHENDRA ISPAT'])
+    expect(ws.getRow(10).values.slice(1, 4)).toEqual(['Unmapped', '—', 'MAHENDRA ISPAT'])
   })
 
   it('writes exact tonnage with a one-decimal cell format — nothing pre-rounded', async () => {
     const { wb } = await renderMtdWorkbook(dsOrders, dsDispatches, dsProductions, dsSkus, dsOpts)
     const ws = wb.getWorksheet('Distributor × SKU')
-    ;[5, 6, 7, 8, 9, 10].forEach(c => expect(ws.getCell(4, c).numFmt).toBe('#,##0.0'))
+    ;[5, 6, 7, 8, 9, 10, 11, 12, 13, 14].forEach(c => expect(ws.getCell(5, c).numFmt).toBe('#,##0.0'))
     const npm = rowStartingWith(ws, 'West') // first West row = NEW PASHCHIM MAHARASHTRA
     // West holds nothing, so Free Stock = 0 on-hand − 56.0 Confirmed across the three WEST
     // distributors = −56.0, and Short by is the full 40 T pending. Neither figure is softened by
     // the 39.3 T sitting in Hyderabad, which no West lorry is going to load.
-    expect(Number(ws.getCell(npm, 9).value)).toBeCloseTo(-56, 6)   // not -34.7, not 39.3
-    expect(Number(ws.getCell(npm, 10).value)).toBeCloseTo(40, 6)   // not 0.7
+    expect(Number(ws.getCell(npm, 13).value)).toBeCloseTo(-56, 6)  // not -34.7, not 39.3
+    expect(Number(ws.getCell(npm, 14).value)).toBeCloseTo(40, 6)   // not 0.7
     expect(ws.getCell(npm, 5).value).toBe('-')                     // nothing invoiced → dashed, not 0.0
   })
 
@@ -1002,8 +1008,10 @@ describe('Distributor × SKU sheet — rendering', () => {
     const { wb } = await renderMtdWorkbook(dsOrders, dsDispatches, dsProductions, dsSkus, dsOpts)
     const ws = wb.getWorksheet('Distributor × SKU')
     const un = rowStartingWith(ws, 'Unmapped')     // MAHENDRA ISPAT — no ship-to state
-    expect(ws.getCell(un, 9).value).toBe('?')      // Free Stock
-    expect(ws.getCell(un, 10).value).toBe('?')     // Short by
+    expect(ws.getCell(un, 13).value).toBe('?')     // Free Stock
+    expect(ws.getCell(un, 14).value).toBe('?')     // Short by
+    // ...and every plant column too, for the same reason: no region, so no plants to ask.
+    expect([9, 10, 11, 12].map(c => ws.getCell(un, c).value)).toEqual(['?', '?', '?', '?'])
     expect(Number(ws.getCell(un, 8).value)).toBeCloseTo(8, 6)  // its pending is a fact and still prints
   })
 
@@ -1016,7 +1024,7 @@ describe('Distributor × SKU sheet — rendering', () => {
       .forEach(v => expect(v).not.toMatch(/total/i))
     // …and no cell in the Free Stock column holds a sum of it — not the whole column, and not the
     // per-region West subtotal (3 × −56) either.
-    const free = ws.getColumn(9).values.filter(v => typeof v === 'number')
+    const free = ws.getColumn(13).values.filter(v => typeof v === 'number')
     expect(free).toHaveLength(5) // the five data rows that HAVE an area; MAHENDRA's cell is "?"
     const colSum = free.reduce((t, v) => t + v, 0)
     ;[colSum, 3 * -56].forEach(sum => free.forEach(v => expect(Math.abs(v - sum)).toBeGreaterThan(0.05)))
@@ -1054,7 +1062,7 @@ describe('Distributor × SKU sheet — rendering', () => {
   it('renders an empty sheet without throwing when nothing is live', async () => {
     const { wb } = await renderMtdWorkbook([], [], [], [], dsOpts)
     const ws = wb.getWorksheet('Distributor × SKU')
-    expect(String(ws.getCell('A4').value)).toContain('No distributor has pending')
+    expect(String(ws.getCell('A5').value)).toContain('No distributor has pending')
   })
 })
 
@@ -1903,5 +1911,90 @@ describe('Sheet 1 — the four new blocks (commit 6)', () => {
     const notes = ws.getColumn(1).values.map(v => String(v || ''))
     expect(notes.some(t => t.includes('Opening + Production − Dispatch = Current'))).toBe(true)
     expect(notes.some(t => t.includes('do not circulate this sheet'))).toBe(false)  // this fixture ties
+  })
+})
+
+// ── Commit 7: Sheet 4 gains one stock column per plant ───────────────────────────────────────────
+// Three symbols, three different facts. They must never share a cell value:
+//   54.7  this plant holds that much of this size — steel someone can walk out and count
+//   0.0   this plant serves the region and holds NONE of it (a real, countable answer)
+//   —     this plant does not serve the region at all (it cannot ship to you; it is not empty)
+//   ?     the distributor has no region, so nobody can say which plants serve it
+//
+// With the s6 fixture: Hyderabad made 160 and invoiced 50 (110 left), NPMD made 40 and invoiced
+// none. South reads Hyderabad 110 / Lepakshi 0.0; West reads NPMD 40 / Tapi 0.0.
+describe('Sheet 4 — on-floor stock by plant (commit 7)', () => {
+  const PC = { hyderabad: 9, lepakshi: 10, npmd: 11, tapi: 12 }   // the four plant columns
+  const FREE = 13, SHORT = 14
+  const rowFor = (ws, customer) =>
+    ws.getColumn(3).values.findIndex(v => String(v || '') === customer)
+
+  it('carries a two-row header: a group band spanning the plant columns', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Distributor × SKU')
+    expect(String(ws.getCell(3, PC.hyderabad).value)).toContain('ON FLOOR, BY PLANT')
+    expect(ws.getCell(4, 1).value).toBe('Region')
+    expect(ws.getCell(4, 8).value).toBe('Pending')
+    expect(ws.getCell(4, PC.hyderabad).value).toBe('Hyderabad')
+    expect(ws.getCell(4, PC.tapi).value).toBe('Tapi')
+    expect(String(ws.getCell(4, FREE).value)).toContain('Free Stock')
+    expect(ws.getCell(4, SHORT).value).toBe('Short by')
+  })
+
+  it('groups the plant columns by the region they serve — South first, then West', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Distributor × SKU')
+    expect([9, 10, 11, 12].map(c => ws.getCell(4, c).value))
+      .toEqual(['Hyderabad', 'Lepakshi', 'NPMD', 'Tapi'])
+  })
+
+  it('a South row reads its two South plants and a DASH under the West pair', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Distributor × SKU')
+    const r = rowFor(ws, 'SOUTH A')
+    expect(Number(ws.getCell(r, PC.hyderabad).value)).toBeCloseTo(110, 6)
+    expect(Number(ws.getCell(r, PC.lepakshi).value)).toBe(0)      // serves, holds none — NOT a dash
+    expect(ws.getCell(r, PC.npmd).value).toBe('—')
+    expect(ws.getCell(r, PC.tapi).value).toBe('—')
+  })
+
+  it('a West row is the mirror of it', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Distributor × SKU')
+    const r = rowFor(ws, 'WEST A')
+    expect(ws.getCell(r, PC.hyderabad).value).toBe('—')
+    expect(ws.getCell(r, PC.lepakshi).value).toBe('—')
+    expect(Number(ws.getCell(r, PC.npmd).value)).toBeCloseTo(40, 6)
+    expect(Number(ws.getCell(r, PC.tapi).value)).toBe(0)
+  })
+
+  it('an Unmapped distributor reads ? in every plant column — never 0, never a dash', async () => {
+    const nowhere = { id: 'o3', distributorCode: 'D-N', customer: 'NEW BUYER', shipToState: '',
+      orderStatus: '', orderDate: '2026-09-01', mmId: 'S1', confirmed: 0, nonConfirmed: 80 }
+    const { wb } = await renderMtdWorkbook([...s6Orders, nowhere], s6Dispatches, s6Productions, s6Skus,
+      { date: s6D, coils: s6Coils, babyCoils: s6Babies })
+    const ws = wb.getWorksheet('Distributor × SKU')
+    const r = rowFor(ws, 'NEW BUYER')
+    expect([9, 10, 11, 12].map(c => ws.getCell(r, c).value)).toEqual(['?', '?', '?', '?'])
+    expect(ws.getCell(r, FREE).value).toBe('?')
+  })
+
+  it('the plant cells add up to the area stock the Free Stock column is derived from', async () => {
+    const { wb, data } = await s6Render()
+    const ws = wb.getWorksheet('Distributor × SKU')
+    const r = rowFor(ws, 'SOUTH A')
+    const cells = [9, 10, 11, 12].map(c => ws.getCell(r, c).value)
+      .filter(v => typeof v === 'number')
+    const sum = cells.reduce((t, v) => t + v, 0)
+    const row = data.distributorSku.rows.find(x => x.customer === 'SOUTH A')
+    expect(sum - row.onhandByPlantUnmatched).toBeCloseTo(row.onhand, 6)
+    // ...and Free Stock is that floor less what the AREA has already promised, not less this row's.
+    expect(Number(ws.getCell(r, FREE).value)).toBeCloseTo(row.onhand - row.allConfirmed, 6)
+  })
+
+  it('still has no total row — inside an area the stock is shared, so a column sum invents steel', async () => {
+    const { wb } = await s6Render()
+    const ws = wb.getWorksheet('Distributor × SKU')
+    expect(ws.getColumn(1).values.findIndex(v => String(v || '').includes('TOTAL'))).toBe(-1)
   })
 })

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -219,6 +219,24 @@ describe('buildMtdDashboardData', () => {
     expect(inventoryProduction.physicalInventory).toBe(58)  // positive on-hand only: S1 28 + S2 30
   })
 
+  it('Fresh Production MTD stops at D, like every other MTD figure (ticket #130)', () => {
+    // The bug this pins: the figure filtered on MONTH alone while `invoicedMtd` filtered on
+    // `MONTH && <= D`. Same-day runs never saw it — the two predicates agree until a production row
+    // is dated after the report date. `buildPlantPipelineSummary` splits this headline per plant
+    // with its own `<= D` rule, so uncapped it would sit above rows that do not add up to it.
+    const skus = [{ skuCode: 'X', productType: 'SHS', height: 40, breadth: 40, thickness: 2, length: 6000, weightPerTube: 10 }]
+    const productions = [
+      { skuCode: 'X', dateOfProduction: '2026-07-05', tubeCount: 10, totalWeight: 10 },  // on or before D
+      { skuCode: 'X', dateOfProduction: '2026-07-20', tubeCount: 7, totalWeight: 7 },    // same month, AFTER D
+    ]
+    const r = buildMtdDashboardData([], [], productions, skus, { date: '2026-07-15' })
+    expect(r.inventoryProduction.freshProductionMtd).toBeCloseTo(10, 6)   // not 17
+
+    // And it now equals the per-plant split of the same rows, which is the whole point.
+    const pipeline = buildPlantPipelineSummary(productions, [], [], [], { date: '2026-07-15' })
+    expect(pipeline.totals.producedMtd).toBeCloseTo(r.inventoryProduction.freshProductionMtd, 6)
+  })
+
   it('FIFO ageing: buckets tie to on-hand, weighted-avg age, and Σ buckets == physical inventory (no over-dispatch)', () => {
     const { inventoryProduction, kpis } = buildMtdDashboardData(dOrders, dDispatches, dProductions, dSkus, { date: D })
     const b = inventoryProduction.buckets

--- a/src/lib/reports.test.js
+++ b/src/lib/reports.test.js
@@ -1631,3 +1631,76 @@ describe('buildPlantPipelineSummary — production and stock by plant', () => {
     expect(p.totals.babyLeft).toBeCloseTo(babyCoilStock(ppBabies, coilConsumption(ppProductions, null, 'babyCoilId')))
   })
 })
+
+// ── Commit 3 of the workbook-parity run: the two builders reach the workbook's data ──────────────
+// Nothing is DRAWN here. This step only proves that `buildMtdDashboardData` carries the servable
+// split and the plant pipeline, and that it carries them as the SAME figures a direct call gives —
+// a renderer wired to a builder that quietly disagrees with its own function is the failure mode
+// the whole sequence exists to avoid.
+describe('buildMtdDashboardData carries the servable split and the plant pipeline', () => {
+  it('exposes the plant pipeline, identical to calling the builder directly', () => {
+    const direct = buildPlantPipelineSummary(ppProductions, ppDispatches, ppCoils, ppBabies, { date: '2026-09-04' })
+    const r = buildMtdDashboardData([], ppDispatches, ppProductions, [],
+      { date: '2026-09-04', coils: ppCoils, babyCoils: ppBabies })
+    expect(r.pipeline.totals).toEqual(direct.totals)
+    expect(r.pipeline.plants.map(p => p.name)).toEqual(direct.plants.map(p => p.name))
+    expect(r.pipeline.checks.movementTiesToFgLeft).toBe(true)
+  })
+
+  it('exposes the servable split, identical to calling the builder directly', () => {
+    const direct = buildServableSummary(svOrders, [], svSkus, { date: '2026-09-04' })
+    const r = buildMtdDashboardData(svOrders, [], [], svSkus, { date: '2026-09-04' })
+    expect(r.servable.totals).toEqual(direct.totals)
+    expect(r.servable.regions.map(g => g.region)).toEqual(direct.regions.map(g => g.region))
+  })
+
+  it('takes the coil registers as NAMED options, never as a 5th positional argument', () => {
+    // Every existing call site passes the options bag 5th. Had the registers gone in positionally,
+    // all ~35 of them would have been silently reinterpreted as `coils` and the options — the DATE
+    // among them — dropped, so the whole file would have quietly reported on today instead of D.
+    const r = buildMtdDashboardData([], ppDispatches, ppProductions, [], { date: '2026-09-04' })
+    expect(r.date).toBe('2026-09-04')
+    expect(r.pipeline.date).toBe('2026-09-04')
+  })
+
+  // ── `null` is not `[]` ─────────────────────────────────────────────────────────────────────────
+  // `notDeleted(null)` returns `[]`, so an unsupplied register computes a perfectly confident RM of
+  // ZERO. A workbook printing "0 T of steel" is not a gap a reader can see; it is a lie they act on.
+  it('reports RM as UNKNOWN, not zero, when the coil registers are not supplied', () => {
+    const r = buildMtdDashboardData([], ppDispatches, ppProductions, [], { date: '2026-09-04' })
+    expect(r.pipelineScope.rmKnown).toBe(false)
+    expect(r.pipeline.totals.rmTotal).toBeNull()
+    expect(r.pipeline.totals.fullCoilLeft).toBeNull()
+    expect(r.pipeline.totals.babyLeft).toBeNull()
+    r.pipeline.plants.forEach(p => {
+      expect(p.rmTotal).toBeNull()
+      expect(p.fullCoilLeft).toBeNull()
+      expect(p.babyLeft).toBeNull()
+    })
+    // The FG side is answerable from productions + dispatches alone, so it still reads a number.
+    expect(r.pipeline.totals.producedMtd).toBeCloseTo(28)
+  })
+
+  it('reports RM as known once both registers are supplied', () => {
+    const r = buildMtdDashboardData([], ppDispatches, ppProductions, [],
+      { date: '2026-09-04', coils: ppCoils, babyCoils: ppBabies })
+    expect(r.pipelineScope.rmKnown).toBe(true)
+    expect(r.pipeline.totals.fullCoilLeft).toBeCloseTo(100)
+    expect(r.pipeline.totals.babyLeft).toBeCloseTo(30)   // b1 30 free; b2's 0.05 is scrap (ADR-0007)
+    expect(r.pipeline.totals.rmTotal).toBeCloseTo(130)
+  })
+
+  it('an EMPTY register is a real answer of zero — only a MISSING one is unknown', () => {
+    // The distinction the whole flag exists for: a plant that genuinely holds no steel reads 0.
+    const r = buildMtdDashboardData([], ppDispatches, ppProductions, [],
+      { date: '2026-09-04', coils: [], babyCoils: [] })
+    expect(r.pipelineScope.rmKnown).toBe(true)
+    expect(r.pipeline.totals.rmTotal).toBeCloseTo(0)
+  })
+
+  it('the pipeline headline is the SAME tonnage as the KPI it sits under', () => {
+    const r = buildMtdDashboardData([], ppDispatches, ppProductions, [],
+      { date: '2026-09-04', coils: ppCoils, babyCoils: ppBabies })
+    expect(r.pipeline.totals.producedMtd).toBeCloseTo(r.inventoryProduction.freshProductionMtd, 6)
+  })
+})


### PR DESCRIPTION
## Summary

Brings the PB MTD `.xlsx` level with the daily WhatsApp message, which was reshaped in `8d5de14` and left the workbook behind. Adds a stock movement table and per-plant stock on the Distributor × SKU sheet. Ten commits, test-first throughout.

**Targets `staging`, not `main`** — per `CLAUDE.md`, `main` is the live site and moves only when staging is merged as a batch.

## The problem this closes

One phrase meant two things, in two places a reader holds side by side:

```
                        04-Sep-2026, the same order book
workbook  "Pending to Dispatch"   4,550.7 T   Confirmed + Non-confirmed
WhatsApp  "Pending to Dispatch"     805.3 T   Confirmed + Servable – Unconfirmed
```

`CONTEXT.md` had asked twice for this to be settled "before either spreads further". It then spread further.

## Naming (ADR-0008)

| | |
|---|---|
| **Pending to Dispatch** | now `Confirmed + Servable – Unconfirmed` — the stock-backed figure. *Servable – Unconfirmed is one term, added, not a subtraction.* |
| **Pending to Serve** | the whole open book (`Confirmed + Non-confirmed`) — the name it already had in `pb-mtd-report` |
| **Total Orders** | → **Indent**, everywhere in the workbook |

Scope is the workbook only. The app screens keep the old wording knowingly, so the phrase means 819 T in the file and 4,542 T on screen until they move (~20 places incl. CSV headers). Every block prints its own formula to compensate. A cell sweep asserts "Total Orders" appears nowhere.

## New on the Dashboard sheet

- **SERVABLE BY REGION** — counted once per `(region, size)`, never per distributor (ADR-0002)
- **STOCK MOVEMENT** — `Opening + Production − Dispatch = Current`, asserted per plant *and* on the total. Opening is a **complement**, not a `date < 1st` filter, so an undated row keeps its tonnage instead of vanishing from the identity
- **BY PLANT — RAW MATERIAL** — a *position*, not a movement: a coil is not dispatched
- Order Status gains Servable – Unconfirmed / Pending to Serve / Pending to Dispatch together

Movement **Current** is the same tonnage as the Physical Inventory card, reached a completely different way — a real cross-check, not arithmetic checking itself.

## Distributor × SKU (ADR-0009)

Four `ON FLOOR, BY PLANT` columns: what each plant **actually holds**, never the pool apportioned. A share would correspond to nothing countable and would move when a *different* distributor ordered — the test multiplies one distributor's pending by 1,000 and asserts both cells sit still.

Four marks, four different facts: `54.7` holds it · `0.0` serves you, holds none · `—` does not serve you · `?` no region to ask. `dash` was unusable here — it renders a real 0 as `-`, the mark a non-serving plant must own.

## Unknown is never 0

RM reads `?` when the coil registers weren't supplied — `notDeleted(null)` returns `[]`, so an unsupplied register computes a *confident zero*. An **empty** register is still a real zero; only a **missing** one is unknown.

## Verified against the live book (07-Sep-2026)

| Expected | Live | |
|---|---|---|
| Invoiced MTD 464 | 463.7 | ✅ |
| Pending to Serve 4,542 | 4,542.0 | ✅ |
| Plant rows sum 4,542.1 | 4,542.1 | ✅ |
| Production 585 | 610.3 | one 25.3 T row dated ≤ 07-Sep was entered on 08-Sep: 585.0 + 25.3 ✅ |

- Movement identity: `1,317.2 + 610.3 − 463.7 = 1,463.787` = Physical Inventory (to 1e-13)
- **Baby-coil trap:** naive `Σ max(0, w−consumed)` = **1,662.1 T**; `babyCoilStock` (ADR-0007) = **1,548.1 T**; workbook prints **1,548.1 T**
- Workbook and message **deep-equal** on live data — all three objects, field for field
- Scoped file: `PB-MTD-Dashboard-…-hyderabad.xlsx`, says "Hyderabad only", never "ALL PLANTS"

**Live data caught a real defect.** 54 of 667 Sheet 4 rows failed the identity this PR originally documented as "exact, always". There are *two* floorings, not one — each cell floors its own plant, `onhand` floors the combined pool — so when a whole area is over-invoiced the left side goes negative while `onhand` is 0. The true form carries a floor:

```
max(0, Σ onhandByPlant − onhandByPlantUnmatched) === onhand    # holds on all 667
```

No figure changed — the code was right; the *claim about it* was wrong, in three places, with a test that only exercised the positive case. Corrected in `ba2af0b`.

## Anti-drift

`scripts/daily-messages.test.mjs` builds workbook and message from **one** row set and asserts whole objects are deep-equal. Verified it bites: injecting a 0.5 MT drift failed two tests.

## Notes

- Coil registers are **named** options — ~35 call sites already pass the options bag 5th, so a positional `coils` would have swallowed the date
- An existing test was found **passing for the wrong reason**: it asserted `?` in columns 9–10, which this PR turned into plant columns that read `?` on an Unmapped row for a different reason
- Caught by an existing test: the two new total rows said "ALL PLANTS" unconditionally, which on a scoped workbook is the mis-attribution ticket #117 exists to end
- `calc.js` carries a NUL byte like `reports.js` — neither may be edited with `sed`; both grep as binary

**553 tests** (from 513), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpCexXFruDbqpAPYjx1iEt