### PR TITLE
Guard fetch lists against silent zeros in daily reports

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -508,3 +508,79 @@ as the code will agree with the code; that is not verification.
 **The unit tests could not have caught this, because I wrote both from the same model of the problem.
 Real data disagreed with the model on the first run.** That is the whole argument for running a change
 against the live book before believing it.
+
+
+## 2026-09-08 — a fetch list is a dependency, and nothing was checking it
+
+`scripts/daily-splits.mjs` asked `orders` for fourteen columns. `salesByDistributor` reads sixteen.
+The two it never asked for were `mm_id` and `description` — the two the servable split is keyed on:
+
+```js
+const code = String(o.mmId || '').trim()
+if (code) { const s = skuOf(r, code, o.description); ... }
+```
+
+`o.mmId` read `undefined` on every fetched row, so no order line ever built a SKU row, `allConfirmed`
+and `allPending` per (region, size) came from dispatch lines alone, and the carve-out collapsed. Same
+1,633 rows, same builder, the only difference being whether the order rows carry `mm_id`, at
+D = 08-Sep-2026:
+
+```
+                          with mm_id     as it fetched
+  Confirmed                  317.4 T          317.4 T
+  Unconfirmed               4384.7 T         4384.7 T
+  Servable – Unconfirmed     632.0 T            0.0 T
+  Pending to Dispatch        949.4 T          317.4 T
+```
+
+**The two headline figures stayed right, which is what made it survive.** Confirmed and Unconfirmed
+are read straight off `o.confirmed` / `o.nonConfirmed` and never touch SKU identity, so the message
+looked ordinary. Only the stock-backed figure — the one ADR-0008 defines as `Confirmed + Servable –
+Unconfirmed` — degraded, and it degraded to exactly `Confirmed`, which is a plausible number.
+
+**All four tie-outs passed while it was wrong.** `confirmedTiesToBook` and `unconfirmedTiesToBook`
+compare region sums against distributor-level totals that do not involve `mmId`. `servableWithinUnconfirmed`
+asserts `servable <= unconfirmed`, which is trivially true at zero. The script exited 0 and the daily
+broadcast went out understating the floor. A check that can only fail upward cannot see a collapse.
+
+**A test can be built so it cannot fail, without anyone choosing that.** The obvious guard was to run
+the script twice through `--in` — whole rows, then rows projected down to the columns the select
+names — and deep-equal the two. Built on `scripts/daily-messages.test.mjs`'s existing fixture it
+passes with the bug in place: that book produces 18.5 T at Hyderabad against a 463.5 T dispatch, so
+its South pool is floored at zero and servable is 0 either way. Measured before writing anything.
+The new fixture puts 1,110 T on the floor and still leaves South short, and both round trips now
+assert the figure is non-trivial **before** asserting it is unchanged. Sweeping `tubeCount` found
+60,000 to be the value that reproduces the live signature rather than the saturated case.
+
+**Existence and sufficiency are different faults and neither guard sees the other.** Checking that
+every selected column exists in `supabase-setup.sql` catches a select that 400s; it is blind to a
+column that is simply missing. The projection round trip catches a figure quietly reading 0; it is
+blind to a column that does not exist, because a fixture happily carries a key no table has. Both
+live in `scripts/fetch-columns.test.mjs`, and both read the select strings from a new `--cols` flag
+rather than regexing the sources — `ORDER_COLS` is two concatenated strings, and a regex that matched
+a superset would turn the round trip into a no-op that passes forever.
+
+**The 04-Sep deferral is closed.** That entry recorded `servable-orders.mjs` asking `skus` for a
+`deleted` column that does not exist and said it "deserves its own test". This is that test, so it is
+now fixed — along with two more faults on the same line that nobody had noticed: `type` where the
+column is `product_type`, and no `nominal_bore` at all. On the live book that costs every size label
+its type suffix (`32 NBx2.5 CHS` reads as `32 NBx2.5 —`) and lets a CHS master row merge with tubes
+it is not.
+
+**`description` is load-bearing on its own.** Today 22 of the 208 distinct ERP codes on the open book
+have no SKU-master row — 139.0 T of open orders whose only statement of what the tube IS lives on the
+order line. (The code comment says 37 and LEARNINGS says 47; the number moves as the master is
+filled. What does not move is that it is never zero.)
+
+Both scripts now check the rows in hand once, after `loadRows()` and before `--dump` can freeze them
+into a fixture that gets replayed for weeks — because `--in` is where this recurs. The live
+verification route hand-writes a column list into an `execute_sql` every time, and no test can see
+that: `loadRows()` returns the parsed JSON long before a select list is read. Verified against the
+real book: the same 1,633 rows projected to the old select exit 1 naming `mmId` instead of printing
+0.0 T.
+
+**Not done here.** `servable-orders.mjs`'s `baby_coils` select omits `deleted`, which is arguably
+right — a soft-deleted baby coil should still carry its mother-coil mapping — and is left alone. And
+the CHS bridge is asymmetric even now: a master CHS row keys on `25 NB` while an order that reaches
+the same tube only through its description keys on `33.7x2.9`, so those two never merge. Both are
+real, both are separate changes, and both deserve their own test.

--- a/scripts/daily-splits.mjs
+++ b/scripts/daily-splits.mjs
@@ -39,6 +39,7 @@
 //   --key    anon key                 ) else SUPABASE_ANON_KEY / VITE_SUPABASE_ANON_KEY, then .env.local
 //   --in     read rows from a dumped JSON instead of the network (offline / reproduce a past day)
 //   --dump   write the fetched rows to a JSON file for --in
+//   --cols   print the PostgREST select lists this script sends, as JSON, and exit
 //   --pretty indent the output
 //
 // stdout: the JSON summary — { date, month, regionSplit, plantSplit, servableSplit, plantPipeline,
@@ -135,6 +136,23 @@ const COIL_COLS = 'id,deleted,created_at,hr_coil_id,actual_weight,plant'
 const BABY_COIL_COLS = 'id,deleted,created_at,baby_coil_id,hr_coil_id,weight,consumed,plant'
 const PLANT_COLS = 'id,created_at,plant_id,serves,deleted'
 
+// One map keyed by TABLE — what goes on the wire and what `--cols` prints are the same object, so a
+// select list cannot be changed without scripts/fetch-columns.test.mjs seeing it. loadRows() looks
+// tables up here by name rather than passing a constant, so a table added without an entry sends
+// `select=undefined` and 400s loudly instead of fetching something nobody declared.
+const SELECT = {
+  orders: ORDER_COLS, dispatches: DISPATCH_COLS, state_regions: REGION_COLS,
+  distributors: DISTRIBUTOR_COLS, productions: PRODUCTION_COLS, skus: SKU_COLS,
+  coils: COIL_COLS, baby_coils: BABY_COIL_COLS, plants: PLANT_COLS,
+}
+
+// `--cols`: print the exact select lists this script sends, then stop. A diagnostic when a fetch
+// 400s ("what did we actually ask for?"), and the seam the column tests read — a test that regexed
+// this file instead would have to cope with ORDER_COLS being two concatenated strings, and a regex
+// that quietly matched a SUPERSET would turn the round-trip test into a no-op.
+// writeFileSync(1, ...) not console.log: stdout to a pipe is async and process.exit can truncate it.
+if (has('cols')) { writeFileSync(1, JSON.stringify(SELECT) + '\n'); process.exit(0) }
+
 async function loadRows() {
   const inFile = flag('in')
   if (inFile) {
@@ -152,17 +170,11 @@ async function loadRows() {
         '  get_project_url + get_publishable_keys (project ref hztblmccvvarmgxmunrp).')
   }
   const base = url.replace(/\/+$/, '')
+  const get = (table) => fetchAll(base, key, table, SELECT[table])
   const [orders, dispatches, stateRegions, distributors, productions, skus, coils, babyCoils, plants] =
     await Promise.all([
-      fetchAll(base, key, 'orders', ORDER_COLS),
-      fetchAll(base, key, 'dispatches', DISPATCH_COLS),
-      fetchAll(base, key, 'state_regions', REGION_COLS),
-      fetchAll(base, key, 'distributors', DISTRIBUTOR_COLS),
-      fetchAll(base, key, 'productions', PRODUCTION_COLS),
-      fetchAll(base, key, 'skus', SKU_COLS),
-      fetchAll(base, key, 'coils', COIL_COLS),
-      fetchAll(base, key, 'baby_coils', BABY_COIL_COLS),
-      fetchAll(base, key, 'plants', PLANT_COLS),
+      get('orders'), get('dispatches'), get('state_regions'), get('distributors'),
+      get('productions'), get('skus'), get('coils'), get('baby_coils'), get('plants'),
     ])
   return { orders, dispatches, stateRegions, distributors, productions, skus, coils, babyCoils, plants }
 }

--- a/scripts/daily-splits.mjs
+++ b/scripts/daily-splits.mjs
@@ -162,6 +162,52 @@ const SELECT = {
 // writeFileSync(1, ...) not console.log: stdout to a pipe is async and process.exit can truncate it.
 if (has('cols')) { writeFileSync(1, JSON.stringify(SELECT) + '\n'); process.exit(0) }
 
+// ── Fields the figures are built from, checked on the rows in hand ──────────────────────────────
+// One entry per field whose ABSENCE turns a printed figure into 0 while every tie-out still passes.
+// `mmId` is why this exists: it was missing from the orders select, so salesByDistributor built no
+// SKU row for any order, Servable – Unconfirmed printed 0.0 T against a real 591.6 T, and nothing
+// objected. "Servable is 0" and "we can serve nothing" read identically to anyone downstream.
+//
+// The bar for adding a field here is exactly that shape — silently zero, and no existing check
+// notices. `shipToState` is NOT on the list: losing it makes every distributor Unmapped, which the
+// unmapped diagnostic already shouts about. `confirmed`/`nonConfirmed` are NOT on it: losing them
+// takes every headline to zero, which nobody can miss. A guard list that grows without a rule
+// becomes noise, and noise is how the next silent zero gets through.
+const REQUIRED = { orders: ['mmId'] }
+
+// PRESENCE first, then value — two faults, two messages, because the fix differs:
+//   • the key is on NO row                              → nobody asked for the column (a select
+//                                                         list, or a hand-written --in bundle built
+//                                                         from an execute_sql that omitted it)
+//   • the key is there, blank on every non-deleted row  → the column was asked for and came back
+//                                                         empty, so the upload is the problem
+// PostgREST returns a selected-but-null column as a present key holding null, so those two really
+// are different signals. Neither can false-fire: a table with no rows is skipped outright (an empty
+// book is not a fault), and a book where ANY live line carries a value passes.
+//
+// Runs on --in as well as the live fetch, deliberately. --in is where this fault recurs: the
+// live-verification route hand-writes the column list into an execute_sql every time, and no test
+// can see that, because loadRows() returns the parsed JSON long before any select list is read.
+function assertRequired(bundle) {
+  for (const [table, fields] of Object.entries(REQUIRED)) {
+    const rows = bundle[table]
+    if (!Array.isArray(rows) || !rows.length) continue
+    const live = rows.filter(r => r && !r.deleted)
+    for (const f of fields) {
+      if (!rows.some(r => r && f in r)) {
+        die(`${table}: not one of the ${rows.length} rows carries \`${f}\`.\n` +
+            `  Every figure built from it would read 0 and every tie-out would still pass, so this\n` +
+            `  would print a false headline rather than fail. Add the column to the ${table} select\n` +
+            `  list (--cols prints what this script sends) or to the query behind the --in bundle.`)
+      }
+      if (live.length && !live.some(r => String(r[f] ?? '').trim())) {
+        die(`${table}: \`${f}\` is present but blank on all ${live.length} live row(s).\n` +
+            `  The column was asked for and came back empty — check the upload, not the select list.`)
+      }
+    }
+  }
+}
+
 async function loadRows() {
   const inFile = flag('in')
   if (inFile) {
@@ -191,6 +237,10 @@ async function loadRows() {
 // ── main ──
 const { orders, dispatches, stateRegions, distributors, productions, skus, coils, babyCoils, plants } =
   await loadRows()
+
+// Before anything is computed off these rows, and before --dump can freeze them into a fixture that
+// gets replayed for weeks: do they carry the fields the figures need? See REQUIRED above.
+assertRequired({ orders })
 
 const dumpFile = flag('dump')
 if (dumpFile) {

--- a/scripts/daily-splits.mjs
+++ b/scripts/daily-splits.mjs
@@ -124,10 +124,12 @@ async function fetchAll(url, key, table, select) {
 // `mm_id` and `description` are what the SERVABLE split is built from. salesByDistributor keys its
 // per-SKU rows on `mmId`, bridging through the order line's OWN description for the ERP codes the
 // SKU master does not carry. Leaving them out did not fail: `o.mmId` read undefined on every row,
-// no order built a SKU row, and Servable – Unconfirmed printed 0.0 T against a real 591.6 T while
-// Pending to Dispatch degraded to just Confirmed (909.0 → 317.4 T on 08-Sep-2026). All four
-// tie-outs at the foot of this file still passed — servableWithinUnconfirmed is trivially true when
-// servable is 0 — so the run exited 0 and the daily broadcast went out understating the floor.
+// no order built a SKU row, Servable – Unconfirmed printed 0.0 T, and Pending to Dispatch degraded
+// to exactly Confirmed. Measured on the live book at D = 08-Sep-2026, same 1,633 rows either way:
+// 632.0 T of servable tonnage read as 0.0, and 949.4 T of Pending to Dispatch read as 317.4. The
+// tonnage moves with the floor through the day; the collapse to exactly Confirmed does not. All
+// four tie-outs at the foot of this file still passed — servableWithinUnconfirmed is trivially true
+// when servable is 0 — so the run exited 0 and the daily broadcast went out understating the floor.
 // Ordered to match servable-orders.mjs's COLS.orders, so the two lists diff to nothing but `plant`.
 const ORDER_COLS = 'id,deleted,created_at,order_date,order_id,child_order_id,line_id,customer,' +
   'distributor_code,ship_to_state,order_status,mm_id,description,confirmed,non_confirmed,plant'
@@ -165,7 +167,7 @@ if (has('cols')) { writeFileSync(1, JSON.stringify(SELECT) + '\n'); process.exit
 // ── Fields the figures are built from, checked on the rows in hand ──────────────────────────────
 // One entry per field whose ABSENCE turns a printed figure into 0 while every tie-out still passes.
 // `mmId` is why this exists: it was missing from the orders select, so salesByDistributor built no
-// SKU row for any order, Servable – Unconfirmed printed 0.0 T against a real 591.6 T, and nothing
+// SKU row for any order, Servable – Unconfirmed printed 0.0 T against a real 632.0 T, and nothing
 // objected. "Servable is 0" and "we can serve nothing" read identically to anyone downstream.
 //
 // The bar for adding a field here is exactly that shape — silently zero, and no existing check

--- a/scripts/daily-splits.mjs
+++ b/scripts/daily-splits.mjs
@@ -120,8 +120,17 @@ async function fetchAll(url, key, table, select) {
 
 // `plant` (ticket #118) is what the plant split groups by. A database that predates it fails the
 // fetch outright rather than quietly reporting every line as Unattributed — see loadRows().
+//
+// `mm_id` and `description` are what the SERVABLE split is built from. salesByDistributor keys its
+// per-SKU rows on `mmId`, bridging through the order line's OWN description for the ERP codes the
+// SKU master does not carry. Leaving them out did not fail: `o.mmId` read undefined on every row,
+// no order built a SKU row, and Servable – Unconfirmed printed 0.0 T against a real 591.6 T while
+// Pending to Dispatch degraded to just Confirmed (909.0 → 317.4 T on 08-Sep-2026). All four
+// tie-outs at the foot of this file still passed — servableWithinUnconfirmed is trivially true when
+// servable is 0 — so the run exited 0 and the daily broadcast went out understating the floor.
+// Ordered to match servable-orders.mjs's COLS.orders, so the two lists diff to nothing but `plant`.
 const ORDER_COLS = 'id,deleted,created_at,order_date,order_id,child_order_id,line_id,customer,' +
-  'distributor_code,ship_to_state,order_status,confirmed,non_confirmed,plant'
+  'distributor_code,ship_to_state,order_status,mm_id,description,confirmed,non_confirmed,plant'
 const DISPATCH_COLS = 'id,deleted,created_at,date_of_dispatch,bundle_entries'
 const REGION_COLS = 'id,created_at,state,region,deleted'
 // The distributor master (ticket #129) carries a per-distributor region OVERRIDE, and an override

--- a/scripts/fetch-columns.test.mjs
+++ b/scripts/fetch-columns.test.mjs
@@ -1,0 +1,229 @@
+// ── The fetch must ask for exactly what the figures read ────────────────────────────────────────
+//
+// scripts/daily-splits.mjs and scripts/servable-orders.mjs each hand-write a PostgREST `select=`
+// list. Nothing tied those lists to what src/lib actually reads off a row, and that cost a headline:
+// `orders` was fetched without `mm_id`, so salesByDistributor (calc.js, `const code = String(o.mmId
+// || '').trim()`) built no per-SKU row for any order, and Servable – Unconfirmed printed 0.0 T
+// against a real 591.6 T on 08-Sep-2026 while Pending to Dispatch fell from 909.0 T to 317.4 T.
+// Every tie-out in the script still passed: servableWithinUnconfirmed is trivially true when
+// servable is 0, so the run exited 0 and the daily broadcast went out understating the floor.
+//
+// Two guards, catching DIFFERENT faults. Neither subsumes the other:
+//
+//   (a) existence    every column a select NAMES is a real column   → catches a select that 400s
+//   (b) sufficiency  every column the code READS is in the select   → catches a figure reading 0
+//
+// (a) cannot see a missing column. (b) cannot see a column that does not exist, because a fixture
+// happily carries a key no table has — which is how servable-orders.mjs asked `skus` for `deleted`
+// and `type` for months without a single test noticing that its live path could not run at all.
+//
+// Both read the select lists from `--cols` rather than regexing the sources. ORDER_COLS is two
+// concatenated strings, and a regex that quietly matched a SUPERSET would turn (b) into a no-op.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const D = '2026-08-31'
+const run = (script, args) =>
+  execFileSync(process.execPath, [resolve(process.cwd(), 'scripts', script), ...args],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+
+// ── (a) The schema, read from the file that creates it ──────────────────────────────────────────
+// Both DDL shapes count: half of what these scripts select (orders.plant, orders.confirmed,
+// skus.weight_per_tube) arrived as an idempotent `alter table … add column`, not in a create block.
+const sql = readFileSync(resolve(process.cwd(), 'supabase-setup.sql'), 'utf8')
+  .replace(/--[^\n]*/g, '')                        // `plant text,   -- ticket #118`
+const NOT_A_COLUMN = /^(unique|primary|foreign|constraint|check|exclude|like|partition)$/i
+
+// Split on commas at paren depth 0 — `unique (distributor_key, month)` is ONE part, not two.
+const topLevelParts = (body) => {
+  const out = []
+  let depth = 0, cur = ''
+  for (const ch of body) {
+    if (ch === '(') depth++
+    else if (ch === ')') depth--
+    if (ch === ',' && depth === 0) { out.push(cur); cur = '' } else cur += ch
+  }
+  return out.concat(cur)
+}
+
+const schema = new Map()
+const addCol = (t, c) => { if (!schema.has(t)) schema.set(t, new Set()); schema.get(t).add(c) }
+for (const [, table, body] of sql.matchAll(/create table (?:if not exists )?(\w+)\s*\(([\s\S]*?)\n\s*\);/gi)) {
+  if (!schema.has(table)) schema.set(table, new Set())
+  for (const part of topLevelParts(body)) {
+    const name = part.trim().split(/\s+/)[0]
+    if (name && !NOT_A_COLUMN.test(name)) addCol(table, name)
+  }
+}
+for (const [, t, c] of sql.matchAll(/alter table (\w+)\s+add column\s+(?:if not exists\s+)?(\w+)/gi)) addCol(t, c)
+
+describe('(a) every column these scripts select exists in supabase-setup.sql', () => {
+  // The parser's own control. A regex that over-matched — swallowing the file as one table body —
+  // would make every assertion below pass while checking nothing. These pin that it discriminates:
+  // the column that IS there, the one named differently, and the two that are not there at all.
+  it('reads the DDL precisely enough to be worth trusting', () => {
+    expect([...schema.keys()]).toEqual(expect.arrayContaining(
+      ['orders', 'dispatches', 'productions', 'skus', 'coils', 'baby_coils', 'plants', 'distributors', 'state_regions']))
+    expect(schema.get('orders')).toContain('mm_id')          // the column this whole file exists for
+    expect(schema.get('orders')).toContain('plant')          // arrives via `alter table … add column`
+    expect(schema.get('skus')).toContain('product_type')
+    expect(schema.get('skus')).toContain('nominal_bore')
+    expect(schema.get('skus')).not.toContain('type')         // servable-orders.mjs asked for this
+    expect(schema.get('skus')).not.toContain('deleted')      // …and this; both 400 the whole fetch
+    expect(schema.get('orders')).not.toContain('unique')     // constraint lines are not columns
+  })
+
+  it.each(['daily-splits.mjs', 'servable-orders.mjs'])('%s names no column the schema lacks', (script) => {
+    const selects = JSON.parse(run(script, ['--cols']))
+    const bad = []
+    for (const [table, select] of Object.entries(selects)) {
+      if (!schema.has(table)) { bad.push(`${table} — no such table`); continue }
+      for (const col of select.split(',').map(s => s.trim()).filter(Boolean)) {
+        if (!schema.get(table).has(col)) bad.push(`${table}.${col}`)
+      }
+    }
+    expect(bad).toEqual([])
+  })
+})
+
+// ── (b) A book built so that dropping a column changes a printed number ─────────────────────────
+// It cannot reuse scripts/daily-messages.test.mjs's fixture: that one produces 18.5 T at Hyderabad
+// against a 463.5 T dispatch, so its South pool is floored at zero and servable is 0 whether or not
+// `mm_id` is fetched. A round trip over it would have passed all through the outage it exists to
+// catch. 60 000 tubes puts 1110 T on the floor, so the figure is real and CAN collapse — and South
+// still ends short, so the partial case is exercised rather than the saturated one.
+//
+// Every feature below is here to make one named column load-bearing. Measured by dropping each
+// column from the select in turn: 30 of them change the output, including all of `mm_id`,
+// `description`, `nominal_bore`, `weight_per_tube`, `plants.serves` and `distributors.region`.
+const SHS = 'MS SHS One Helix IS 4923 YSt 210 Black 50x50x2.00x6000'
+const CHS = 'MS CHS One Helix IS 1239 YSt 210 Black 33.7x2.9x6000'
+
+const book = {
+  skus: [
+    { id: 's1', skuCode: 'S1', description: SHS, productType: 'SHS', height: 50, breadth: 50,
+      nominalBore: '', outsideDiameter: '', thickness: 2, length: 6000, weightPerTube: 18.5, status: 'published' },
+    // A CHS master row keys on its NOMINAL BORE ("25 NB"); an order that reaches it only through a
+    // description keys on the section ("33.7x2.9"). Drop nominal_bore and the two wrongly merge.
+    { id: 's2', skuCode: 'C1', description: CHS, productType: 'CHS', height: '', breadth: '',
+      nominalBore: '25', outsideDiameter: 33.7, thickness: 2.9, length: 6000, weightPerTube: 4.4, status: 'published' },
+  ],
+  // `totalWeight` is deliberately stale: tonnage must come from tubeCount x weightPerTube
+  // (CLAUDE.md non-negotiable), so dropping weight_per_tube has to change the answer, not fall back
+  // to a frozen total that happens to agree.
+  productions: [
+    { id: 'p1', deleted: false, plant: 'hyderabad', dateOfProduction: '2026-08-05', skuCode: 'S1', tubeCount: 60000, totalWeight: 1 },
+    { id: 'p2', deleted: false, plant: 'hyderabad', dateOfProduction: '2026-08-06', skuCode: 'C1', tubeCount: 20000, totalWeight: 1 },
+  ],
+  orders: [
+    // South, the SHS book — the servable figure lives here.
+    { id: 'o1', deleted: false, plant: 'hyderabad', orderDate: '2026-08-10', customer: 'PATEL STEEL', distributorCode: 'D1',
+      lineId: 'L1', orderId: 'PO-1', childOrderId: 'CO-1', shipToState: 'TELANGANA', orderStatus: '',
+      mmId: 'S1', description: SHS, confirmed: 400, nonConfirmed: 361.441 },
+    // West by state, but the distributor master overrides it to South (ticket #129 / ADR-0003).
+    { id: 'o2', deleted: false, plant: 'npmd', orderDate: '2026-08-10', customer: 'PUNE STEEL', distributorCode: 'D2',
+      lineId: 'L2', orderId: 'PO-2', childOrderId: 'CO-2', shipToState: 'MAHARASHTRA', orderStatus: '',
+      mmId: 'S1', description: SHS, confirmed: 0, nonConfirmed: 1044 },
+    // An ERP code the SKU master does not carry — it reaches a physical identity ONLY through the
+    // order line's own description, which is the other column that went missing.
+    { id: 'o3', deleted: false, plant: 'hyderabad', orderDate: '2026-08-11', customer: 'ARIHANT STEEL', distributorCode: 'D3',
+      lineId: 'L3', orderId: 'PO-3', childOrderId: 'CO-3', shipToState: 'KARNATAKA', orderStatus: '',
+      mmId: 'C-ERP-9', description: CHS, confirmed: 0, nonConfirmed: 50 },
+    // One distributor, two states, EARLIER line first — the most recent line decides its region.
+    { id: 'o4', deleted: false, plant: 'npmd', orderDate: '2026-08-01', customer: 'KIRTI TUBES', distributorCode: 'D4',
+      lineId: 'L4', orderId: 'PO-4', childOrderId: 'CO-4', shipToState: 'GUJARAT', orderStatus: '',
+      mmId: 'S1', description: SHS, confirmed: 0, nonConfirmed: 20 },
+    { id: 'o5', deleted: false, plant: 'hyderabad', orderDate: '2026-08-20', customer: 'KIRTI TUBES', distributorCode: 'D4',
+      lineId: 'L5', orderId: 'PO-5', childOrderId: 'CO-5', shipToState: 'TAMIL NADU', orderStatus: '',
+      mmId: 'S1', description: SHS, confirmed: 30, nonConfirmed: 60 },
+    // Soft-deleted, carrying tonnage nobody may count.
+    { id: 'o6', deleted: true, plant: 'hyderabad', orderDate: '2026-08-12', customer: 'PATEL STEEL', distributorCode: 'D1',
+      lineId: 'L6', orderId: 'PO-6', childOrderId: 'CO-6', shipToState: 'TELANGANA', orderStatus: '',
+      mmId: 'S1', description: SHS, confirmed: 999, nonConfirmed: 999 },
+    // Delivered — off the open book.
+    { id: 'o7', deleted: false, plant: 'hyderabad', orderDate: '2026-08-13', customer: 'PATEL STEEL', distributorCode: 'D1',
+      lineId: 'L7', orderId: 'PO-7', childOrderId: 'CO-7', shipToState: 'TELANGANA', orderStatus: 'Delivered',
+      mmId: 'S1', description: SHS, confirmed: 888, nonConfirmed: 888 },
+  ],
+  // Three bundle entries carrying NO code and NO customer of their own — each resolves to D1 through
+  // a different link key, which is what makes line_id / order_id / child_order_id load-bearing.
+  dispatches: [
+    { id: 'd1', deleted: false, dateOfDispatch: '2026-08-12', bundleEntries: [
+      { plant: 'hyderabad', orderLineId: 'L1', skuCode: 'S1', weight: 200, pieces: 10 },
+      { plant: 'hyderabad', orderId: 'PO-1', skuCode: 'S1', weight: 150, pieces: 8 },
+      { plant: 'hyderabad', childOrderId: 'CO-1', skuCode: 'S1', weight: 113.5, pieces: 6 },
+    ] },
+  ],
+  coils: [{ id: 'c1', deleted: false, hrCoilId: 'H1', plant: 'hyderabad', actualWeight: 260 }],
+  babyCoils: [{ id: 'b1', deleted: false, babyCoilId: 'B1', hrCoilId: 'H9', plant: 'hyderabad', weight: 44 }],
+  stateRegions: null,
+  plants: [
+    { id: 'pl1', deleted: false, plantId: 'hyderabad', serves: 'South' },
+    { id: 'pl2', deleted: false, plantId: 'npmd', serves: 'West' },
+  ],
+  distributors: [
+    { id: 'dm1', deleted: false, distributorKey: 'D2', distributorName: 'PUNE STEEL', region: 'South' },
+  ],
+}
+
+// snake_case → camelCase, TOP LEVEL ONLY. The keys inside dispatches.bundleEntries are already
+// camelCase and no select list covers them; recursing would strip every entry to {}.
+const camel = (k) => k.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase())
+const project = (bundle, selects) => {
+  const out = { ...bundle }
+  for (const [table, select] of Object.entries(selects)) {
+    const keep = new Set(select.split(',').map(s => camel(s.trim())).filter(Boolean))
+    const key = camel(table)                       // baby_coils → babyCoils, state_regions → stateRegions
+    // `null` is meaningful here — "this master is absent, use the code seed" — so it is left alone.
+    if (Array.isArray(out[key])) out[key] = out[key].map(r => Object.fromEntries(
+      Object.entries(r).filter(([k]) => keep.has(k))))
+  }
+  return out
+}
+
+describe('(b) every column these scripts read is in the select they send', () => {
+  let dir
+  beforeAll(() => { dir = mkdtempSync(join(tmpdir(), 'jsw-cols-')) })
+  afterAll(() => rmSync(dir, { recursive: true, force: true }))
+  const fixture = (name, obj) => {
+    const p = join(dir, `${name}.json`); writeFileSync(p, JSON.stringify(obj)); return p
+  }
+
+  it('daily-splits.mjs — the servable split survives the round trip', () => {
+    const selects = JSON.parse(run('daily-splits.mjs', ['--cols']))
+    const whole = JSON.parse(run('daily-splits.mjs', ['--date', D, '--in', fixture('whole', book)]))
+
+    // The line that keeps this test honest. If the book cannot produce a servable figure, the round
+    // trip compares 0 with 0 and proves nothing — which is exactly how this bug survived the
+    // existing suite. Assert the figure is real BEFORE asserting it is unchanged.
+    expect(whole.servableSplit.totals.servableUnconfirmed).toBeGreaterThan(1)
+
+    const thin = JSON.parse(run('daily-splits.mjs', ['--date', D, '--in', fixture('thin', project(book, selects))]))
+    expect(thin).toEqual(whole)
+  })
+
+  it('servable-orders.mjs — the per-distributor report survives the round trip', () => {
+    const selects = JSON.parse(run('servable-orders.mjs', ['--cols']))
+    const whole = JSON.parse(run('servable-orders.mjs', ['--date', D, '--json', '--in', fixture('so-whole', book)]))
+
+    // Same precondition, in this script's own terms: distributors on the list, with stock behind
+    // them. Compared as JSON, not as the WhatsApp text — a text diff hides a figure that still
+    // rounds to the same 0.1 T.
+    expect(whole.totals.distributors).toBeGreaterThan(1)
+    expect(whole.distributors.reduce((a, r) => a + r.servable, 0)).toBeGreaterThan(1)
+
+    const thin = JSON.parse(run('servable-orders.mjs', ['--date', D, '--json', '--in', fixture('so-thin', project(book, selects))]))
+    expect(thin).toEqual(whole)
+  })
+})
+
+// What (b) cannot prove, so that nobody reads more into a green run than is there:
+//   • `created_at` is load-bearing only as the SERVER-SIDE sort key (`order=created_at.asc,id.asc`,
+//     which distributorOrderIndex depends on — it takes the first non-blank row per link key). No
+//     --in fixture reaches that ordering; (a) covers the column's existence and nothing covers the
+//     ORDER BY, which is why both scripts carry it in a comment instead.
+//   • sufficiency, never minimality. It will never tell you a column is fetched and read by nobody.

--- a/scripts/servable-orders.mjs
+++ b/scripts/servable-orders.mjs
@@ -137,7 +137,7 @@ if (has('cols')) { writeFileSync(1, JSON.stringify(COLS) + '\n'); process.exit(0
 // ── Fields the figures are built from, checked on the rows in hand ──────────────────────────────
 // One entry per field whose ABSENCE turns a printed figure into 0 while every tie-out still passes.
 // `mmId` is why this exists: it was missing from the orders select, so salesByDistributor built no
-// SKU row for any order, Servable – Unconfirmed printed 0.0 T against a real 591.6 T, and nothing
+// SKU row for any order, Servable – Unconfirmed printed 0.0 T against a real 632.0 T, and nothing
 // objected. "Servable is 0" and "we can serve nothing" read identically to anyone downstream.
 //
 // The bar for adding a field here is exactly that shape — silently zero, and no existing check

--- a/scripts/servable-orders.mjs
+++ b/scripts/servable-orders.mjs
@@ -134,6 +134,52 @@ const COLS = {
 // writeFileSync(1, ...) not console.log: stdout to a pipe is async and process.exit can truncate it.
 if (has('cols')) { writeFileSync(1, JSON.stringify(COLS) + '\n'); process.exit(0) }
 
+// ── Fields the figures are built from, checked on the rows in hand ──────────────────────────────
+// One entry per field whose ABSENCE turns a printed figure into 0 while every tie-out still passes.
+// `mmId` is why this exists: it was missing from the orders select, so salesByDistributor built no
+// SKU row for any order, Servable – Unconfirmed printed 0.0 T against a real 591.6 T, and nothing
+// objected. "Servable is 0" and "we can serve nothing" read identically to anyone downstream.
+//
+// The bar for adding a field here is exactly that shape — silently zero, and no existing check
+// notices. `shipToState` is NOT on the list: losing it makes every distributor Unmapped, which the
+// unmapped diagnostic already shouts about. `confirmed`/`nonConfirmed` are NOT on it: losing them
+// takes every headline to zero, which nobody can miss. A guard list that grows without a rule
+// becomes noise, and noise is how the next silent zero gets through.
+const REQUIRED = { orders: ['mmId'] }
+
+// PRESENCE first, then value — two faults, two messages, because the fix differs:
+//   • the key is on NO row                              → nobody asked for the column (a select
+//                                                         list, or a hand-written --in bundle built
+//                                                         from an execute_sql that omitted it)
+//   • the key is there, blank on every non-deleted row  → the column was asked for and came back
+//                                                         empty, so the upload is the problem
+// PostgREST returns a selected-but-null column as a present key holding null, so those two really
+// are different signals. Neither can false-fire: a table with no rows is skipped outright (an empty
+// book is not a fault), and a book where ANY live line carries a value passes.
+//
+// Runs on --in as well as the live fetch, deliberately. --in is where this fault recurs: the
+// live-verification route hand-writes the column list into an execute_sql every time, and no test
+// can see that, because loadRows() returns the parsed JSON long before any select list is read.
+function assertRequired(bundle) {
+  for (const [table, fields] of Object.entries(REQUIRED)) {
+    const rows = bundle[table]
+    if (!Array.isArray(rows) || !rows.length) continue
+    const live = rows.filter(r => r && !r.deleted)
+    for (const f of fields) {
+      if (!rows.some(r => r && f in r)) {
+        die(`${table}: not one of the ${rows.length} rows carries \`${f}\`.\n` +
+            `  Every figure built from it would read 0 and every tie-out would still pass, so this\n` +
+            `  would print a false headline rather than fail. Add the column to the ${table} select\n` +
+            `  list (--cols prints what this script sends) or to the query behind the --in bundle.`)
+      }
+      if (live.length && !live.some(r => String(r[f] ?? '').trim())) {
+        die(`${table}: \`${f}\` is present but blank on all ${live.length} live row(s).\n` +
+            `  The column was asked for and came back empty — check the upload, not the select list.`)
+      }
+    }
+  }
+}
+
 async function loadRows() {
   const aggFile = flag('agg')
   if (aggFile) return loadAggregated(aggFile)
@@ -273,6 +319,10 @@ function assertBundleTies(checks, { orders, productions, dispatches }) {
 // down, and two different things under one name in one module is a bug waiting to be written.
 const { orders, dispatches, productions, skus, babyCoils, stateRegions, plants,
         distributors: distributorMaster, aggregated } = await loadRows()
+
+// Before anything is computed off these rows, and before --dump can freeze them into a fixture that
+// gets replayed for weeks: do they carry the fields the figures need? See REQUIRED above.
+assertRequired({ orders })
 
 const dumpFile = flag('dump')
 if (dumpFile) {

--- a/scripts/servable-orders.mjs
+++ b/scripts/servable-orders.mjs
@@ -42,6 +42,7 @@
 //   --top   at most this many SKU lines per distributor (default 5). The rest collapse into one
 //           "+N more sizes" line that still carries their tonnage, so nothing vanishes from a
 //           distributor's total. Use --top 0 for every size.
+//   --cols  print the PostgREST select lists this script sends, as JSON, and exit.
 //   --json  emit the JSON summary on stdout instead of the WhatsApp text.
 //
 // stdout: the WhatsApp message (or JSON with --json)
@@ -119,6 +120,12 @@ const COLS = {
   plants: 'id,created_at,plant_id,serves,deleted',
   distributors: 'id,created_at,distributor_key,distributor_name,region,deleted',
 }
+
+// `--cols`: print the exact select lists this script sends, then stop. A diagnostic when a fetch
+// 400s ("what did we actually ask for?"), and the seam scripts/fetch-columns.test.mjs reads. Sits
+// above loadRows() so it needs no credentials.
+// writeFileSync(1, ...) not console.log: stdout to a pipe is async and process.exit can truncate it.
+if (has('cols')) { writeFileSync(1, JSON.stringify(COLS) + '\n'); process.exit(0) }
 
 async function loadRows() {
   const aggFile = flag('agg')

--- a/scripts/servable-orders.mjs
+++ b/scripts/servable-orders.mjs
@@ -114,7 +114,14 @@ const COLS = {
   orders: 'id,deleted,created_at,order_date,order_id,child_order_id,line_id,customer,distributor_code,ship_to_state,order_status,mm_id,description,confirmed,non_confirmed',
   dispatches: 'id,deleted,created_at,date_of_dispatch,bundle_entries',
   productions: 'id,deleted,created_at,date_of_production,sku_code,tube_count,total_weight,coil_allocations,plant',
-  skus: 'id,deleted,created_at,sku_code,description,type,height,breadth,outside_diameter,thickness,length,weight_per_tube',
+  // Three faults, one line, and the first of them meant this script's LIVE path had never run:
+  // `skus` has no `deleted` column, so PostgREST 400'd the whole fetch and only --agg ever
+  // worked. `type` is not the column either — it is `product_type`, which is what line 443 and
+  // canonicalSkuKey read. And without `nominal_bore`, skuSizeLabel falls through to parsing the
+  // description, so a 25 NB tube keys and labels as 33.7x2.9 and merges with things it is not.
+  // Differs from daily-splits.mjs's SKU_COLS by exactly `status`, which that script filters on
+  // and this one does not read.
+  skus: 'id,created_at,sku_code,description,product_type,height,breadth,nominal_bore,outside_diameter,thickness,length,weight_per_tube',
   baby_coils: 'id,created_at,baby_coil_id,hr_coil_id',
   state_regions: 'id,created_at,state,region,deleted',
   plants: 'id,created_at,plant_id,serves,deleted',


### PR DESCRIPTION
## Summary

`scripts/daily-splits.mjs` fetched `orders` without `mm_id` and `description` — the two columns the servable split is keyed on. `salesByDistributor` builds a per-SKU row only for a line that carries a code (`const code = String(o.mmId || '').trim()`), so no order ever built one, and `Servable – Unconfirmed` printed **0.0 T against a real 632.0 T** while `Pending to Dispatch` degraded to exactly `Confirmed`.

All four tie-outs passed while it was wrong: `servableWithinUnconfirmed` is trivially true at zero, and the other three never touch SKU identity. The run exited 0 and the daily broadcast went out understating the floor.

### Measured on the live book, D = 08-Sep-2026

Same 1,633 rows, same builder, the only difference being whether the order rows carry `mm_id`:

| | Confirmed | Unconfirmed | Servable – Unconf. | Pending to Dispatch |
|---|---|---|---|---|
| with `mm_id` | 317.4 T | 4384.7 T | **632.0 T** | **949.4 T** |
| as it used to fetch | 317.4 T | 4384.7 T | **0.0 T** | **317.4 T** |

Confirmed and Unconfirmed are identical either way, which is why this survived — the two headline order figures looked right while the stock-backed one read zero. Per ADR-0008 `Pending to Dispatch = Confirmed + Servable – Unconfirmed`, so it degraded to just Confirmed.

The originally-reported figures were 591.6 T / 909.0 T on the same date; the gap is the floor moving through the day, not a modelling difference. Ruled out the one thing that could have made it one: the verification bundle carries only non-deleted dispatch rows (214 of 8,672), and both consumers — `producedPool` (`calc.js:430`) and `salesByDistributor`'s invoice loop (`calc.js:1926`) — filter `!d.deleted` themselves.

## Changes

- **`scripts/daily-splits.mjs`** — `mm_id` and `description` added to `ORDER_COLS`, ordered to match `servable-orders.mjs`'s `COLS.orders` so the two lists diff to nothing but `plant`. Select lists collected into one `SELECT` map keyed by table, which `loadRows()` now looks tables up in — a table added without an entry sends `select=undefined` and 400s loudly.
- **`scripts/servable-orders.mjs`** — its orders select already carried both columns, so it did **not** have this bug. Its `skus` select was broken three ways instead, and the first meant this script's live path had never run at all: `deleted` (no such column, so PostgREST 400s the whole fetch), `type` where the column is `product_type`, and no `nominal_bore`. Closes the deferral left open at `LEARNINGS.md:376-382`.
- **`--cols` on both scripts** — prints the select lists as JSON and exits, above `loadRows()` so it needs no credentials. Neither script can be imported to read its constants (`daily-splits.mjs` ends in a top-level `await loadRows()`).
- **`assertRequired()` on both** — refuses to print rather than report a plausible zero, once after `loadRows()` and before `--dump` can freeze the rows into a fixture. Two arms: the key is on no row (nobody asked for the column) vs present but blank on every live row (the upload is the problem).
- **New `scripts/fetch-columns.test.mjs`** — the two guards below.
- **`LEARNINGS.md`** — the measurement, why it survived, and the fixture finding.

## Why two guards

They catch disjoint faults and neither subsumes the other:

- **(a) Existence** — every column a select *names* is a real column in `supabase-setup.sql`. This is what catches a select that 400s, and it is what would have caught `servable-orders.mjs` asking `skus` for `deleted` and `type`. It is blind to a column that is simply missing.
- **(b) Sufficiency** — every column the code *reads* is in the select, proved by running each script twice through `--in` (whole rows, then rows projected down to the columns the select names) and deep-equalling the two. This is what catches a figure quietly reading 0. It is blind to a column that does not exist, because a fixture happily carries a key no table has.

Both read the select strings from `--cols` rather than regexing the sources: `ORDER_COLS` is two concatenated strings, and a regex that quietly matched a *superset* would turn (b) into a no-op that passes forever.

## The fixture is new, and that is the point

Built on the fixture already in `scripts/daily-messages.test.mjs`, the round trip **passes with the bug in place** — that book produces 18.5 T at Hyderabad against a 463.5 T dispatch, so its South pool is floored at zero and servable is 0 either way. Measured before writing the test rather than after trusting it.

The new book puts 1,110 T on the floor and still leaves South short, so the partial case is exercised rather than the saturated one, and both round trips assert the figure is non-trivial **before** asserting it is unchanged. Every fixture feature earns its place: dropping any one of 30 columns changes a printed number.

## Verification

- 558 tests passing.
- Each of the four fixed columns removed individually → exactly one failure, in the named test.
- Guard verified against the real book: the same 1,633 rows projected to the old select exit 1 naming `mmId` instead of printing 0.0 T. Confirmed it cannot false-fire — an empty book runs, and so does one whose every row is soft-deleted.
- Live schema check via `execute_sql`: the old `skus` list errors on `deleted`; the corrected one returns rows.

## Heads-up on the numbers

The daily figures jump when this lands — Servable – Unconfirmed up from 0.0 T, Pending to Dispatch up by roughly the same. Against yesterday's broadcast that will read as a data problem rather than a fix.

## Not done

- `servable-orders.mjs`'s `baby_coils` select omits `deleted` — arguably right, since a soft-deleted baby coil should still carry its mother-coil mapping. Left alone.
- The CHS bridge stays asymmetric: a master row keys on `25 NB` while an order reaching the same tube only through its description keys on `33.7x2.9`, so those two never merge.
- `servableWithinUnconfirmed` untouched. It is not wrong, only insensitive to this fault; a "servable must be > 0" tie-out would fire every time the plant is genuinely empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QX8FuwdvfxiHUnbUgtCxRZ