### PR TITLE
Backfill 13 missing SKUs from catalog to live database

### DIFF
--- a/scripts/backfill-sku-master-drift.sql
+++ b/scripts/backfill-sku-master-drift.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- backfill-sku-master-drift.sql
+-- Persists catalog SKUs that exist in src/data/skus.js but were never written to
+-- the live `skus` table.
+--
+-- PROBLEM: a SKU lives in two layers joined on sku_code — the catalog
+-- (src/data/skus.js, the fallback + skuImportResolver's self-heal source) and the
+-- live `skus` table (what the running app actually reads). Batches added to the
+-- catalog were not always backfilled, so 13 catalog codes had no live row: the app
+-- fell back to resolving those orders by description instead of by code.
+--
+-- Codes covered (as of 2026-09-08):
+--   SHS  20x20x1, 20x20x2.80, 50x50x3.20, 100x100x1.60
+--   CHS  IS 1161  25/32/40/100 NB x 3.20, and 32 NB x 4
+--   CHS  IS 3601  32 NB x 2, 32 NB x 2.50, 50 NB x 1.60, 50 NB x 2
+--
+-- SAFETY: every value is copied verbatim from src/data/skus.js — no weight is
+-- recomputed here, per CLAUDE.md ("no density constants in app code"; the formula
+-- is quarantined in scripts/generate-skus.mjs). Verified before running that none
+-- of these 13 collides with an existing live row on canonicalSkuKey, so no new
+-- duplicate physical identity is created and no netting changes.
+--
+-- This is additive and idempotent: `on conflict (sku_code) do nothing` means
+-- re-running is a no-op, and no existing row is ever modified or deleted.
+--
+-- NOT addressed here: 23 live rows have no catalog counterpart, 19 of them created
+-- through the UI "+ Add SKU" form with generated codes (SHS-25x25x3.20,
+-- RHS-100x50x2.00, CHS-20NB-2.00) or with the whole description stored as the
+-- sku_code. Those need their own decision — see the note at the end of this file.
+-- ============================================================================
+
+insert into skus (id, product_type, sku_code, description, height, breadth, thickness, length,
+                  nominal_bore, outside_diameter, hsn_code, status,
+                  weight_per_tube, base_conversion, thickness_extra, ladder_price, total_conversion)
+values
+  (gen_random_uuid()::text, 'SHS', '1139-13064-10078291', 'MS SHS One Helix IS 4923 YSt 210 Black 20x20x1x6000', 20, 20, 1, 6000, '', '', '72080000', 'published', 3.5796, 2900, 1000, 3900, 13.96044),
+  (gen_random_uuid()::text, 'SHS', '1139-13064-10078310', 'MS SHS One Helix IS 4923 YSt 210 Black 100x100x1.60x6000', 100, 100, 1.6, 6000, '', '', '72080000', 'published', 29.661696, 2900, 750, 3650, 108.2651904),
+  (gen_random_uuid()::text, 'CHS', '1141-13068-10078417', 'MS CHS One Helix IS 1161 YSt 210 Black 32 NBx3.20x6000', null, null, 3.2, 6000, '32', '42.4', '72080000', 'published', 18.561233114162903, 2900, 0, 2900, 53.82757603107241),
+  (gen_random_uuid()::text, 'SHS', '1139-13064-10078288', 'MS SHS One Helix IS 4923 YSt 210 Black 20x20x2.80x6000', 20, 20, 2.8, 6000, '', '', '72080000', 'published', 9.073344, 2900, 0, 2900, 26.312697600000003),
+  (gen_random_uuid()::text, 'CHS', '1141-13171-10074221', 'MS CHS One Helix IS 3601 YSt 210 Black 50 NBx1.60x6000', null, null, 1.6, 6000, '50', '60.3', '72080000', 'published', 13.897249793384724, 2900, 750, 3650, 50.724961745854245),
+  (gen_random_uuid()::text, 'CHS', '1141-13171-10074222', 'MS CHS One Helix IS 3601 YSt 210 Black 50 NBx2x6000', null, null, 2, 6000, '50', '60.3', '72080000', 'published', 17.25318703054364, 2900, 500, 3400, 58.66083590384837),
+  (gen_random_uuid()::text, 'CHS', '1141-13068-10078413', 'MS CHS One Helix IS 1161 YSt 210 Black 40 NBx3.20x6000', null, null, 3.2, 6000, '40', '48.3', '72080000', 'published', 21.354888098182318, 2900, 0, 2900, 61.929175484728724),
+  (gen_random_uuid()::text, 'CHS', '1141-13068-10078407', 'MS CHS One Helix IS 1161 YSt 210 Black 25 NBx3.20x6000', null, null, 3.2, 6000, '25', '33.7', '72080000', 'published', 14.441775764846138, 2900, 0, 2900, 41.8811497180538),
+  (gen_random_uuid()::text, 'CHS', '1141-13068-10078419', 'MS CHS One Helix IS 1161 YSt 210 Black 100 NBx3.20x6000', null, null, 3.2, 6000, '100', '114.3', '72080000', 'published', 52.605943851619855, 2900, 0, 2900, 152.5572371696976),
+  (gen_random_uuid()::text, 'SHS', '1139-13064-10078304', 'MS SHS One Helix IS 4923 YSt 210 Black 50x50x3.20x6000', 50, 50, 3.2, 6000, '', '', '72080000', 'published', 28.214784, 2900, 0, 2900, 81.82287360000001),
+  (gen_random_uuid()::text, 'CHS', '1141-13171-10074211', 'MS CHS One Helix IS 3601 YSt 210 Black 32 NBx2.50x6000', null, null, 2.5, 6000, '32', '42.4', '72080000', 'published', 14.759909144911907, 2900, 0, 2900, 42.80373652024453),
+  (gen_random_uuid()::text, 'CHS', '1141-13171-10074209', 'MS CHS One Helix IS 3601 YSt 210 Black 32 NBx2x6000', null, null, 2, 6000, '32', '42.4', '72080000', 'published', 11.955896329913603, 2900, 500, 3400, 40.65004752170625),
+  (gen_random_uuid()::text, 'CHS', '1141-13068-10078416', 'MS CHS One Helix IS 1161 YSt 210 Black 32 NBx4x6000', null, null, 4, 6000, '32', '42.4', '72080000', 'published', 22.72804054795457, 2900, 0, 2900, 65.91131758906826)
+on conflict (sku_code) do nothing;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- POST-CHECK (read-only). All 13 codes should now return a published row.
+-- ─────────────────────────────────────────────────────────────────────────
+select sku_code, description, status, weight_per_tube
+from skus
+where sku_code in (
+  '1139-13064-10078288','1139-13064-10078291','1139-13064-10078304','1139-13064-10078310',
+  '1141-13068-10078407','1141-13068-10078413','1141-13068-10078416','1141-13068-10078417',
+  '1141-13068-10078419','1141-13171-10074209','1141-13171-10074211','1141-13171-10074221',
+  '1141-13171-10074222')
+order by sku_code;
+
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- NOTE (manual review, NOT auto-fixed): live rows with no catalog counterpart.
+-- Two are outright malformed and should be looked at first:
+--   • 'MS CHS One Helix IS 1161 YSt 210 Black 25 NBx4x60000' — length typo in the
+--     code AND the description (60000 instead of 6000); the row's length column
+--     is correct at 6000.
+--   • 'MS CHS One Helix IS 1161 YSt 210 Black 50 NBx4x6000' — description is NULL.
+--   • 'MS CHS One Helix IS 1161 YSt 210 Black 65 NBx2.8x6000' — thickness is NULL.
+-- Deleting or remapping any of these can move production tonnage (productions join
+-- on sku_code), so they need the dedupe-sku-master.sql treatment — remap first,
+-- retire second — not a delete. Left alone deliberately.
+-- ─────────────────────────────────────────────────────────────────────────

--- a/scripts/generate-skus.mjs
+++ b/scripts/generate-skus.mjs
@@ -132,6 +132,10 @@ const MISSING = [
   { mmId: '1141-13068-10080546', description: 'MS CHS One Helix IS 1161 YSt 210 Black 100 NBx3x6000' },
   { mmId: '1141-13068-10080562', description: 'MS CHS One Helix IS 1161 YSt 210 Black 100 NBx5x6000' },
   { mmId: '1141-13068-10095310', description: 'MS CHS One Helix IS 1161 YSt 210 Black 50 NBx1.20x6000' },
+  // 2026-09-08 batch: 32 NB x 4 is ordered in ERP (2 open lines, 13 MT, V V N STEELS / Hyderabad)
+  // but absent from the catalog. The 2026-06-24 batch took its neighbour ...10078417 (32 NB x 3.20)
+  // and 4 mm at 25/40/50/65/80/100 NB, and skipped this one.
+  { mmId: '1141-13068-10078416', description: 'MS CHS One Helix IS 1161 YSt 210 Black 32 NBx4x6000' },
 ]
 
 // Serialize one object in the same single-line style as src/data/skus.js.

--- a/src/data/skus.js
+++ b/src/data/skus.js
@@ -1,6 +1,6 @@
-// Full SKU Master catalog - 309 entries
+// Full SKU Master catalog - 310 entries
 // SKU-001..232 auto-generated from "Book 74.xlsx";
-// SKU-233..309 added for ERP dispatch import (see scripts/generate-skus.mjs).
+// SKU-233..310 added for ERP dispatch import (see scripts/generate-skus.mjs).
 
 const DEFAULT_SKUS = [
   { id: 'SKU-001', productType: 'SHS', skuCode: '1139-13064-10055315', description: 'MS SHS One Helix IS 4923 YSt 210 Black 25x25x2.50x6000', height: 25, breadth: 25, thickness: 2.5, length: 6000, nominalBore: '', outsideDiameter: '', hsnCode: '72080000', status: 'published', weightPerTube: 10.5975, baseConversion: 2900, thicknessExtra: 0, ladderPrice: 2900, totalConversion: 30.73275 },
@@ -314,6 +314,7 @@ const DEFAULT_SKUS = [
   { id: 'SKU-307', productType: 'CHS', skuCode: '1141-13068-10080546', description: 'MS CHS One Helix IS 1161 YSt 210 Black 100 NBx3x6000', height: null, breadth: null, thickness: 3, length: 6000, nominalBore: '100', outsideDiameter: '114.3', hsnCode: '72080000', status: 'published', weightPerTube: 49.406853769284055, baseConversion: 2900, thicknessExtra: 0, ladderPrice: 2900, totalConversion: 143.27987593092377 },
   { id: 'SKU-308', productType: 'CHS', skuCode: '1141-13068-10080562', description: 'MS CHS One Helix IS 1161 YSt 210 Black 100 NBx5x6000', height: null, breadth: null, thickness: 5, length: 6000, nominalBore: '100', outsideDiameter: '114.3', hsnCode: '72080000', status: 'published', weightPerTube: 80.86506614229931, baseConversion: 2900, thicknessExtra: 0, ladderPrice: 2900, totalConversion: 234.508691812668 },
   { id: 'SKU-309', productType: 'CHS', skuCode: '1141-13068-10095310', description: 'MS CHS One Helix IS 1161 YSt 210 Black 50 NBx1.20x6000', height: null, breadth: null, thickness: 1.2, length: 6000, nominalBore: '50', outsideDiameter: '60.3', hsnCode: '72080000', status: 'published', weightPerTube: 10.4939624717509, baseConversion: 2900, thicknessExtra: 1000, ladderPrice: 3900, totalConversion: 40.92645363982851 },
+  { id: 'SKU-310', productType: 'CHS', skuCode: '1141-13068-10078416', description: 'MS CHS One Helix IS 1161 YSt 210 Black 32 NBx4x6000', height: null, breadth: null, thickness: 4, length: 6000, nominalBore: '32', outsideDiameter: '42.4', hsnCode: '72080000', status: 'published', weightPerTube: 22.72804054795457, baseConversion: 2900, thicknessExtra: 0, ladderPrice: 2900, totalConversion: 65.91131758906826 },
 ]
 
 export default DEFAULT_SKUS


### PR DESCRIPTION
## Summary
Adds 13 SKU codes that exist in the catalog (`src/data/skus.js`) but were never persisted to the live `skus` table. These codes fell back to order resolution by description instead of by code, creating a two-layer catalog drift.

## Changes
- **scripts/backfill-sku-master-drift.sql** (new)
  - Inserts 13 SKU rows (SHS and CHS variants) copied verbatim from the catalog
  - Uses `on conflict (sku_code) do nothing` for idempotency
  - Includes a post-check query to verify all 13 codes are now published
  - Documents the problem, safety guarantees, and 23 unaddressed live rows that have no catalog counterpart

- **src/data/skus.js**
  - Adds SKU-310: `1141-13068-10078416` (MS CHS One Helix IS 1161 YSt 210 Black 32 NBx4x6000)
  - Updates catalog count from 309 to 310 entries

- **scripts/generate-skus.mjs**
  - Adds the same SKU-310 to the `MISSING` array with context: ordered in ERP (2 open lines, 13 MT from V V N STEELS / Hyderabad) but absent from the 2026-06-24 batch

## Implementation details
- All 13 values are copied directly from `src/data/skus.js` — no weight recomputation (per CLAUDE.md: density constants are quarantined in `scripts/generate-skus.mjs`)
- Verified before running that none collide with existing live rows on `canonicalSkuKey`
- Additive and safe: re-running the SQL is a no-op; no existing rows are modified or deleted
- The SQL script includes a note on 23 live rows with no catalog counterpart (3 malformed, 19 UI-generated) that require separate decision and remap-then-retire treatment

https://claude.ai/code/session_012ctvs423sbr4uDei5KNHVN