### PR TITLE
Plant-wise Tracker: three defects the #175 review found

### DIFF
--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -67,10 +67,11 @@ stays inside every total, exactly as `Unmapped` does for region.
 > **amber line naming the excluded tonnage and the flow rows it entered by** the moment any appears, and
 > renders nothing at all when there is none. The exclusion is the decision; the amber line is what
 > stops it being a silent one. This is one grid with one reason, not a licence to drop `Unattributed`
-> anywhere else. See `docs/adr/0012-*`. An unrecognised code **imports**;
-it never fails the upload, because a fifth company appearing in the ERP must not stop the daily file
-loading. Orders are replace-all on upload, so one run backfills every historical row — there is no
-separate migration.
+> anywhere else. See `docs/adr/0012-*`.
+
+An unrecognised code **imports**; it never fails the upload, because a fifth company appearing in
+the ERP must not stop the daily file loading. Orders are replace-all on upload, so one run backfills
+every historical row — there is no separate migration.
 
 ### Invoice lines (ticket #119)
 The Invoice sheet is shaped differently from Orders: it has **no `CM name` column at all**. It

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2138,7 +2138,7 @@ function PlantTrackerTable({ grid }) {
           {grid.blocks.map(b => b.rows.map((r, i) => {
             // Stock rows are shaded throughout the grid — the visual cue for the MTD column carrying
             // two kinds of arithmetic (a flow sums the month, a stock shows its latest close).
-                    // Fully OPAQUE on both sides, not a tint: this class also paints the STICKY label cell,
+            // Fully OPAQUE on both sides, not a tint: this class also paints the STICKY label cell,
             // and a translucent sticky cell lets the day columns scroll visibly underneath it.
             const bg = r.kind === 'stock' ? 'bg-slate-50 dark:bg-slate-900' : 'bg-white dark:bg-slate-800'
             const strong = b.isTotal ? 'font-semibold' : ''
@@ -3910,8 +3910,11 @@ function InventoryApp({ session, onLogout }) {
   // plants' tonnage never reaches the page at all — an absence in the data, not a rendering choice.
   // `trackerPlant` then tells the grid to drop the TOTAL block: a total that is one plant's numbers
   // repeated is noise. Both halves are driven by the same `access.plantSelector`, so nothing widens.
-  // The LIVE plant master, not the compiled-in default: which blocks exist and what each is called
-  // is the master's answer, so a plant renamed on the Masters tab is renamed here too.
+  // The plant master, read through `plantMaster` rather than the compiled-in seed directly — which
+  // blocks exist and what each is called is the master's answer, so this stays right the day a plant
+  // is added to it. What the `plants` TABLE actually overrides today is `serves` ALONE (the one
+  // editable cell on the Masters tab); ids and display names come from the seed and are not
+  // editable anywhere, so nothing a person can type on that tab renames a block here.
   const plantMasterRows = useMemo(() => plantMaster(plants), [plants])
   const trackerPlant = access.plantSelector ? null : access.plant
   const trackerCoils = access.plantSelector ? coils : plantCoils

--- a/src/lib/calc.test.js
+++ b/src/lib/calc.test.js
@@ -18,7 +18,7 @@ import {
   normalizeProductionPoNo, productionPoOptions,
   ALL_PLANTS, plantFilterOptions, plantKeysIn, plantNamesIn, filterByPlant, filterDispatchesByPlant, withDispatchEntries,
   crossPlantAllocationRows,
-  plantTrackerGrid,
+  plantTrackerGrid, dataMonthKeys, trackerDayLabel, trackerCellBlank,
   plantMaster, plantsServingRegion, servedRegions, filterByPlants, filterDispatchesByPlants,
   distributorStateIndex, distributorRegionResolver, distributorRegionIndex,
   salesKpis, salesByDistributor, salesByMonth,
@@ -3998,5 +3998,79 @@ describe('plantTrackerGrid', () => {
       b.rows.forEach(r => { expect(r.mtd).toBe(0); g.days.forEach(d => expect(r.cells[d]).toBe(0)) })
     })
     expect(g.excluded).toBeNull()
+  })
+})
+
+// The three tracker exports the screen and the CSV both read but neither owns. They were covered
+// only indirectly, through `plantTrackerGrid`'s own describe above — which never exercises the
+// month dropdown's rule, a label on its own, or the blank rule the export half depends on. #175
+// asks for every figure on that section to come from "one pure function in the tested lib module";
+// these three decide what a figure LOOKS like, on two screens that must not drift apart.
+describe('dataMonthKeys — the months a dropdown may offer', () => {
+  it('runs from the earliest dated row through today’s month, newest first', () => {
+    expect(dataMonthKeys(['2026-07-14', '2026-08-02'], '2026-09-09'))
+      .toEqual(['2026-09', '2026-08', '2026-07'])
+  })
+
+  it('offers today’s month alone when nothing carries a date', () => {
+    expect(dataMonthKeys([], '2026-09-09')).toEqual(['2026-09'])
+    expect(dataMonthKeys([null, undefined, '', 'not-a-date'], '2026-09-09')).toEqual(['2026-09'])
+  })
+
+  it('crosses a year boundary', () => {
+    expect(dataMonthKeys(['2025-11-30'], '2026-01-05')).toEqual(['2026-01', '2025-12', '2025-11'])
+  })
+
+  it('offers a GAP month that carries nothing, rather than skipping it', () => {
+    // Deliberate, and inherited from the Dashboard's own period picker: a month with no activity is
+    // a finding, and a dropdown that silently skipped it would make that month unreachable.
+    expect(dataMonthKeys(['2026-06-01', '2026-09-01'], '2026-09-09'))
+      .toEqual(['2026-09', '2026-08', '2026-07', '2026-06'])
+  })
+
+  it('caps the list, so one stray 1970 date cannot render six hundred options', () => {
+    expect(dataMonthKeys(['1970-01-01'], '2026-09-09')).toHaveLength(36)
+  })
+
+  it('returns nothing when it cannot read today', () => {
+    expect(dataMonthKeys(['2026-08-01'], '')).toEqual([])
+  })
+})
+
+describe('trackerDayLabel', () => {
+  it('renders a day column head, unpadded day and short month', () => {
+    expect(trackerDayLabel('2026-09-05')).toBe('5-Sep')
+    expect(trackerDayLabel('2026-09-30')).toBe('30-Sep')
+    expect(trackerDayLabel('2026-01-01')).toBe('1-Jan')
+    expect(trackerDayLabel('2026-12-31')).toBe('31-Dec')
+  })
+
+  it('hands back what it cannot read rather than inventing a date', () => {
+    expect(trackerDayLabel('')).toBe('')
+    expect(trackerDayLabel(null)).toBe('')
+    expect(trackerDayLabel('2026-09')).toBe('2026-09')
+  })
+})
+
+describe('trackerCellBlank — stillness is not the same mark as unknown', () => {
+  const flow = { kind: 'flow' }, stock = { kind: 'stock' }
+
+  it('blanks a FLOW cell with no activity, so a busy day stands out from a still one', () => {
+    expect(trackerCellBlank(flow, 0)).toBe(true)
+    expect(trackerCellBlank(flow, 12.5)).toBe(false)
+    expect(trackerCellBlank(flow, -3)).toBe(false)   // a negative flow is a fault to SEE
+  })
+
+  it('never blanks a STOCK cell, even an unchanged or zero one', () => {
+    // A blank stock cell would read as "we do not know" when the truth is "the steel is still
+    // there" — the unknown-vs-empty rule the Unmapped distributor already enforces elsewhere.
+    expect(trackerCellBlank(stock, 0)).toBe(false)
+    expect(trackerCellBlank(stock, 402.1)).toBe(false)
+  })
+
+  it('is total on a missing row or value, because both callers pass it straight through', () => {
+    expect(trackerCellBlank(null, 5)).toBe(false)
+    expect(trackerCellBlank(flow, undefined)).toBe(true)
+    expect(trackerCellBlank(stock, undefined)).toBe(false)
   })
 })


### PR DESCRIPTION
A two-axis review of the shipped Plant-wise Tracker against ticket #175's acceptance criteria. **Two documentation defects and one coverage gap. No behaviour change** — every figure on the section reads exactly as it does on `staging` today.

Ticket #175 itself needed no implementation: #174 shipped whole (all ten KPI rows, the CSV, the plant-login collapse, ADRs 0011/0012), and #175 is the flow-row subset of it. 19 of its 20 acceptance criteria are met in code.

## What changed

**`docs/DATA-MODEL.md`** — the #174 blockquote was pasted mid-sentence. `An unrecognised code **imports**;` ended up *inside* the quote and `it never fails the upload, because…` was orphaned outside it. One sentence, two blocks, in the file that documents the very rule being excepted. Rejoined.

**`src/App.jsx`** — the comment on `plantMasterRows` claimed *"a plant renamed on the Masters tab is renamed here too"*. It is not: `plantMaster` spreads the seed and copies only `serves` from the stored rows, and `serves` is the one editable cell on that tab. Nothing a person can type there renames a block. Reading through `plantMaster` is still right — it is where a plant *added* to the master would arrive — so the call stands and only the reason is corrected. Also fixes one misindented comment inside `PlantTrackerTable`.

**`src/lib/calc.test.js`** — `dataMonthKeys`, `trackerDayLabel` and `trackerCellBlank` are exported from `calc.js` and read by the screen and the CSV export both, and had no unit tests of their own; they were covered only indirectly through `plantTrackerGrid`. #175 asks for every figure on that section to come from one pure function in the tested lib module, and these three decide what a figure *looks like* on two surfaces that must not drift apart. 11 tests added.

One of them **pins a known deviation rather than hiding it**: `dataMonthKeys` offers a gap month carrying no data, against #175's *"lists only months that carry data"*. That behaviour is inherited from the Dashboard's own period picker, so it is a faithful copy of an already-loose rule, not a new defect — and it is now asserted instead of remembered.

## Reported, deliberately not fixed here

- **A future-dated row vanishes from the stock replay.** In `plantTrackerGrid`'s `add()`, a row dated after the last shown day lands in neither the opening balance nor a day column. Undated rows get a careful comment about exactly this hazard; future-dated rows get that treatment silently, which would break #176's tie between the last column and the Dashboard's Coil and FG cards. Checked against the live database: **0 future-dated and 0 undated rows** across 483 coils, 2,773 baby coils, 1,378 productions and 214 dispatches — latent today. It changes stock arithmetic and belongs to #176's acceptance criteria, so it is not a drive-by edit.
- `downloadTrackerCSV` re-derives its day headers while the table reads `grid.columns[].label` — two derivations of one header row, against the code's own "the file and a screenshot cannot disagree". Correct today; no test covers that path, so a mistake there would be invisible.
- `plant = null` for all-plants, where `docs/DATA-MODEL.md` says to pass the `ALL_PLANTS` **sentinel**. Handles `''` correctly, so no bug — two spellings of one scope, worth one decision rather than a drive-by change.
- The six `tracker*` props travelling together through `InventoryApp` → `Dashboard` → `plantTrackerGrid`.

## Verification

`npm test` — 600 passing (589 before, 11 added). `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zUyDU9rGu9uLaK8nPP1Mp

---
_Generated by [Claude Code](https://claude.ai/code/session_018zUyDU9rGu9uLaK8nPP1Mp)_